### PR TITLE
fix: Add visualizations.html to service worker cache

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
  * Version: 2.0.0 - Enhanced PWA Support
  */
 
-const CACHE_VERSION = 'aion-v2.0.0';
+const CACHE_VERSION = 'aion-v2.1.0';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const IMAGE_CACHE = `${CACHE_VERSION}-images`;
@@ -14,6 +14,8 @@ const ANALYTICS_CACHE = 'analytics-queue';
 const STATIC_ASSETS = [
     '/aion-visualization/',
     '/aion-visualization/index.html',
+    '/aion-visualization/visualizations.html',
+    '/aion-visualization/test-visualizations.html',
     '/aion-visualization/offline.html',
     '/aion-visualization/manifest.json',
     '/aion-visualization/assets/css/bundle.min.css'


### PR DESCRIPTION
- Added visualizations.html and test-visualizations.html to STATIC_ASSETS
- Updated cache version to v2.1.0 to force refresh
- This fixes the offline page issue when accessing /visualizations.html

The service worker was not caching the new visualization index page, causing it to show the offline fallback instead of the actual content.

# Pull Request

Thank you for contributing! Please review the checklist below before submitting.

- [ ] My code follows the project's coding style and guidelines
- [ ] I have tested my changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have linked any relevant issues

Provide a short summary of your changes below.
