### PR TITLE
Fix: Visualizations page showing offline error

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
  * Version: 2.0.0 - Enhanced PWA Support
  */
 
-const CACHE_VERSION = 'aion-v2.0.0';
+const CACHE_VERSION = 'aion-v2.1.0';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const IMAGE_CACHE = `${CACHE_VERSION}-images`;
@@ -14,6 +14,8 @@ const ANALYTICS_CACHE = 'analytics-queue';
 const STATIC_ASSETS = [
     '/aion-visualization/',
     '/aion-visualization/index.html',
+    '/aion-visualization/visualizations.html',
+    '/aion-visualization/test-visualizations.html',
     '/aion-visualization/offline.html',
     '/aion-visualization/manifest.json',
     '/aion-visualization/assets/css/bundle.min.css'


### PR DESCRIPTION
## Problem
The visualizations.html page was showing an offline error because it wasn't included in the service worker's static assets cache.

## Solution
- Added visualizations.html and test-visualizations.html to STATIC_ASSETS in sw.js
- Updated cache version from v2.0.0 to v2.1.0 to force cache refresh
- This ensures the new visualization index page loads properly

## Testing
After merge, users should be able to access:
- /visualizations.html - Main visualization index
- /test-visualizations.html - Testing page

## Impact
Fixes the user experience issue where the main visualization access point was broken.