### PR TITLE
Add network visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An interactive visualization suite exploring the core themes from C.G. Jung's *A
 
 ## Visualizations
 
-This project includes five interactive visualizations:
+This project includes six interactive visualizations:
 
 1. **Historical Timeline** - Tracing the Christ-pole and Antichrist-shadow dynamics across 2000+ years of history, following the zodiacal "hour-hand."
 
@@ -17,7 +17,8 @@ This project includes five interactive visualizations:
 3. **Archetype Profiles** - Radar chart comparison of archetypal configurations, contrasting patterns between 2025 and 2200 to reveal epochal shifts.
 
 4. **Self-Integration Curve** - The trajectory from projection to integration of the Self archetype through historical milestones, moving toward Jung's "coniunctio."
-5. **Polygon Bounce** - A playful p5.js sketch showing a ball bouncing inside a spinning polygon with adjustable sides and speed controls.
+5. **Archetype Network** - Force-directed graph exploring relationships between Self, Shadow, Anima/Animus and Trickster.
+6. **Polygon Bounce** - A playful p5.js sketch showing a ball bouncing inside a spinning polygon with adjustable sides and speed controls.
 
 ## Features
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
     <title>Aion Visualization Hub</title>
     <link rel="stylesheet" href="styles.css">
     <style>
+        .hero-banner {
+            background: linear-gradient(135deg, var(--chart-1), var(--chart-4));
+            color: var(--card-foreground);
+            padding: 40px 30px;
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-lg);
+            margin-bottom: 40px;
+        }
+
         /* Card grid layout */
         .viz-grid {
             display: grid;
@@ -88,8 +97,10 @@
 </head>
 <body>
     <div class="container">
-        <h1>Jung's Aion: Archetype Visualizations</h1>
-        <p>Interactive visualizations exploring the core themes from C.G. Jung's <em>Aion: Researches into the Phenomenology of the Self</em> (CW9ii).</p>
+        <div class="hero-banner">
+            <h1>Jung's Aion: Archetype Visualizations</h1>
+            <p>Interactive explorations of Jungian archetypes and their historical interplay.</p>
+        </div>
 
         <div class="viz-grid">
             <a href="timeline.html" class="viz-card">
@@ -110,6 +121,11 @@
             <a href="integration.html" class="viz-card">
                 <h2>Self-Integration Curve</h2>
                 <p>The trajectory from projection to integration of the Self archetype through historical milestones, moving toward Jung's "coniunctio."</p>
+            </a>
+
+            <a href="network.html" class="viz-card">
+                <h2>Archetype Network</h2>
+                <p>Force-directed graph exploring relationships among Self, Shadow, Anima/Animus and Trickster.</p>
             </a>
 
             <a href="hexagon.html" class="viz-card">

--- a/navigation.js
+++ b/navigation.js
@@ -58,10 +58,16 @@ function createSidebar() {
             <span>Profiles</span>
           </a>
         </li>
-        <li class="nav-item ${window.location.pathname.includes('integration.html') ? 'active' : ''}">
-          <a href="integration.html" class="nav-link">
-            <svg width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.14645 2.14645C7.34171 1.95118 7.65829 1.95118 7.85355 2.14645L11.8536 6.14645C12.0488 6.34171 12.0488 6.65829 11.8536 6.85355C11.6583 7.04882 11.3417 7.04882 11.1464 6.85355L8 3.70711L8 12.5C8 12.7761 7.77614 13 7.5 13C7.22386 13 7 12.7761 7 12.5L7 3.70711L3.85355 6.85355C3.65829 7.04882 3.34171 7.04882 3.14645 6.85355C2.95118 6.65829 2.95118 6.34171 3.14645 6.14645L7.14645 2.14645Z" fill="currentColor"></path></svg>
+      <li class="nav-item ${window.location.pathname.includes('integration.html') ? 'active' : ''}">
+        <a href="integration.html" class="nav-link">
+          <svg width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.14645 2.14645C7.34171 1.95118 7.65829 1.95118 7.85355 2.14645L11.8536 6.14645C12.0488 6.34171 12.0488 6.65829 11.8536 6.85355C11.6583 7.04882 11.3417 7.04882 11.1464 6.85355L8 3.70711L8 12.5C8 12.7761 7.77614 13 7.5 13C7.22386 13 7 12.7761 7 12.5L7 3.70711L3.85355 6.85355C3.65829 7.04882 3.34171 7.04882 3.14645 6.85355C2.95118 6.65829 2.95118 6.34171 3.14645 6.14645L7.14645 2.14645Z" fill="currentColor"></path></svg>
           <span>Integration</span>
+        </a>
+      </li>
+      <li class="nav-item ${window.location.pathname.includes('network.html') ? 'active' : ''}">
+        <a href="network.html" class="nav-link">
+          <svg width="20" height="20" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="7.5" cy="2.5" r="1.5" fill="currentColor"/><circle cx="7.5" cy="12.5" r="1.5" fill="currentColor"/><circle cx="2.5" cy="7.5" r="1.5" fill="currentColor"/><circle cx="12.5" cy="7.5" r="1.5" fill="currentColor"/><path d="M7.5 4v6M4 7.5h7" stroke="currentColor"/></svg>
+          <span>Network</span>
         </a>
       </li>
       <li class="nav-item ${window.location.pathname.includes('hexagon.html') ? 'active' : ''}">

--- a/network.html
+++ b/network.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aion - Archetype Network</title>
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .link {
+      stroke: var(--border);
+      stroke-width: 1.5px;
+    }
+    .node circle {
+      stroke: var(--background);
+      stroke-width: 1.5px;
+    }
+    .node text {
+      font-size: 12px;
+      fill: var(--foreground);
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Archetype Network</h1>
+    <p>Interactive network graph depicting relationships among key archetypes.</p>
+    <div class="visualization-area">
+      <svg id="network-chart" width="800" height="500"></svg>
+    </div>
+    <a href="index.html" class="back-link">Back to Hub</a>
+  </div>
+
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <script>
+    const nodes = [
+      { id: 'Self', group: 'Self_Integration' },
+      { id: 'Shadow', group: 'Shadow' },
+      { id: 'Anima/Animus', group: 'Anima_Animus' },
+      { id: 'Trickster', group: 'Trickster' }
+    ];
+
+    const links = [
+      { source: 'Self', target: 'Shadow' },
+      { source: 'Self', target: 'Anima/Animus' },
+      { source: 'Self', target: 'Trickster' },
+      { source: 'Shadow', target: 'Trickster' },
+      { source: 'Anima/Animus', target: 'Trickster' },
+      { source: 'Shadow', target: 'Anima/Animus' }
+    ];
+
+    const colors = {
+      Shadow: 'var(--color-shadow-jung)',
+      Self_Integration: 'var(--color-self-jung)',
+      Anima_Animus: 'var(--color-anima-jung)',
+      Trickster: 'var(--color-trickster-jung)'
+    };
+
+    const svg = d3.select('#network-chart');
+    const width = +svg.attr('width');
+    const height = +svg.attr('height');
+
+    const simulation = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(links).id(d => d.id).distance(120))
+      .force('charge', d3.forceManyBody().strength(-300))
+      .force('center', d3.forceCenter(width / 2, height / 2));
+
+    const link = svg.append('g')
+      .attr('class', 'links')
+      .selectAll('line')
+      .data(links)
+      .enter().append('line')
+      .attr('class', 'link');
+
+    const node = svg.append('g')
+      .attr('class', 'nodes')
+      .selectAll('g')
+      .data(nodes)
+      .enter().append('g')
+      .attr('class', 'node')
+      .call(d3.drag()
+        .on('start', dragstarted)
+        .on('drag', dragged)
+        .on('end', dragended));
+
+    node.append('circle')
+      .attr('r', 20)
+      .attr('fill', d => colors[d.group]);
+
+    node.append('text')
+      .attr('dy', 4)
+      .attr('text-anchor', 'middle')
+      .text(d => d.id);
+
+    simulation.on('tick', () => {
+      link
+        .attr('x1', d => d.source.x)
+        .attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x)
+        .attr('y2', d => d.target.y);
+      node
+        .attr('transform', d => `translate(${d.x},${d.y})`);
+    });
+
+    function dragstarted(event) {
+      if (!event.active) simulation.alphaTarget(0.3).restart();
+      event.subject.fx = event.subject.x;
+      event.subject.fy = event.subject.y;
+    }
+
+    function dragged(event) {
+      event.subject.fx = event.x;
+      event.subject.fy = event.y;
+    }
+
+    function dragended(event) {
+      if (!event.active) simulation.alphaTarget(0);
+      event.subject.fx = null;
+      event.subject.fy = null;
+    }
+  </script>
+  <script src="navigation.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Archetype Network page with a force-directed graph
- display the new viz on the hub page with a hero banner
- update navigation sidebar for the new page
- document the new visualization in README

## Testing
- `npm test` *(fails: `package.json` not found)*