### PR TITLE
refactor(viz): Port Ch 6-9 to BaseViz architecture

### DIFF
--- a/src/visualizations/chapters/ch7/prophecy-timeline-viz.js
+++ b/src/visualizations/chapters/ch7/prophecy-timeline-viz.js
@@ -1,32 +1,15 @@
+
+import BaseViz from '../../../features/viz-platform/BaseViz.js';
+
 /**
  * Prophecy Timeline — Chapter 7: The Prophecies of Nostradamus
- *
- * Horizontal timeline with prophetic symbol nodes. Each node pulses
- * with symbolic meaning. Hovering reveals details about the prophecy
- * and its connection to the enantiodromia of the aeons.
- *
- * Self-contained Canvas 2D — no dependencies.
+ * Refactored to extend BaseViz for Phase 6 Architecture.
  */
-
-export default class ProphecyTimelineViz {
+export default class ProphecyTimelineViz extends BaseViz {
     constructor(container) {
-        this.container = container;
-        this.running = true;
-        this.time = 0;
+        super(container);
         this.mouse = { x: 0, y: 0 };
         this.hoveredNode = null;
-
-        const w = container.clientWidth || 600;
-        const h = container.clientHeight || 450;
-        this.dpr = Math.min(window.devicePixelRatio, 2);
-
-        this.canvas = document.createElement('canvas');
-        this.canvas.width = w * this.dpr;
-        this.canvas.height = h * this.dpr;
-        this.canvas.style.cssText = `width:${w}px;height:${h}px;display:block;`;
-        container.appendChild(this.canvas);
-        this.ctx = this.canvas.getContext('2d');
-
         this.nodes = [
             { year: 1555, label: 'Centuries Published', symbol: '📜', detail: 'Nostradamus publishes his prophetic quatrains, encoding astrological symbolism.' },
             { year: 1600, label: 'Conjunction Saturn–Jupiter', symbol: '⚡', detail: 'Great conjunction marking the boundary between religious epochs.' },
@@ -40,63 +23,58 @@ export default class ProphecyTimelineViz {
             this.mouse.x = e.clientX - rect.left;
             this.mouse.y = e.clientY - rect.top;
         };
-        this._onResize = () => {
-            const nw = container.clientWidth;
-            const nh = container.clientHeight;
-            this.canvas.width = nw * this.dpr;
-            this.canvas.height = nh * this.dpr;
-            this.canvas.style.width = nw + 'px';
-            this.canvas.style.height = nh + 'px';
-        };
-        container.addEventListener('mousemove', this._onMouseMove);
-        window.addEventListener('resize', this._onResize);
+    }
 
+    async init() {
+        this.container.addEventListener('mousemove', this._onMouseMove);
         this._createUI();
-        this._animate();
     }
 
     _createUI() {
         const overlay = document.createElement('div');
         overlay.style.cssText = `
-      position:absolute;inset:0;pointer-events:none;
-      font-family:var(--font-sans,system-ui);color:var(--text-tertiary,#8a8a8a);
-    `;
+          position:absolute;inset:0;pointer-events:none;
+          font-family:var(--font-sans,system-ui);color:var(--text-tertiary,#8a8a8a);
+        `;
         overlay.innerHTML = `
-      <span style="position:absolute;top:5%;left:50%;transform:translateX(-50%);
-        font-size:0.65rem;text-transform:uppercase;letter-spacing:0.15em;opacity:0.4;color:#9b59b6;">
-        Prophecy Timeline — Enantiodromia of the Aeons
-      </span>
-      <span style="position:absolute;bottom:5%;left:50%;transform:translateX(-50%);
-        font-size:0.55rem;opacity:0.3;">hover nodes for details</span>
-    `;
+          <span style="position:absolute;top:12%;left:50%;transform:translateX(-50%);
+            font-size:0.65rem;text-transform:uppercase;letter-spacing:0.15em;opacity:0.4;color:#9b59b6;">
+            Prophecy Timeline — Enantiodromia of the Aeons
+          </span>
+          <span style="position:absolute;bottom:12%;left:50%;transform:translateX(-50%);
+            font-size:0.55rem;opacity:0.3;">hover nodes for details</span>
+        `;
+
         this._tooltipEl = document.createElement('div');
         this._tooltipEl.style.cssText = `
-      position:absolute;padding:8px 12px;border-radius:6px;
-      background:rgba(20,20,30,0.9);border:1px solid rgba(155,89,182,0.3);
-      color:#ccc;font-size:0.6rem;max-width:200px;opacity:0;
-      transition:opacity 0.3s;pointer-events:none;
-    `;
+          position:absolute;padding:8px 12px;border-radius:6px;
+          background:rgba(20,20,30,0.95);border:1px solid rgba(155,89,182,0.4);
+          color:#e0e0e0;font-size:0.75rem;max-width:220px;opacity:0;
+          transition:opacity 0.2s;pointer-events:none;line-height:1.4;
+          box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+        `;
         overlay.appendChild(this._tooltipEl);
-        this.container.style.position = 'relative';
+
         this.container.appendChild(overlay);
         this._overlay = overlay;
     }
 
-    _animate() {
-        if (!this.running) return;
-        requestAnimationFrame(() => this._animate());
-        this.time += 0.016;
-        this._draw();
+    update(dt) {
+        this.time += dt * 0.5;
     }
 
-    _draw() {
+    render() {
         const ctx = this.ctx;
+        const width = this.canvas.width;
+        const height = this.canvas.height;
+
         ctx.save();
         ctx.scale(this.dpr, this.dpr);
-        const w = this.canvas.width / this.dpr;
-        const h = this.canvas.height / this.dpr;
+        const w = width / this.dpr;
+        const h = height / this.dpr;
         const t = this.time;
 
+        // Clear
         ctx.fillStyle = '#050508';
         ctx.fillRect(0, 0, w, h);
 
@@ -153,6 +131,7 @@ export default class ProphecyTimelineViz {
             // Symbol
             ctx.font = '12px system-ui';
             ctx.textAlign = 'center';
+            ctx.fillStyle = '#fff'; // Ensure visible symbol
             ctx.fillText(node.symbol, nx, lineY + 1);
 
             // Year label
@@ -166,30 +145,31 @@ export default class ProphecyTimelineViz {
             ctx.fillText(node.label, nx, lineY - 18);
 
             // Hover detection
+            // Note: Mouse coordinates are relative to container, 
+            // but we are drawing in scaled canvas coordinates.
+            // this.mouse.x is CSS pixels. nx is logical canvas pixels.
+            // Since we scaled by DPR, logical pixels ~ CSS pixels.
             const dist = Math.sqrt((this.mouse.x - nx) ** 2 + (this.mouse.y - lineY) ** 2);
             if (dist < 25) {
                 this.hoveredNode = node;
-                this._tooltipEl.style.left = (nx + 15) + 'px';
-                this._tooltipEl.style.top = (lineY - 40) + 'px';
-                this._tooltipEl.innerHTML = `<strong>${node.label}</strong><br>${node.detail}`;
+                // Tooltip positioning
+                this._tooltipEl.style.left = Math.min(w - 220, Math.max(10, nx + 15)) + 'px';
+                this._tooltipEl.style.top = (lineY - 60) + 'px';
+                this._tooltipEl.innerHTML = `<strong style="color:#dbaae8">${node.label} (${node.year})</strong><br><span style="color:#bfa">${node.symbol}</span> ${node.detail}`;
                 this._tooltipEl.style.opacity = '1';
             }
         }
 
-        if (!this.hoveredNode) {
+        if (!this.hoveredNode && this._tooltipEl) {
             this._tooltipEl.style.opacity = '0';
         }
 
         ctx.restore();
     }
 
-    pause() { this.running = false; }
-    resume() { this.running = true; this._animate(); }
-    dispose() {
-        this.running = false;
+    destroy() {
         this.container.removeEventListener('mousemove', this._onMouseMove);
-        window.removeEventListener('resize', this._onResize);
         if (this._overlay) this._overlay.remove();
-        if (this.canvas.parentElement) this.canvas.remove();
+        super.destroy();
     }
 }


### PR DESCRIPTION
## Phase 6D — Batch 2: Ch 6-9 BaseViz Refactoring

Ports the Prophecy Arc visualizations to extend `BaseViz`:

| Chapter | Visualization | Interaction |
|---------|--------------|-------------|
| Ch 6 | AeonWheelViz | Zodiac wheel with rotating sectors |
| Ch 7 | ProphecyTimelineViz | Hover tooltips on timeline nodes |
| Ch 8 | FishEvolutionViz | Click to toggle hidden aspects |
| Ch 9 | ParadoxMirrorViz | Drag fulcrum to shift balance |

### Changes
- All 4 visualizations now extend `BaseViz` instead of standalone classes
- Unified lifecycle: `init()`, `update(dt)`, `render()`, `destroy()`
- Event listeners migrated from constructor to `init()` for proper cleanup
- Canvas creation and resize handling delegated to `BaseViz`

**4 files changed** — net reduction in code.