### PR TITLE
Implement lazy load hook and clean styles

### DIFF
--- a/src/chapter-navigation.css
+++ b/src/chapter-navigation.css
@@ -349,3 +349,8 @@
         background: rgba(0, 0, 0, 0.1);
     }
 }
+@media (max-width: 480px) {
+  .chapter-card {
+    margin-bottom: 1rem;
+  }
+}

--- a/src/chapter1.html
+++ b/src/chapter1.html
@@ -6,7 +6,6 @@
     <title>Chapter 1: The Ego - Aion Visualization</title>
     <link rel="stylesheet" href="styles-v2.css">
     <!-- Phase 3 Enhancements -->
-    <link rel="stylesheet" href="css/styles-v3.css">
     <style>
         .chapter-hero {
             height: 100vh;
@@ -69,6 +68,7 @@
     </style>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="visualization-loader.js"></script>
+    <script type="module" src="lazy-visualizations.js"></script>
 </head>
 <body>
     <!-- Navigation -->

--- a/src/chapter5.html
+++ b/src/chapter5.html
@@ -90,9 +90,10 @@
         </div>
     </main>
 
-    <canvas id="bg-canvas"></canvas>
+    <canvas id="bg-canvas" data-load-fn="initChapter5"></canvas>
 
     <script>
+        function initChapter5() {
         // Background shader
         const canvas = document.getElementById('bg-canvas');
         const gl = canvas.getContext('webgl');
@@ -477,6 +478,8 @@
         document.querySelector('.nav-toggle').addEventListener('click', function() {
             document.querySelector('.nav-links').classList.toggle('active');
         });
+    }
+    observeVisualization(document.getElementById("bg-canvas"), "initChapter5");
     </script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Aion - A Visual Journey Through Jung's Masterwork</title>
     <link rel="stylesheet" href="styles-v2.css">
-    <link rel="stylesheet" href="styles-v3.css">
     <link rel="stylesheet" href="responsive-utils.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="webgl-utils.js"></script>
     <script src="accessibility-utils.js"></script>
     <script src="progress-tracker.js"></script>
     <script src="visualization-loader.js"></script>
+    <script type="module" src="lazy-visualizations.js"></script>
     <script src="apply-fixes.js" defer></script>
     <style>
         .hero-announcement {

--- a/src/lazy-visualizations.js
+++ b/src/lazy-visualizations.js
@@ -1,0 +1,32 @@
+// Lazy loading for chapter visualizations using IntersectionObserver
+const observerOptions = {
+  root: null,
+  rootMargin: '50px',
+  threshold: 0.1
+};
+
+const visualizationObserver = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      const fnName = entry.target.dataset.loadFn;
+      if (fnName && typeof window[fnName] === 'function') {
+        window[fnName](entry.target);
+      }
+      visualizationObserver.unobserve(entry.target);
+    }
+  });
+}, observerOptions);
+
+export function observeVisualization(element, fnName) {
+  if (element) {
+    element.dataset.loadFn = fnName;
+    visualizationObserver.observe(element);
+  }
+}
+
+
+window.observeVisualization = observeVisualization;
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll("[data-load-fn]").forEach(el => observeVisualization(el, el.dataset.loadFn));
+});
+


### PR DESCRIPTION
## Summary
- remove unused v3 stylesheet references
- add IntersectionObserver based lazy loader utility
- update chapter5 to lazily load its visualization
- include lazy loader script on index and chapter1
- tweak chapter navigation CSS for small screens

## Testing
- `npm run lint` *(fails: many indent errors)*

------
https://chatgpt.com/codex/tasks/task_e_683faf1884b4832d97696146b46629f2