### PR TITLE
feat: add visual polish loop foundation

### DIFF
--- a/docs/AION_CONTINUAL_VISUAL_POLISH_LOOP.md
+++ b/docs/AION_CONTINUAL_VISUAL_POLISH_LOOP.md
@@ -1,0 +1,167 @@
+# Aion Continual Visual Polish Loop
+
+## Objective
+
+Keep improving Aion Visualization as a visual-first learning atlas for Jung's *Aion*. Each batch should make the current site more visually meaningful, more interactive, more coherent, and easier to verify without drifting into a giant unreviewable redesign.
+
+## Working Principles
+
+- Stabilize before ornament: never start a visual batch from a dirty or failing baseline.
+- Preserve the strongest prior design DNA: deep charcoal field, alchemical gold, cool analytic cyan, expressive serif display type, and Chapter 1's depth-field teaching rhythm.
+- Make visuals teach: every animation, orbit, glyph, panel, and scene control should clarify a concept, relation, or chapter transition.
+- Reduce text pressure: keep prose concise and let diagrams, scenes, symbolic marks, concept maps, and motion grammar carry the explanation.
+- Improve the system, then the page: extract repeatable tokens and primitives before doing one-off chapter fixes.
+- Ship one focused PR per batch with local checks, PR checks, and Pages smoke when routes change.
+
+## Skill Stack For Each Loop
+
+- Orchestration autopilot: split broad audits into independent scout, planner, reviewer, verifier, and devil-advocate tracks.
+- Redesign existing projects: identify generic UI drift and upgrade the existing stack rather than replacing it.
+- Frontend design pro and design taste frontend: enforce distinctive typography, asymmetric composition, tactile states, and anti-generic visual choices.
+- High-end visual design: add refined material details, glass edge treatment, button-in-button cues, and cinematic rhythm where they support learning.
+- Storytelling web: keep chapter pages as scrollytelling sequences with progressive visual understanding.
+- Accessibility review: check contrast, focus, keyboard paths, landmarks, target size, and reduced-motion parity before handoff.
+- React component performance: protect scene mounts, Three.js lazy loading, stable props, cleanup, and route budget discipline.
+
+## Batch Loop
+
+1. Baseline scan
+   - Confirm `git status --short --branch` is clean or create a backup branch/patch first.
+   - Run a narrow route/file audit for the target batch.
+   - Identify the one reusable improvement that will compound across later pages.
+
+2. Design intent
+   - Name the learning job of the target surface.
+   - Pick the visual grammar: opposition, integration, transformation, or cyclical return.
+   - Define the visual proof: what the learner can now see or manipulate that was previously only text.
+
+3. Component pass
+   - Polish shared components before page-specific surfaces.
+   - Prefer existing React pages, `src/app/styles.css`, canonical data, and Three scene adapters.
+   - Avoid overlapping write scopes when using implementation workers.
+
+4. Page pass
+   - Apply the shared component upgrade to one route family.
+   - Keep page copy short, visual hierarchy clear, and navigation consistent.
+   - Check desktop and mobile composition before expanding the pattern.
+
+5. Verification
+   - Run the fastest targeted checks first, then broaden.
+   - Inspect the rendered route with Playwright or the in-app browser.
+   - Record any residual debt as the next batch input, not as hidden knowledge.
+
+6. Ship
+   - Commit a focused batch.
+   - Push the branch and open a PR when the batch is coherent.
+   - After merge, smoke live GitHub Pages for changed routes.
+
+## Component Polish Order
+
+1. Global shell
+   - Floating scholarly nav, visible active state, quick chapter jump, skip link, and mobile wrapping.
+   - Acceptance: all routes expose visible navigation, active route state, keyboard focus, and no mobile overlap.
+
+2. Design tokens and material primitives
+   - Typography stack, gold/cyan/rose palette, motion curves, surface treatments, chip styles, panels, and buttons.
+   - Acceptance: repeated cards/panels/chips share one visual language without generic box-shadow or purple-blue drift.
+
+3. ChapterSigil
+   - Stronger chapter identity mark that can scale from compact nav/card usage to chapter hero usage.
+   - Acceptance: sigils remain readable at compact size and do not become decorative noise.
+
+4. Orbit and map controls
+   - Reusable orbit semantics for Home, Chapters, Atlas, Timeline, Symbols, and About.
+   - Acceptance: selected, hover, focus, and disabled states are visually distinct and keyboard-operable.
+
+5. SceneHost
+   - Loading, fallback, reduced-motion, nonblank canvas, and cleanup reliability.
+   - Acceptance: scene routes pass smoke tests, reduced-motion shows meaningful non-motion summaries, and no console errors appear.
+
+6. Chapter panel system
+   - Scrollytelling panels, symbolic mini-diagrams, concept anchors, checkpoints, reflection, and next/previous links.
+   - Acceptance: panels communicate the chapter's core movement with minimal prose and clear active state.
+
+## Page Polish Order
+
+1. Home
+   - Gold-standard first viewport with living Aion constellation, concise path choices, and chapter orbit preview.
+
+2. Shell and Chapters
+   - Make the route system feel like one atlas: no route family should look bolted on.
+
+3. Atlas
+   - Evolve the map into a searchable concept-symbol-chapter constellation using canonical data.
+
+4. Chapter 1: The Ego
+   - Treat as the reference chapter. Preserve the depth field, root filaments, Self reveal, and teaching-by-reveal cadence.
+
+5. Chapters 2-4
+   - Shadow, Syzygy, and Self as the first coherent psychology cluster.
+
+6. Chapters 5-9
+   - Christ symbol and fish aeon cluster with stronger opposition, historical strata, and ambivalence visuals.
+
+7. Chapters 10-14
+   - Alchemy, Gnosis, and final synthesis cluster with transformation and integration grammar.
+
+8. Timeline, Symbols, About
+   - Bring supporting routes up to the same visual system after the core journey feels mature.
+
+## Motion Grammar Backlog
+
+- Opposition: split fields, mirror tension, projection arcs, warm/cool conflict.
+- Integration: orbital relation, conjunction flashes, paired colors resolving into one field.
+- Transformation: vessel, strata, phase change, heat, opacity, and material state shifts.
+- Cyclical return: mandala, orbit, recurrence, return paths, and chapter-to-chapter resonance.
+
+`opposition` and `integration` already have stronger CSS treatment. The next grammar batch should make `transformation` and `cyclical-return` equally distinct in the chapter panel system and route visuals.
+
+## Verification Gates
+
+Fast local sequence for most visual batches:
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm run validate:consistency
+npm run ci:chapter-shell
+npm run test:app
+npm run build
+```
+
+Route-impacting or page-polish batches also run:
+
+```bash
+npm run test:e2e:app
+npm run test:a11y:app
+npm run build:pages
+npm run test:pages:artifact
+```
+
+Visual proof checklist:
+
+- No console errors.
+- No unexpected `404`s.
+- Visible global navigation and active state.
+- Keyboard path through nav, route controls, and selected interactive elements.
+- Reduced-motion fallback is meaningful.
+- Expected scene canvas is nonblank.
+- Mobile layout has no incoherent overlap.
+- Text stays short and does not crowd visual elements.
+
+## First Five Batches
+
+1. Visual system foundation
+   - Tokens, typography, nav material, buttons, chips, shared cards/panels, and this loop document.
+
+2. Home and shell detailing
+   - Strengthen first viewport, path choices, metrics, nav choreography, and mobile polish.
+
+3. Atlas constellation
+   - Upgrade chapter/concept/symbol search into a more visual constellation with richer selection feedback.
+
+4. Chapter 1 reference pass
+   - Preserve and elevate the Ego page until it becomes the exemplar for every chapter.
+
+5. Chapter cluster passes
+   - Work in clusters: 2-4, 5-9, 10-14, each with focused scene/panel/route tests.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Outfit:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,600&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/app/components/HomeAionField.tsx
+++ b/src/app/components/HomeAionField.tsx
@@ -1,11 +1,29 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { ChapterRecord } from '../types';
 
-export default function HomeAionField({ chapters }: { chapters: ChapterRecord[] }) {
-  const mountRef = useRef<HTMLDivElement | null>(null);
+function useReducedMotionPreference() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
   useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+export default function HomeAionField({ chapters }: { chapters: ChapterRecord[] }) {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const prefersReducedMotion = useReducedMotionPreference();
+
+  useEffect(() => {
+    if (prefersReducedMotion) return undefined;
+
     let disposed = false;
     let frameId = 0;
     let cleanup = () => {};
@@ -17,7 +35,6 @@ export default function HomeAionField({ chapters }: { chapters: ChapterRecord[] 
       const THREE = await import('three');
       if (disposed || !mountRef.current) return;
 
-      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
       const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: 'high-performance' });
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
       mount.appendChild(renderer.domElement);
@@ -161,15 +178,15 @@ export default function HomeAionField({ chapters }: { chapters: ChapterRecord[] 
         const t = time * 0.001;
 
         root.rotation.x = pointerSmooth.y * 0.08;
-        root.rotation.y = pointerSmooth.x * 0.18 + (reduceMotion ? 0 : Math.sin(t * 0.08) * 0.035);
-        stars.rotation.y = reduceMotion ? 0 : t * 0.012;
+        root.rotation.y = pointerSmooth.x * 0.18 + Math.sin(t * 0.08) * 0.035;
+        stars.rotation.y = t * 0.012;
         stars.rotation.x = pointerSmooth.y * 0.03;
         core.rotation.x = t * 0.18;
         core.rotation.y = t * 0.28;
-        veil.scale.setScalar(1 + (reduceMotion ? 0 : Math.sin(t * 0.9) * 0.06));
+        veil.scale.setScalar(1 + Math.sin(t * 0.9) * 0.06);
 
         for (const item of chapterNodes) {
-          const pulse = reduceMotion ? 0 : (Math.sin(t * 1.2 + item.chapter.order * 0.7) + 1) * 0.5;
+          const pulse = (Math.sin(t * 1.2 + item.chapter.order * 0.7) + 1) * 0.5;
           item.node.scale.setScalar(1 + pulse * 0.45);
           item.halo.scale.setScalar(1 + pulse * 0.28);
           const material = item.thread.material as THREE.LineBasicMaterial;
@@ -177,14 +194,13 @@ export default function HomeAionField({ chapters }: { chapters: ChapterRecord[] 
         }
 
         renderer.render(scene, camera);
-        if (!reduceMotion) frameId = window.requestAnimationFrame(render);
+        frameId = window.requestAnimationFrame(render);
       };
 
       resize();
       window.addEventListener('resize', resize);
       mount.addEventListener('pointermove', onPointerMove);
       render(0);
-      if (!reduceMotion) frameId = window.requestAnimationFrame(render);
 
       cleanup = () => {
         window.removeEventListener('resize', resize);
@@ -211,10 +227,45 @@ export default function HomeAionField({ chapters }: { chapters: ChapterRecord[] 
       disposed = true;
       cleanup();
     };
-  }, [chapters]);
+  }, [chapters, prefersReducedMotion]);
+
+  if (prefersReducedMotion) {
+    return (
+      <div
+        className="home-aion-field home-aion-field--static"
+        role="img"
+        aria-label="Static Aion field connecting ego, shadow, fish, alchemy, and Self across fourteen chapters."
+      >
+        <div className="home-aion-field__static" aria-hidden="true">
+          <span className="home-aion-field__static-ring home-aion-field__static-ring--outer" />
+          <span className="home-aion-field__static-ring home-aion-field__static-ring--middle" />
+          <span className="home-aion-field__static-ring home-aion-field__static-ring--inner" />
+          <span className="home-aion-field__static-core" />
+          {chapters.map((chapter) => (
+            <span
+              key={chapter.id}
+              className="home-aion-field__static-node"
+              style={{ ['--node-index' as string]: chapter.order - 1, ['--node-count' as string]: chapters.length }}
+            />
+          ))}
+        </div>
+        <div className="home-aion-field__caption">
+          <span>ego</span>
+          <span>shadow</span>
+          <span>fish</span>
+          <span>alchemy</span>
+          <span>self</span>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="home-aion-field" aria-hidden="true">
+    <div
+      className="home-aion-field"
+      role="img"
+      aria-label="Animated Aion constellation connecting ego, shadow, fish, alchemy, and Self across fourteen chapters."
+    >
       <div ref={mountRef} className="home-aion-field__mount" />
       <div className="home-aion-field__caption">
         <span>ego</span>

--- a/src/app/pages/AtlasPage.tsx
+++ b/src/app/pages/AtlasPage.tsx
@@ -31,7 +31,21 @@ export default function AtlasPage() {
   const active = chapters.find((chapter) => chapter.id === selected) || chapters[0];
   const activeConcepts = getConceptsForChapter(active.id);
   const linkedSymbols = symbols.filter((symbol) => symbol.conceptIds.some((id) => active.keyConceptIds.includes(id)));
-  const linkedRelationships = relationships.filter((rel) => rel.source === active.id || rel.target === active.id).slice(0, 4);
+  const relationshipEntityIds = new Set([
+    active.id,
+    ...active.keyConceptIds,
+    ...linkedSymbols.map((symbol) => symbol.id),
+  ]);
+  const linkedRelationships = relationships
+    .filter((rel) => relationshipEntityIds.has(rel.source) || relationshipEntityIds.has(rel.target))
+    .sort((a, b) => b.weight - a.weight)
+    .slice(0, 4);
+  const entityLabel = (id: string) => (
+    concepts.find((concept) => concept.id === id)?.label
+    || symbols.find((symbol) => symbol.id === id)?.label
+    || chapters.find((chapter) => chapter.id === id)?.title
+    || id
+  );
 
   return (
     <div className="page">
@@ -61,7 +75,9 @@ export default function AtlasPage() {
                   type="button"
                   onClick={() => setSelected(chapter.id)}
                   style={{ ['--node-index' as string]: chapter.order - 1, ['--node-count' as string]: filtered.length }}
+                  aria-controls="atlas-selected-detail"
                   aria-label={`Select chapter ${chapter.order}: ${chapter.title}`}
+                  aria-pressed={chapter.id === selected}
                 >
                   {chapter.order}
                 </button>
@@ -69,7 +85,7 @@ export default function AtlasPage() {
             </div>
           </div>
 
-          <aside className="atlas-detail" aria-label="Selected atlas chapter">
+          <aside id="atlas-selected-detail" className="atlas-detail" aria-label="Selected atlas chapter" aria-live="polite">
             <ChapterSigil chapter={active} compact />
             <p className="eyebrow">Chapter {active.order}</p>
             <h2>{active.title}</h2>
@@ -85,7 +101,17 @@ export default function AtlasPage() {
             </div>
             <div className="atlas-detail__section">
               <h3>Relations</h3>
-              <p>{linkedRelationships.map((rel) => rel.relationType).join(' · ') || 'Chapter sequence relation.'}</p>
+              {linkedRelationships.length > 0 ? (
+                <div className="relation-stack">
+                  {linkedRelationships.map((rel) => (
+                    <span key={rel.id}>
+                      {entityLabel(rel.source)} <em>{rel.relationType.replaceAll('_', ' ')}</em> {entityLabel(rel.target)}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p>Direct relationships are still being curated for this chapter.</p>
+              )}
             </div>
             <Link className="button button--primary" to={getChapterRoute(active.id)}>
               Open chapter

--- a/src/app/pages/ChaptersPage.tsx
+++ b/src/app/pages/ChaptersPage.tsx
@@ -31,7 +31,7 @@ export default function ChaptersPage() {
 
         <div className="chapters-orbit" aria-label="Interactive chapter orbit">
           <div className="chapters-orbit__rings" aria-hidden="true" />
-          <div className="chapters-orbit__center">
+          <div id="chapters-selected-detail" className="chapters-orbit__center" aria-live="polite">
             <ChapterSigil chapter={selected} compact />
             <span>Chapter {selected.order}</span>
             <strong>{selected.title}</strong>
@@ -44,7 +44,9 @@ export default function ChaptersPage() {
               type="button"
               onClick={() => setSelectedId(chapter.id)}
               style={{ ['--node-index' as string]: chapter.order - 1, ['--node-count' as string]: chapters.length }}
+              aria-controls="chapters-selected-detail"
               aria-label={`Preview chapter ${chapter.order}: ${chapter.title}`}
+              aria-pressed={chapter.id === selected.id}
             >
               {String(chapter.order).padStart(2, '0')}
             </button>

--- a/src/app/pages/TimelinePage.tsx
+++ b/src/app/pages/TimelinePage.tsx
@@ -42,7 +42,7 @@ export default function TimelinePage() {
           <p className="lede">A focused chronology places Aion inside a longer rhythm of life, publication, encounter, and concept formation.</p>
         </div>
         <div className="timeline-orbit" aria-label="Timeline orbit">
-          <div className="timeline-orbit__core">
+          <div id="timeline-selected-orbit-detail" className="timeline-orbit__core" aria-live="polite">
             <span>{year(selected.date)}</span>
             <strong>{selected.title}</strong>
           </div>
@@ -53,7 +53,9 @@ export default function TimelinePage() {
               type="button"
               style={{ ['--node-index' as string]: index, ['--node-count' as string]: orbitEvents.length }}
               onClick={() => setSelectedId(event.id)}
+              aria-controls="timeline-selected-detail timeline-selected-orbit-detail"
               aria-label={`Select ${year(event.date)}: ${event.title}`}
+              aria-pressed={event.id === selected.id}
             >
               {year(event.date).slice(2)}
             </button>
@@ -80,6 +82,8 @@ export default function TimelinePage() {
                 type="button"
                 className={event.id === selected.id ? 'timeline-rail__item timeline-rail__item--active' : 'timeline-rail__item'}
                 onClick={() => setSelectedId(event.id)}
+                aria-controls="timeline-selected-detail timeline-selected-orbit-detail"
+                aria-pressed={event.id === selected.id}
               >
                 <span>{year(event.date)}</span>
                 <strong>{event.title}</strong>
@@ -87,7 +91,7 @@ export default function TimelinePage() {
             </li>
           ))}
         </ol>
-        <aside className="timeline-detail">
+        <aside id="timeline-selected-detail" className="timeline-detail" aria-live="polite">
           <p className="eyebrow">{selected.category}</p>
           <h2>{selected.title}</h2>
           <p>{selected.summary}</p>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1,9 +1,17 @@
+@font-face {
+  font-family: 'Aion Fraunces';
+  src: url('../../assets/fonts/Fraunces-Variable-latin.woff2') format('woff2');
+  font-display: swap;
+  font-weight: 300 900;
+}
+
 :root {
   color-scheme: dark;
-  --bg: #030307;
-  --bg-soft: #08080f;
+  --bg: #050508;
+  --bg-soft: #0a0a10;
   --surface: rgba(255, 255, 255, 0.045);
   --surface-strong: rgba(255, 255, 255, 0.08);
+  --surface-machined: linear-gradient(145deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.018));
   --line: rgba(255, 255, 255, 0.11);
   --line-strong: rgba(212, 175, 55, 0.38);
   --text: #f4f0e8;
@@ -14,11 +22,17 @@
   --cyan: #53d8e8;
   --green: #84c99b;
   --rose: #cc6d86;
-  --font-display: 'Instrument Serif', 'Playfair Display', ui-serif, serif;
-  --font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Aion Fraunces', 'Instrument Serif', ui-serif, serif;
+  --font-ui: 'Outfit', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-body: 'Source Serif 4', ui-serif, Georgia, serif;
   --font-serif: 'Source Serif 4', ui-serif, Georgia, serif;
   --radius: 8px;
+  --radius-lg: 14px;
   --max: 1180px;
+  --motion-spring: cubic-bezier(0.32, 0.72, 0, 1);
+  --motion-reveal: cubic-bezier(0.22, 1, 0.36, 1);
+  --shadow-ambient: 0 1.2rem 4rem rgba(0, 0, 0, 0.28), 0 3.5rem 8rem rgba(5, 5, 8, 0.4);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.08), inset 0 -1px 0 rgba(0, 0, 0, 0.16);
 }
 
 * {
@@ -43,6 +57,20 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0.045;
+  background-image:
+    radial-gradient(circle at 18% 22%, rgba(255, 255, 255, 0.85) 0 1px, transparent 1px),
+    radial-gradient(circle at 72% 64%, rgba(212, 175, 55, 0.72) 0 1px, transparent 1px);
+  background-size: 5.4rem 5.4rem, 7.2rem 7.2rem;
+  mix-blend-mode: soft-light;
+}
+
 a {
   color: inherit;
 }
@@ -51,6 +79,7 @@ button,
 input,
 select {
   font: inherit;
+  font-family: var(--font-ui);
 }
 
 button:focus-visible,
@@ -75,7 +104,7 @@ summary:focus-visible {
   position: fixed;
   left: 1rem;
   top: 1rem;
-  z-index: 999;
+  z-index: 60;
   transform: translateY(-160%);
   border-radius: var(--radius);
   background: var(--gold);
@@ -93,21 +122,23 @@ summary:focus-visible {
 
 .app-nav {
   position: fixed;
-  inset: 0 0 auto;
-  z-index: 100;
+  inset: 1rem clamp(0.85rem, 2.4vw, 2rem) auto;
+  z-index: 40;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.95rem clamp(1rem, 3vw, 2.5rem);
-  background: rgba(3, 3, 7, 0.68);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
-  backdrop-filter: blur(18px);
+  padding: 0.55rem 0.7rem 0.55rem clamp(0.95rem, 2vw, 1.3rem);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 999px;
+  background: rgba(5, 5, 8, 0.72);
+  box-shadow: var(--shadow-inset), 0 1.2rem 4rem rgba(0, 0, 0, 0.34);
+  backdrop-filter: blur(24px);
 }
 
 .app-nav__brand {
   font-family: var(--font-display);
-  font-size: 1.45rem;
+  font-size: 1.32rem;
   color: var(--gold-soft);
   text-decoration: none;
 }
@@ -129,15 +160,25 @@ summary:focus-visible {
 .app-nav__link {
   border-radius: 999px;
   color: var(--muted);
+  font-family: var(--font-ui);
   font-size: 0.86rem;
+  font-weight: 600;
   padding: 0.45rem 0.72rem;
   text-decoration: none;
+  transition:
+    background 0.38s var(--motion-spring),
+    color 0.38s var(--motion-spring),
+    transform 0.38s var(--motion-spring);
 }
 
 .app-nav__link:hover,
 .app-nav__link--active {
   background: var(--surface);
   color: var(--text);
+}
+
+.app-nav__link:hover {
+  transform: translateY(-1px);
 }
 
 .chapter-jump {
@@ -162,10 +203,18 @@ summary:focus-visible {
   border-radius: 50%;
   color: var(--gold-soft);
   text-decoration: none;
+  transition:
+    border-color 0.38s var(--motion-spring),
+    transform 0.38s var(--motion-spring);
 }
 
 .chapter-jump__sequence span {
   color: var(--dim);
+}
+
+.chapter-jump__sequence a:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
 }
 
 .chapter-jump select {
@@ -196,8 +245,10 @@ summary:focus-visible {
 .eyebrow {
   margin: 0 0 0.7rem;
   color: var(--gold);
+  font-family: var(--font-ui);
   font-size: 0.78rem;
   font-weight: 700;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
@@ -213,6 +264,7 @@ h2,
 h3 {
   font-family: var(--font-display);
   font-weight: 400;
+  text-wrap: balance;
 }
 
 h1 {
@@ -248,12 +300,14 @@ h3 {
   border-radius: 999px;
   padding: 0.72rem 0.58rem 0.72rem 1.1rem;
   position: relative;
+  font-family: var(--font-ui);
+  font-weight: 700;
   overflow: hidden;
   text-decoration: none;
   transition:
-    transform 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    border-color 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    background 0.45s cubic-bezier(0.32, 0.72, 0, 1);
+    transform 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring);
 }
 
 .button::after {
@@ -265,7 +319,8 @@ h3 {
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.16);
   font-weight: 700;
-  transition: transform 0.45s cubic-bezier(0.32, 0.72, 0, 1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  transition: transform 0.45s var(--motion-spring);
 }
 
 .button--primary {
@@ -342,10 +397,76 @@ h3 {
   inset: 0;
 }
 
+.home-aion-field--static {
+  background:
+    radial-gradient(circle at 66% 48%, rgba(212, 175, 55, 0.16), transparent 15rem),
+    radial-gradient(circle at 62% 52%, rgba(83, 216, 232, 0.1), transparent 22rem);
+}
+
 .home-aion-field__mount canvas {
   width: 100%;
   height: 100%;
   display: block;
+}
+
+.home-aion-field__static {
+  position: absolute;
+  right: max(2rem, 8vw);
+  top: 50%;
+  width: min(58vw, 42rem);
+  aspect-ratio: 1;
+  transform: translateY(-50%);
+}
+
+.home-aion-field__static-ring,
+.home-aion-field__static-core,
+.home-aion-field__static-node {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.home-aion-field__static-ring {
+  border: 1px solid rgba(212, 175, 55, 0.2);
+  box-shadow: inset 0 0 5rem rgba(83, 216, 232, 0.04);
+}
+
+.home-aion-field__static-ring--outer {
+  width: 82%;
+  aspect-ratio: 1;
+}
+
+.home-aion-field__static-ring--middle {
+  width: 58%;
+  aspect-ratio: 1;
+  border-color: rgba(244, 240, 232, 0.09);
+}
+
+.home-aion-field__static-ring--inner {
+  width: 35%;
+  aspect-ratio: 1;
+  border-color: rgba(83, 216, 232, 0.23);
+}
+
+.home-aion-field__static-core {
+  width: 9%;
+  aspect-ratio: 1;
+  background: radial-gradient(circle, var(--gold-soft), var(--gold) 58%, transparent 65%);
+  box-shadow:
+    0 0 2.8rem rgba(212, 175, 55, 0.64),
+    0 0 8rem rgba(83, 216, 232, 0.12);
+}
+
+.home-aion-field__static-node {
+  --angle: calc((360deg / var(--node-count)) * var(--node-index));
+  width: 0.7rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.42);
+  background: rgba(244, 240, 232, 0.86);
+  box-shadow: 0 0 1.6rem rgba(212, 175, 55, 0.32);
+  transform: rotate(var(--angle)) translateX(min(21vw, 16.4rem)) rotate(calc(-1 * var(--angle)));
 }
 
 .home-aion-field__caption {
@@ -416,22 +537,65 @@ h3 {
 .chapter-preview,
 .symbol-panel,
 .about-principles article {
+  position: relative;
   min-height: 16rem;
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  background: var(--surface-machined);
+  box-shadow: var(--shadow-inset);
   padding: 1.25rem;
+  overflow: hidden;
   text-decoration: none;
+  transition:
+    transform 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring),
+    box-shadow 0.45s var(--motion-spring);
+}
+
+.path-panel::before,
+.chapter-preview::before,
+.symbol-panel::before,
+.about-principles article::before {
+  content: '';
+  position: absolute;
+  inset: 0.38rem;
+  border: 1px solid rgba(255, 255, 255, 0.055);
+  border-radius: calc(var(--radius) - 2px);
+  pointer-events: none;
+}
+
+.path-panel::after,
+.chapter-preview::after,
+.symbol-panel::after,
+.about-principles article::after {
+  content: '';
+  position: absolute;
+  right: -2.4rem;
+  bottom: -2.6rem;
+  width: 9rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.16);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 0 1.6rem rgba(83, 216, 232, 0.025),
+    0 0 4rem rgba(212, 175, 55, 0.055);
+  pointer-events: none;
 }
 
 .path-panel:hover,
-.chapter-preview:hover {
+.chapter-preview:hover,
+.symbol-panel:hover,
+.about-principles article:hover {
   border-color: var(--line-strong);
+  box-shadow: var(--shadow-inset), var(--shadow-ambient);
+  transform: translateY(-3px);
 }
 
 .path-panel__mark,
 .about-principles span {
   color: var(--cyan);
+  font-family: var(--font-ui);
   font-weight: 700;
 }
 
@@ -454,6 +618,7 @@ h3 {
 .chapter-card span,
 .sequence-link span {
   color: var(--dim);
+  font-family: var(--font-ui);
   font-size: 0.8rem;
 }
 
@@ -750,9 +915,9 @@ h3 {
   cursor: pointer;
   transform: rotate(var(--angle)) translateX(var(--orbit-radius)) rotate(calc(-1 * var(--angle)));
   transition:
-    transform 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    background 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    border-color 0.45s cubic-bezier(0.32, 0.72, 0, 1);
+    transform 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring);
 }
 
 .chapters-orbit__node:hover {
@@ -764,6 +929,13 @@ h3 {
   border-color: var(--gold);
   color: #050508;
   transform: rotate(var(--angle)) translateX(var(--orbit-radius)) rotate(calc(-1 * var(--angle))) scale(1.14);
+}
+
+.chapters-orbit__node[aria-pressed="true"],
+.atlas-node[aria-pressed="true"],
+.timeline-orbit__node[aria-pressed="true"],
+.timeline-rail__item[aria-pressed="true"] {
+  border-color: var(--line-strong);
 }
 
 .chapters-orbit__concepts {
@@ -791,6 +963,7 @@ h3 {
 }
 
 .chapter-card {
+  position: relative;
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 1rem;
@@ -799,16 +972,31 @@ h3 {
   border-radius: var(--radius);
   padding: 1rem;
   text-decoration: none;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.016));
+  background: var(--surface-machined);
+  box-shadow: var(--shadow-inset);
+  overflow: hidden;
   transition:
-    transform 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    border-color 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    background 0.45s cubic-bezier(0.32, 0.72, 0, 1);
+    transform 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring),
+    box-shadow 0.45s var(--motion-spring);
+}
+
+.chapter-card::after {
+  content: '';
+  position: absolute;
+  inset: auto -2rem -4rem auto;
+  width: 11rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.12);
+  border-radius: 50%;
+  pointer-events: none;
 }
 
 .chapter-card:hover {
   border-color: var(--line-strong);
   background: linear-gradient(145deg, rgba(212, 175, 55, 0.08), rgba(255, 255, 255, 0.02));
+  box-shadow: var(--shadow-inset), var(--shadow-ambient);
   transform: translateY(-2px);
 }
 
@@ -829,8 +1017,20 @@ h3 {
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--muted);
+  font-family: var(--font-ui);
   padding: 0.32rem 0.58rem;
   font-size: 0.78rem;
+  transition:
+    border-color 0.38s var(--motion-spring),
+    color 0.38s var(--motion-spring),
+    transform 0.38s var(--motion-spring);
+}
+
+.chip-row span:hover,
+.concept-cloud span:hover {
+  border-color: rgba(212, 175, 55, 0.28);
+  color: var(--text);
+  transform: translateY(-1px);
 }
 
 .atlas-layout,
@@ -867,7 +1067,8 @@ h3 {
 .chapter-knowledge__block {
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: rgba(255, 255, 255, 0.035);
+  background: var(--surface-machined);
+  box-shadow: var(--shadow-inset);
   padding: 1.2rem;
 }
 
@@ -922,9 +1123,9 @@ h3 {
   cursor: pointer;
   transform: rotate(var(--angle)) translateX(var(--orbit-radius)) rotate(calc(-1 * var(--angle)));
   transition:
-    transform 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    border-color 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    background 0.45s cubic-bezier(0.32, 0.72, 0, 1);
+    transform 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring);
 }
 
 .atlas-node--active {
@@ -935,6 +1136,24 @@ h3 {
 
 .concept-cloud {
   max-width: 58rem;
+}
+
+.relation-stack {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.relation-stack span {
+  border-left: 1px solid rgba(212, 175, 55, 0.28);
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  padding-left: 0.65rem;
+}
+
+.relation-stack em {
+  color: var(--gold-soft);
+  font-style: normal;
 }
 
 .chapter-stage {
@@ -1031,9 +1250,9 @@ h3 {
   padding: 0.35rem 0.72rem 0.35rem 0.42rem;
   text-decoration: none;
   transition:
-    transform 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    border-color 0.45s cubic-bezier(0.32, 0.72, 0, 1),
-    color 0.45s cubic-bezier(0.32, 0.72, 0, 1);
+    transform 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    color 0.45s var(--motion-spring);
 }
 
 .chapter-stage__thesis-node span {
@@ -1094,8 +1313,8 @@ h3 {
   margin-left: auto;
   opacity: 0.72;
   transition:
-    opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1),
-    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+    opacity 0.7s var(--motion-reveal),
+    transform 0.7s var(--motion-reveal);
 }
 
 .chapter-panel:nth-child(even) {
@@ -1251,8 +1470,8 @@ h3 {
   right: auto;
   left: 78%;
   top: 30%;
-  background: #b874ff;
-  box-shadow: 0 0 1.4rem rgba(184, 116, 255, 0.64);
+  background: #d79a72;
+  box-shadow: 0 0 1.4rem rgba(215, 154, 114, 0.56);
 }
 
 .chapter-experience[data-motion-grammar="integration"] .chapter-panel__symbol {
@@ -1459,6 +1678,8 @@ h3 {
   .app-nav {
     align-items: flex-start;
     flex-direction: column;
+    border-radius: var(--radius-lg);
+    padding: 0.75rem;
   }
 
   .app-nav__right {


### PR DESCRIPTION
## Summary
- add the continual visual polish loop plan for component-by-component and page-by-page Aion development
- strengthen the shared visual system with Fraunces/Outfit typography, floating scholarly nav, machined panels, richer chips/buttons, and reduced generic neon drift
- add accessible selected-state semantics for Chapters, Atlas, and Timeline selector surfaces
- replace Atlas placeholder relation text with canonical concept/symbol relationship details
- add a reduced-motion Home constellation fallback that avoids creating a WebGL canvas

## Verification
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- npm run build
- node scripts/testing/app-shell-smoke.mjs
- node scripts/testing/app-accessibility-smoke.mjs
- npm run build:pages
- npm run test:pages:artifact
- Playwright visual sanity: Home, Chapters, Atlas, Timeline, Chapter 1 desktop; Home/Chapters/Atlas/Timeline mobile; reduced-motion Home with zero canvases

## Notes
- Existing large Three.js chunk warning remains and should stay in the performance batch backlog.
- GitHub reports existing Dependabot vulnerabilities on the default branch; not changed by this PR.