### PR TITLE
Fix duplicate resize listener

### DIFF
--- a/starfield.js
+++ b/starfield.js
@@ -55,7 +55,6 @@ window.addEventListener('DOMContentLoaded', () => {
       svg.appendChild(line);
     }
   }
-  window.addEventListener('resize', drawMandala);
   drawMandala();
 
   const stars = Array.from({ length: 150 }, () => ({


### PR DESCRIPTION
## Summary
- remove separate resize handler for drawMandala

## Testing
- `npm test` *(fails: could not find package.json)*