### PR TITLE
Fix newline at end of workflow files

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -23,15 +23,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
-          
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: './src'
-          
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,8 +15,10 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment.
+# Skips runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow
+# these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -33,11 +35,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v4
-        - name: Upload artifact
-          uses: actions/upload-pages-artifact@v3
-          with:
-            # Upload static site
-            path: './src'
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload static site
+          path: './src'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- fix indentation and trailing newline issues in deploy-pages.yml and static.yml
- add missing newlines so deploy-pages.yml and static.yml end properly
- run yamllint to verify workflow syntax

## Testing
- `~/.local/bin/yamllint .github/workflows/deploy-pages.yml .github/workflows/static.yml`


------
https://chatgpt.com/codex/tasks/task_e_683fa7876008832d9ebec5d77403d041