### PR TITLE
feat: detail Home and shell visual system

### DIFF
--- a/scripts/build-pages-artifact.mjs
+++ b/scripts/build-pages-artifact.mjs
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 const distDir = path.resolve('dist');
 const pagesBase = normalizeBase(process.env.PAGES_BASE || '/aion-visualization');
+const viteBase = pagesBase ? `${pagesBase}/` : '/';
 
 const shellRoutes = [
   '/',
@@ -160,7 +161,7 @@ async function materializePagesRoutes() {
   console.log(`Materialized ${canonicalRoutes.length} canonical Pages routes, ${legacyChapterRoutes.length} legacy chapter redirects, and the legacy query redirect.`);
 }
 
-await run('npx', ['vite', 'build'], {
+await run('npx', ['vite', 'build', '--base', viteBase], {
   env: {
     ...process.env,
     GITHUB_PAGES: 'true',

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -7,6 +7,14 @@ import { chromium } from 'playwright';
 const port = Number(process.env.AION_SMOKE_PORT || 4174);
 const baseUrl = `http://127.0.0.1:${port}`;
 const canonicalRoutes = ['/', '/chapters', '/atlas', '/timeline', '/symbols', '/about'];
+const canonicalRouteLabels = new Map([
+  ['/', 'Home'],
+  ['/chapters', 'Chapters'],
+  ['/atlas', 'Atlas'],
+  ['/timeline', 'Timeline'],
+  ['/symbols', 'Symbols'],
+  ['/about', 'About'],
+]);
 const chapterRoutes = Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`);
 const desktopViewport = { width: 1440, height: 1000 };
 const mobileViewport = { width: 390, height: 844 };
@@ -151,6 +159,36 @@ async function smokeCanonicalRoutes(page, failures) {
   for (const route of canonicalRoutes) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, route, failures);
+
+    const routeContext = await page.locator('.app-nav__context strong').textContent();
+    const expectedRouteContext = canonicalRouteLabels.get(route);
+    if (routeContext?.trim() !== expectedRouteContext) {
+      failures.push(`route context mismatch for ${route}: ${routeContext}`);
+    }
+  }
+}
+
+async function smokeHomeVisualDetail(page, failures) {
+  await gotoAppRoute(page, '/');
+
+  const routeContext = await page.locator('.app-nav__context strong').textContent();
+  const pathPanelCount = await page.locator('.path-panel').count();
+  const pathDiagramCount = await page.locator('.path-panel__diagram').count();
+  const metricCellCount = await page.locator('.metrics-strip__cell').count();
+  const orbitNodeCount = await page.locator('.home-chapter-orbit a').count();
+  const featuredOrbitNodeCount = await page.locator('.home-chapter-orbit__item--featured a').count();
+  const previewLabels = await page.locator('.chapter-preview').evaluateAll((links) => links.map((link) => link.getAttribute('aria-label') || ''));
+
+  if (routeContext?.trim() !== 'Home') failures.push(`home route context mismatch: ${routeContext}`);
+  if (pathPanelCount !== 3) failures.push(`home path panel count mismatch: ${pathPanelCount}`);
+  if (pathDiagramCount !== 3) failures.push(`home path diagram count mismatch: ${pathDiagramCount}`);
+  if (metricCellCount !== 3) failures.push(`home metric cell count mismatch: ${metricCellCount}`);
+  if (orbitNodeCount !== 14) failures.push(`home chapter orbit node count mismatch: ${orbitNodeCount}`);
+  if (featuredOrbitNodeCount !== 4) failures.push(`home featured orbit node count mismatch: ${featuredOrbitNodeCount}`);
+  for (const label of previewLabels) {
+    if (!/^Chapter \d+: /.test(label) || label.includes('Visual sigil')) {
+      failures.push(`noisy home chapter preview label: ${label}`);
+    }
   }
 }
 
@@ -180,8 +218,30 @@ async function smokeKeyboard(page, failures) {
   if (!brandFocused) failures.push('keyboard focus did not proceed to brand link');
 }
 
-async function smokeReducedMotion(page, failures) {
+async function smokeReducedMotion(browser, failures) {
+  const page = await browser.newPage({ viewport: desktopViewport });
+  const routeFailures = watchForRouteFailures(page);
+  const threeRequests = [];
+
+  page.on('request', (request) => {
+    const url = request.url();
+    if (/\/assets\/three-|three.*\.js/i.test(url)) {
+      threeRequests.push(url);
+    }
+  });
+
   await page.emulateMedia({ reducedMotion: 'reduce' });
+  await gotoAppRoute(page, '/');
+  const staticHomeFieldVisible = await page.locator('.home-aion-field--static').isVisible();
+  const animatedHomeCanvasCount = await page.locator('.home-aion-field__mount canvas').count();
+  const navTransitionProperty = await page.locator('.app-nav__link').first().evaluate((element) => window.getComputedStyle(element).transitionProperty);
+  const pathTransitionProperty = await page.locator('.path-panel').first().evaluate((element) => window.getComputedStyle(element).transitionProperty);
+
+  if (!staticHomeFieldVisible) failures.push('reduced-motion home field is not visible');
+  if (animatedHomeCanvasCount !== 0) failures.push(`reduced-motion home rendered animated canvas: ${animatedHomeCanvasCount}`);
+  if (navTransitionProperty !== 'none') failures.push(`reduced-motion nav transition remains active: ${navTransitionProperty}`);
+  if (pathTransitionProperty !== 'none') failures.push(`reduced-motion path transition remains active: ${pathTransitionProperty}`);
+
   await gotoAppRoute(page, '/journey/chapter/ch1');
   await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
   const fallbackVisible = await page.locator('.scene-host__fallback').isVisible();
@@ -189,7 +249,11 @@ async function smokeReducedMotion(page, failures) {
 
   if (!fallbackVisible) failures.push('reduced-motion fallback is not visible for chapter scene');
   if (reducedMotionAttribute !== 'true') failures.push('chapter did not record reduced-motion state');
-  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
+
+  failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
+  failures.push(...routeFailures.consoleErrors.map((message) => `reduced-motion console error: ${message}`));
+  await page.close();
 }
 
 async function smokeLegacyRedirect(page, failures) {
@@ -363,6 +427,23 @@ async function smokeMobile(page, failures) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
+
+  for (const viewport of [mobileViewport, { width: 320, height: 568 }]) {
+    await page.setViewportSize(viewport);
+    await gotoAppRoute(page, '/');
+
+    const navBox = await page.locator('.app-nav').boundingBox();
+    const heroCopyBox = await page.locator('.home-hero__copy').boundingBox();
+    if (!navBox || !heroCopyBox) {
+      failures.push(`mobile home geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const navBottom = navBox.y + navBox.height;
+    if (navBottom > heroCopyBox.y - 1) {
+      failures.push(`mobile nav overlaps home hero copy at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(navBottom)}, copy top ${Math.round(heroCopyBox.y)}`);
+    }
+  }
 }
 
 async function runSmoke() {
@@ -373,13 +454,15 @@ async function runSmoke() {
   try {
     await waitForServer(server);
     browser = await chromium.launch({ headless: true });
+    await smokeReducedMotion(browser, failures);
+
     const page = await browser.newPage({ viewport: desktopViewport });
     const routeFailures = watchForRouteFailures(page);
 
     await smokeCanonicalRoutes(page, failures);
+    await smokeHomeVisualDetail(page, failures);
     await smokeChapterRoutes(page, failures);
     await smokeKeyboard(page, failures);
-    await smokeReducedMotion(page, failures);
     await smokeLegacyRedirect(page, failures);
     await smokeChapterJump(page, failures);
     await smokeChapterSceneControls(page, failures);

--- a/src/app/components/HomeAionField.tsx
+++ b/src/app/components/HomeAionField.tsx
@@ -3,7 +3,10 @@ import { useEffect, useRef, useState } from 'react';
 import type { ChapterRecord } from '../types';
 
 function useReducedMotionPreference() {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -22,7 +25,7 @@ export default function HomeAionField({ chapters }: { chapters: ChapterRecord[] 
   const prefersReducedMotion = useReducedMotionPreference();
 
   useEffect(() => {
-    if (prefersReducedMotion) return undefined;
+    if (prefersReducedMotion !== false) return undefined;
 
     let disposed = false;
     let frameId = 0;
@@ -229,7 +232,7 @@ export default function HomeAionField({ chapters }: { chapters: ChapterRecord[] 
     };
   }, [chapters, prefersReducedMotion]);
 
-  if (prefersReducedMotion) {
+  if (prefersReducedMotion !== false) {
     return (
       <div
         className="home-aion-field home-aion-field--static"

--- a/src/app/components/Shell.tsx
+++ b/src/app/components/Shell.tsx
@@ -16,6 +16,18 @@ export default function Shell({ children }: { children: ReactNode }) {
   const isChapter = location.pathname.startsWith('/journey/chapter/');
   const activeChapter = isChapter ? getChapterById(normalizeChapterId(location.pathname.split('/').pop())) : null;
   const adjacent = activeChapter ? getAdjacentChapters(activeChapter.id) : null;
+  const activeRoute = navRoutes.find((route) => route.path === location.pathname);
+  const navContext = activeChapter
+    ? {
+        kicker: 'Journey',
+        label: `${String(activeChapter.order).padStart(2, '0')} · ${activeChapter.title}`,
+        detail: activeChapter.cluster,
+      }
+    : {
+        kicker: 'Current route',
+        label: activeRoute?.label || 'Home',
+        detail: 'Visual learning path',
+      };
 
   return (
     <div className={isChapter ? 'app-shell app-shell--chapter' : 'app-shell'}>
@@ -23,9 +35,16 @@ export default function Shell({ children }: { children: ReactNode }) {
         Skip to content
       </a>
       <header className="app-nav" aria-label="Global navigation">
-        <NavLink to="/" className="app-nav__brand" aria-label="Aion home">
-          Aion
-        </NavLink>
+        <div className="app-nav__identity">
+          <NavLink to="/" className="app-nav__brand" aria-label="Aion home">
+            Aion
+          </NavLink>
+          <div className="app-nav__context" aria-label={`Current route: ${navContext.label}`}>
+            <span>{navContext.kicker}</span>
+            <strong>{navContext.label}</strong>
+            <em>{navContext.detail}</em>
+          </div>
+        </div>
         <div className="app-nav__right">
           <nav className="app-nav__links" aria-label="Primary">
             {navRoutes.map((route) => (

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -15,7 +15,10 @@ import type { ChapterRecord } from '../types';
 import { CHAPTER_SCENES } from '../visualization/chapterScenes';
 
 function useReducedMotionPreference() {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -41,7 +44,8 @@ export default function ChapterPage({ chapterId }: { chapterId: string }) {
 }
 
 function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
-  const reducedMotion = useReducedMotionPreference();
+  const reducedMotionPreference = useReducedMotionPreference();
+  const reducedMotion = reducedMotionPreference !== false;
   const experience = CHAPTER_SCENES[chapter.id];
   const [activePanelId, setActivePanelId] = useState(experience.panels[0]?.id || '');
   const concepts = getConceptsForChapter(chapter.id);

--- a/src/app/pages/HomePage.tsx
+++ b/src/app/pages/HomePage.tsx
@@ -6,7 +6,37 @@ import { getChapterRoute, getChapters, getConcepts, getSymbols } from '../data/a
 
 export default function HomePage() {
   const chapters = getChapters();
+  const concepts = getConcepts();
+  const symbols = getSymbols();
   const featured = [chapters[0], chapters[4], chapters[8], chapters[13]];
+  const conceptLabel = (id: string) => concepts.find((concept) => concept.id === id)?.label || id;
+  const symbolLabel = (id: string) => symbols.find((symbol) => symbol.id === id)?.label || id;
+  const pathPanels = [
+    {
+      href: getChapterRoute('ch1'),
+      mark: 'I',
+      title: 'Guided journey',
+      body: 'Move chapter by chapter through a visual argument about the Self.',
+      mode: 'sequence',
+      tags: [conceptLabel('ego'), conceptLabel('shadow'), conceptLabel('self')],
+    },
+    {
+      href: '/atlas',
+      mark: 'II',
+      title: 'Concept atlas',
+      body: 'Enter non-linearly through concepts, symbols, and chapter relationships.',
+      mode: 'constellation',
+      tags: [conceptLabel('self'), symbolLabel('mandala'), symbolLabel('fish')],
+    },
+    {
+      href: '/timeline',
+      mark: 'III',
+      title: 'Time and symbols',
+      body: "Place Aion beside Jung's life, publications, and recurring motifs.",
+      mode: 'cycle',
+      tags: [conceptLabel('aeon'), conceptLabel('fish-symbol'), symbolLabel('zodiac')],
+    },
+  ];
 
   return (
     <div className="page page--home">
@@ -34,16 +64,16 @@ export default function HomePage() {
 
       <section className="section-band section-band--tight">
         <div className="metrics-strip" aria-label="Aion knowledge model summary">
-          <div>
+          <div className="metrics-strip__cell">
             <strong>{chapters.length}</strong>
             <span>chapters</span>
           </div>
-          <div>
-            <strong>{getConcepts().length}</strong>
+          <div className="metrics-strip__cell">
+            <strong>{concepts.length}</strong>
             <span>concepts</span>
           </div>
-          <div>
-            <strong>{getSymbols().length}</strong>
+          <div className="metrics-strip__cell">
+            <strong>{symbols.length}</strong>
             <span>symbols</span>
           </div>
         </div>
@@ -55,21 +85,23 @@ export default function HomePage() {
           <h2>Read, map, return</h2>
         </div>
         <div className="path-grid">
-          <Link to={getChapterRoute('ch1')} className="path-panel">
-            <span className="path-panel__mark">I</span>
-            <h3>Guided journey</h3>
-            <p>Move chapter by chapter through a visual argument about the Self.</p>
-          </Link>
-          <Link to="/atlas" className="path-panel">
-            <span className="path-panel__mark">II</span>
-            <h3>Concept atlas</h3>
-            <p>Enter non-linearly through concepts, symbols, and chapter relationships.</p>
-          </Link>
-          <Link to="/timeline" className="path-panel">
-            <span className="path-panel__mark">III</span>
-            <h3>Time and symbols</h3>
-            <p>Place Aion beside Jung's life, publications, and recurring motifs.</p>
-          </Link>
+          {pathPanels.map((path) => (
+            <Link key={path.href} to={path.href} className={`path-panel path-panel--${path.mode}`}>
+              <span className="path-panel__mark">{path.mark}</span>
+              <span className="path-panel__diagram" aria-hidden="true">
+                <span />
+                <span />
+                <span />
+              </span>
+              <h3>{path.title}</h3>
+              <p>{path.body}</p>
+              <span className="path-panel__tags" aria-hidden="true">
+                {path.tags.map((tag) => (
+                  <span key={tag}>{tag}</span>
+                ))}
+              </span>
+            </Link>
+          ))}
         </div>
       </section>
 
@@ -78,9 +110,22 @@ export default function HomePage() {
           <p className="eyebrow">First orbit</p>
           <h2>Four luminous thresholds</h2>
         </div>
+        <ol className="home-chapter-orbit" aria-label="Aion chapter orbit quick launch">
+          {chapters.map((chapter) => (
+            <li
+              key={chapter.id}
+              style={{ ['--node-index' as string]: chapter.order - 1, ['--node-count' as string]: chapters.length }}
+              className={featured.includes(chapter) ? 'home-chapter-orbit__item home-chapter-orbit__item--featured' : 'home-chapter-orbit__item'}
+            >
+              <Link to={getChapterRoute(chapter.id)} aria-label={`Open Chapter ${chapter.order}: ${chapter.title}`}>
+                {String(chapter.order).padStart(2, '0')}
+              </Link>
+            </li>
+          ))}
+        </ol>
         <div className="chapter-preview-grid">
           {featured.map((chapter) => (
-            <Link key={chapter.id} to={getChapterRoute(chapter.id)} className="chapter-preview">
+            <Link key={chapter.id} to={getChapterRoute(chapter.id)} className="chapter-preview" aria-label={`Chapter ${chapter.order}: ${chapter.title}`}>
               <ChapterSigil chapter={chapter} />
               <span>Chapter {chapter.order}</span>
               <h3>{chapter.title}</h3>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -16,7 +16,7 @@
   --line-strong: rgba(212, 175, 55, 0.38);
   --text: #f4f0e8;
   --muted: #a7a29a;
-  --dim: #6e6a63;
+  --dim: #8d887f;
   --gold: #d4af37;
   --gold-soft: #ffe39c;
   --cyan: #53d8e8;
@@ -136,11 +136,56 @@ summary:focus-visible {
   backdrop-filter: blur(24px);
 }
 
+.app-nav__identity {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.65rem, 1.4vw, 1rem);
+  min-width: 0;
+}
+
 .app-nav__brand {
   font-family: var(--font-display);
   font-size: 1.32rem;
   color: var(--gold-soft);
   text-decoration: none;
+}
+
+.app-nav__context {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.08rem 0.5rem;
+  min-width: 0;
+  max-width: min(24vw, 19rem);
+  border-left: 1px solid rgba(212, 175, 55, 0.2);
+  padding-left: clamp(0.62rem, 1.2vw, 0.9rem);
+  font-family: var(--font-ui);
+  line-height: 1.05;
+}
+
+.app-nav__context span,
+.app-nav__context em {
+  color: var(--dim);
+  font-size: 0.62rem;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.app-nav__context span {
+  color: var(--gold);
+}
+
+.app-nav__context strong {
+  grid-column: 1 / -1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .app-nav__links {
@@ -493,17 +538,51 @@ h3 {
 }
 
 .metrics-strip {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   border-block: 1px solid var(--line);
+  overflow: hidden;
+  background:
+    linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.06), transparent),
+    rgba(255, 255, 255, 0.016);
 }
 
-.metrics-strip div {
+.metrics-strip::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: min(38rem, 78vw);
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.1);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 0 4rem rgba(83, 216, 232, 0.012),
+    0 0 6rem rgba(212, 175, 55, 0.05);
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.metrics-strip__cell {
+  position: relative;
   padding: 1.2rem;
   text-align: center;
 }
 
-.metrics-strip div + div {
+.metrics-strip__cell::after {
+  content: '';
+  position: absolute;
+  right: 1.1rem;
+  top: 1rem;
+  width: 1.1rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(83, 216, 232, 0.18);
+  border-radius: 50%;
+  box-shadow: 0 0 1.4rem rgba(83, 216, 232, 0.12);
+}
+
+.metrics-strip__cell + .metrics-strip__cell {
   border-left: 1px solid var(--line);
 }
 
@@ -553,6 +632,14 @@ h3 {
     box-shadow 0.45s var(--motion-spring);
 }
 
+.path-panel {
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+  min-height: 19rem;
+  padding: 1.35rem;
+}
+
 .path-panel::before,
 .chapter-preview::before,
 .symbol-panel::before,
@@ -599,6 +686,162 @@ h3 {
   font-weight: 700;
 }
 
+.path-panel__mark {
+  width: 2.35rem;
+  height: 2.35rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(83, 216, 232, 0.24);
+  border-radius: 50%;
+  background: rgba(3, 3, 7, 0.42);
+  box-shadow: 0 0 1.8rem rgba(83, 216, 232, 0.08);
+}
+
+.path-panel h3 {
+  max-width: 10ch;
+  margin-top: 1.1rem;
+}
+
+.path-panel__diagram {
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  width: min(35%, 8.5rem);
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.15);
+  border-radius: 50%;
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.path-panel__diagram::before,
+.path-panel__diagram::after,
+.path-panel__diagram span {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+}
+
+.path-panel__diagram::before {
+  inset: 18%;
+  border: 1px solid rgba(83, 216, 232, 0.16);
+}
+
+.path-panel__diagram::after {
+  left: 50%;
+  top: 50%;
+  width: 0.55rem;
+  aspect-ratio: 1;
+  background: var(--gold-soft);
+  box-shadow: 0 0 1.5rem rgba(212, 175, 55, 0.62);
+  transform: translate(-50%, -50%);
+}
+
+.path-panel__diagram span {
+  width: 0.46rem;
+  aspect-ratio: 1;
+  background: var(--cyan);
+  box-shadow: 0 0 1.2rem rgba(83, 216, 232, 0.38);
+}
+
+.path-panel--sequence .path-panel__diagram {
+  border-radius: var(--radius);
+  transform: rotate(-8deg);
+}
+
+.path-panel--sequence .path-panel__diagram::before {
+  inset: 50% 12% auto;
+  height: 1px;
+  border: 0;
+  border-radius: 0;
+  background: linear-gradient(90deg, var(--cyan), var(--gold), var(--rose));
+  transform: rotate(-27deg);
+}
+
+.path-panel--sequence .path-panel__diagram span:nth-child(1) {
+  left: 16%;
+  top: 64%;
+}
+
+.path-panel--sequence .path-panel__diagram span:nth-child(2) {
+  left: 46%;
+  top: 45%;
+  background: var(--gold);
+}
+
+.path-panel--sequence .path-panel__diagram span:nth-child(3) {
+  right: 15%;
+  top: 23%;
+  background: var(--rose);
+}
+
+.path-panel--constellation .path-panel__diagram {
+  box-shadow:
+    inset 0 0 0 1.2rem rgba(83, 216, 232, 0.02),
+    0 0 3rem rgba(212, 175, 55, 0.06);
+}
+
+.path-panel--constellation .path-panel__diagram span:nth-child(1) {
+  left: 20%;
+  top: 28%;
+}
+
+.path-panel--constellation .path-panel__diagram span:nth-child(2) {
+  right: 18%;
+  top: 34%;
+  background: var(--gold);
+}
+
+.path-panel--constellation .path-panel__diagram span:nth-child(3) {
+  left: 48%;
+  bottom: 16%;
+  background: var(--rose);
+}
+
+.path-panel--cycle .path-panel__diagram {
+  transform: rotateX(56deg) rotateZ(-14deg);
+}
+
+.path-panel--cycle .path-panel__diagram::before {
+  inset: 7%;
+  border-color: rgba(212, 175, 55, 0.28);
+}
+
+.path-panel--cycle .path-panel__diagram span:nth-child(1) {
+  left: 50%;
+  top: 1%;
+}
+
+.path-panel--cycle .path-panel__diagram span:nth-child(2) {
+  right: 3%;
+  top: 52%;
+  background: var(--gold);
+}
+
+.path-panel--cycle .path-panel__diagram span:nth-child(3) {
+  left: 8%;
+  bottom: 12%;
+  background: var(--rose);
+}
+
+.path-panel__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: auto;
+}
+
+.path-panel__tags span {
+  border: 1px solid rgba(212, 175, 55, 0.16);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.34);
+  color: rgba(244, 240, 232, 0.52);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 0.28rem 0.5rem;
+}
+
 .path-panel p,
 .chapter-preview p,
 .symbol-panel p,
@@ -612,6 +855,89 @@ h3 {
 
 .chapter-preview-grid {
   grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.home-chapter-orbit {
+  --home-orbit-radius: min(37vw, 14.6rem);
+  position: relative;
+  width: min(100%, 34rem);
+  aspect-ratio: 1;
+  margin: 0 auto clamp(2rem, 5vw, 3.8rem);
+  padding: 0;
+  border: 1px solid rgba(212, 175, 55, 0.16);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(212, 175, 55, 0.13), transparent 19%),
+    radial-gradient(circle at 50% 50%, rgba(83, 216, 232, 0.08), transparent 38%);
+  box-shadow:
+    inset 0 0 0 4.6rem rgba(255, 255, 255, 0.012),
+    0 0 5rem rgba(212, 175, 55, 0.045);
+  list-style: none;
+}
+
+.home-chapter-orbit::before,
+.home-chapter-orbit::after {
+  content: '';
+  position: absolute;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.home-chapter-orbit::before {
+  inset: 18%;
+  border-color: rgba(83, 216, 232, 0.16);
+  transform: rotateX(58deg);
+}
+
+.home-chapter-orbit::after {
+  inset: 42%;
+  background: radial-gradient(circle, rgba(212, 175, 55, 0.32), rgba(3, 3, 7, 0.18) 60%, transparent 68%);
+  box-shadow: 0 0 4rem rgba(212, 175, 55, 0.22);
+}
+
+.home-chapter-orbit__item {
+  --angle: calc((360deg / var(--node-count)) * var(--node-index) - 90deg);
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: rotate(var(--angle)) translateX(var(--home-orbit-radius)) rotate(calc(-1 * var(--angle)));
+  z-index: 2;
+}
+
+.home-chapter-orbit__item a {
+  width: 2.7rem;
+  height: 2.7rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(212, 175, 55, 0.22);
+  border-radius: 50%;
+  background: rgba(3, 3, 7, 0.78);
+  color: var(--muted);
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-decoration: none;
+  transform: translate(-50%, -50%);
+  transition:
+    background 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    color 0.45s var(--motion-spring),
+    transform 0.45s var(--motion-spring);
+}
+
+.home-chapter-orbit__item a:hover,
+.home-chapter-orbit__item a:focus-visible {
+  border-color: var(--line-strong);
+  color: var(--text);
+  transform: translate(-50%, -50%) scale(1.12);
+}
+
+.home-chapter-orbit__item--featured a {
+  border-color: rgba(212, 175, 55, 0.7);
+  background: radial-gradient(circle, var(--gold-soft), var(--gold) 72%);
+  color: #080704;
+  box-shadow: 0 0 2.2rem rgba(212, 175, 55, 0.32);
 }
 
 .chapter-preview span,
@@ -1660,16 +1986,30 @@ h3 {
   }
 
   .button:hover,
-  .chapter-card:hover {
+  .chapter-card:hover,
+  .path-panel:hover,
+  .chapter-preview:hover,
+  .symbol-panel:hover,
+  .about-principles article:hover {
     transform: none;
+  }
+
+  .home-chapter-orbit__item a:hover,
+  .home-chapter-orbit__item a:focus-visible {
+    transform: translate(-50%, -50%);
   }
 
   .button,
   .button::after,
+  .app-nav__link,
+  .chapter-jump__sequence a,
+  .path-panel,
+  .chapter-preview,
   .chapter-card,
   .chapter-panel,
   .chapter-stage__thesis-node,
-  .chapters-orbit__node {
+  .chapters-orbit__node,
+  .home-chapter-orbit__item a {
     transition: none;
   }
 }
@@ -1678,8 +2018,9 @@ h3 {
   .app-nav {
     align-items: flex-start;
     flex-direction: column;
+    gap: 0.6rem;
     border-radius: var(--radius-lg);
-    padding: 0.75rem;
+    padding: 0.62rem;
   }
 
   .app-nav__right {
@@ -1689,8 +2030,27 @@ h3 {
     width: 100%;
   }
 
+  .app-nav__identity {
+    width: 100%;
+  }
+
+  .app-nav__context {
+    flex: 1;
+    max-width: none;
+  }
+
+  .app-nav__context strong {
+    white-space: normal;
+  }
+
   .app-nav__links {
+    gap: 0.16rem;
     justify-content: flex-start;
+  }
+
+  .app-nav__link {
+    font-size: 0.8rem;
+    padding: 0.36rem 0.56rem;
   }
 
   .chapter-jump {
@@ -1701,8 +2061,10 @@ h3 {
 
   .chapter-jump select {
     flex: 1;
+    min-height: 2rem;
     min-width: 0;
     max-width: none;
+    padding-block: 0.28rem;
     width: 100%;
   }
 
@@ -1714,6 +2076,11 @@ h3 {
   .timeline-layout,
   .chapter-knowledge {
     grid-template-columns: 1fr;
+  }
+
+  .home-hero {
+    min-height: auto;
+    padding-top: 14rem;
   }
 
   .page-header--visual {
@@ -1800,7 +2167,7 @@ h3 {
     grid-template-columns: 1fr;
   }
 
-  .metrics-strip div + div {
+  .metrics-strip__cell + .metrics-strip__cell {
     border-left: 0;
     border-top: 1px solid var(--line);
   }
@@ -1840,5 +2207,32 @@ h3 {
 
   .chapter-next {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 420px) {
+  .app-nav__context {
+    grid-template-columns: 1fr;
+    gap: 0.05rem;
+  }
+
+  .app-nav__context em {
+    display: none;
+  }
+
+  .app-nav__context span {
+    font-size: 0.56rem;
+  }
+
+  .app-nav__context strong {
+    font-size: 0.72rem;
+  }
+
+  .app-nav__links {
+    row-gap: 0.08rem;
+  }
+
+  .home-hero {
+    padding-top: 13.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- add a compact current-route/chapter context readout to the global shell
- make Home more visual-first with instrumented metrics, path micro-diagrams, canonical-label chips, and a 14-node chapter orbit
- gate Home and chapter scenes so reduced-motion users get static/fallback views without requesting Three.js scene chunks
- harden app smoke coverage for Home visual details, route-context labels, reduced-motion network behavior, mobile nav overlap, and preview link names
- pass Vite's Pages base explicitly during the Pages artifact build

## Verification
- rg -n "^<<<<<<<|^=======$|^>>>>>>>" .
- git diff --check
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run test:app
- npm run test:e2e:app
- npm run test:a11y:app
- npm test
- npm run build:pages && npm run test:pages:artifact
- in-app browser visual inspection at http://127.0.0.1:4190/ for desktop and mobile Home geometry

Known residual: Vite still warns that the Three.js chunk is larger than 500 kB; this was pre-existing and remains the next performance-hardening target.