### PR TITLE
fix: stabilize Aion baseline config

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,10 +3,13 @@
     "collect": {
       "numberOfRuns": 1,
       "startServerCommand": "npm run serve",
-      "startServerReadyPattern": "Serving HTTP on",
+      "startServerReadyPattern": "Local:",
       "url": [
         "http://localhost:3000/",
-        "http://localhost:3000/journey/chapter/index.html?id=ch1"
+        "http://localhost:3000/chapters",
+        "http://localhost:3000/atlas",
+        "http://localhost:3000/journey/chapter/ch1",
+        "http://localhost:3000/journey/chapter/ch14"
       ]
     },
     "assert": {

--- a/scripts/performance/performance-budgets.json
+++ b/scripts/performance/performance-budgets.json
@@ -1,7 +1,10 @@
 {
   "routes": [
     "/",
-    "/journey/chapter/index.html"
+    "/chapters",
+    "/atlas",
+    "/journey/chapter/ch1",
+    "/journey/chapter/ch14"
   ],
   "webVitals": {
     "lcpMs": 2500,

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,7 +1,8 @@
 export type ChapterId = `ch${number}`;
 
 export interface SourceRef {
-  label: string;
+  work: 'Aion';
+  chapterId: ChapterId;
   locator?: string;
   note?: string;
 }
@@ -26,6 +27,7 @@ export interface ConceptRecord {
   symbolRefs: string[];
   difficulty: 'foundational' | 'intermediate' | 'advanced';
   prerequisites: string[];
+  sourceRefs?: SourceRef[];
 }
 
 export interface SymbolRecord {
@@ -34,6 +36,7 @@ export interface SymbolRecord {
   motif: string;
   historicPeriod: string;
   conceptIds: string[];
+  sourceRefs?: SourceRef[];
 }
 
 export interface LearningObjectRecord {

--- a/src/data/aion-core/chapters.schema.json
+++ b/src/data/aion-core/chapters.schema.json
@@ -21,7 +21,22 @@
             "summary": { "type": "string", "minLength": 1 },
             "keyConceptIds": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 1, "uniqueItems": true },
             "relatedChapterIds": { "type": "array", "items": { "type": "string", "pattern": "^ch[0-9]+$" }, "uniqueItems": true },
-            "learningObjectIds": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 2, "uniqueItems": true }
+            "learningObjectIds": { "type": "array", "items": { "type": "string", "minLength": 1 }, "minItems": 2, "uniqueItems": true },
+            "sourceRefs": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["work", "chapterId"],
+                "additionalProperties": false,
+                "properties": {
+                  "work": { "const": "Aion" },
+                  "chapterId": { "type": "string", "pattern": "^ch[0-9]+$" },
+                  "locator": { "type": "string", "minLength": 1 },
+                  "note": { "type": "string", "minLength": 1 }
+                }
+              },
+              "uniqueItems": true
+            }
           }
         }
       }

--- a/src/data/aion-core/concepts.schema.json
+++ b/src/data/aion-core/concepts.schema.json
@@ -20,7 +20,22 @@
           "chapterRefs": { "type": "array", "items": { "type": "string", "pattern": "^ch[0-9]+$" }, "minItems": 1, "uniqueItems": true },
           "symbolRefs": { "type": "array", "items": { "type": "string", "pattern": "^[a-z0-9-]+$" }, "uniqueItems": true },
           "difficulty": { "type": "string", "enum": ["foundational", "intermediate", "advanced"] },
-          "prerequisites": { "type": "array", "items": { "type": "string", "pattern": "^[a-z0-9-]+$" }, "uniqueItems": true }
+          "prerequisites": { "type": "array", "items": { "type": "string", "pattern": "^[a-z0-9-]+$" }, "uniqueItems": true },
+          "sourceRefs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["work", "chapterId"],
+              "additionalProperties": false,
+              "properties": {
+                "work": { "const": "Aion" },
+                "chapterId": { "type": "string", "pattern": "^ch[0-9]+$" },
+                "locator": { "type": "string", "minLength": 1 },
+                "note": { "type": "string", "minLength": 1 }
+              }
+            },
+            "uniqueItems": true
+          }
         }
       }
     }

--- a/src/data/aion-core/symbols.schema.json
+++ b/src/data/aion-core/symbols.schema.json
@@ -18,7 +18,22 @@
           "label": { "type": "string", "minLength": 1 },
           "motif": { "type": "string", "minLength": 1 },
           "historicPeriod": { "type": "string", "minLength": 1 },
-          "conceptIds": { "type": "array", "items": { "type": "string", "pattern": "^[a-z0-9-]+$" }, "minItems": 1, "uniqueItems": true }
+          "conceptIds": { "type": "array", "items": { "type": "string", "pattern": "^[a-z0-9-]+$" }, "minItems": 1, "uniqueItems": true },
+          "sourceRefs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["work", "chapterId"],
+              "additionalProperties": false,
+              "properties": {
+                "work": { "const": "Aion" },
+                "chapterId": { "type": "string", "pattern": "^ch[0-9]+$" },
+                "locator": { "type": "string", "minLength": 1 },
+                "note": { "type": "string", "minLength": 1 }
+              }
+            },
+            "uniqueItems": true
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- update Lighthouse and runtime performance route lists to canonical Vite app routes
- align Lighthouse server readiness with Vite preview output
- add the lightweight Aion source-reference contract to app types and canonical data schemas

## Verification
- rg -n "^(<<<<<<<|=======|>>>>>>>)" scoped conflict/config files: no matches
- jq empty package/lighthouse/performance/schema JSON files
- git diff --check
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run build
- npm run build:pages
- npm run test:app
- npm test
- npm run test:e2e:app
- npm run test:a11y:app

## Notes
- Backup branch preserved at backup/stabilize-baseline-20260601-210447.
- npm run perf:lighthouse now walks the canonical routes and Vite server readiness correctly, but the current visual app misses the existing strict LCP/TBT budgets; performance hardening remains the later batch rather than this baseline gate.