### PR TITLE
Add editorconfig and ESLint setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ npm-debug.log
 yarn-debug.log
 yarn-error.log
 
+# Environment files
+.env
+.env.*
+
 # IDE files
 .idea/
 .vscode/
@@ -21,3 +25,4 @@ yarn-error.log
 dist/
 build/
 *.log
+logs/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,17 @@
+export default [
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ecmaVersion: 2015,
+      sourceType: "module",
+    },
+    ignores: ["node_modules/**"],
+    plugins: {},
+    rules: {
+      indent: ["error", 2],
+      "linebreak-style": ["error", "unix"],
+      quotes: ["error", "single"],
+      semi: ["error", "always"],
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- ignore `.env` and log directories
- configure indent and newline style for editors
- add ESLint config using the modern `eslint.config.js`

## Testing
- `npx eslint src/navigation.js`

------
https://chatgpt.com/codex/tasks/task_e_683fa1f6a2e4832d8ef500697b24aba3