### PR TITLE
feat: polish Chapter 1 reference scene

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -190,7 +190,7 @@ async function runAccessibilitySmoke() {
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -273,8 +273,11 @@ async function smokeLegacyRedirect(page, failures) {
 
 async function smokeChapterJump(page, failures) {
   await gotoAppRoute(page, '/chapters');
+  await page.locator('#chapter-jump-select').waitFor({ state: 'visible', timeout: 10_000 });
   await page.selectOption('#chapter-jump-select', 'ch3');
   await page.waitForURL(/\/journey\/chapter\/ch3$/, { timeout: 10_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.waitForFunction(() => document.querySelector('#chapter-jump-select')?.value === 'ch3', null, { timeout: 10_000 }).catch(() => {});
 
   const selectValue = await page.locator('#chapter-jump-select').inputValue();
   const previousVisible = await page.locator('.chapter-jump__sequence a[aria-label^="Previous chapter"]').isVisible();
@@ -290,11 +293,26 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterOneReferenceCount = await page.locator('.chapter-stage__reference-node').count();
   if (chapterOneReferenceCount !== 3) failures.push(`chapter 1 reference node count mismatch: ${chapterOneReferenceCount}`);
 
+  const pauseAnimation = page.getByRole('button', { name: /Pause animation/ });
+  await pauseAnimation.click();
+  await page.waitForTimeout(5_400);
+  const paused = await page.getByRole('button', { name: /Resume animation/ }).getAttribute('aria-pressed');
+  const pausedAnnotationCount = await page.locator('.ch1-a.vis').count();
+  if (paused !== 'true') failures.push(`chapter animation pause control did not stay pressed: ${paused}`);
+  if (pausedAnnotationCount !== 0) failures.push(`chapter animation pause allowed timed annotations to reveal: ${pausedAnnotationCount}`);
+  await page.getByRole('button', { name: /Resume animation/ }).click();
+
   const rootsReference = page.locator('.chapter-stage__reference-node[data-panel-id="roots"]');
   await rootsReference.click();
-  await page.waitForTimeout(200);
+  await page.waitForTimeout(5_400);
   const rootsReferencePressed = await rootsReference.getAttribute('aria-pressed');
+  const rootsAnnotationState = await page.evaluate(() => ({
+    egoVisible: document.querySelector('.ch1-a--ego')?.classList.contains('vis') || false,
+    rootsPanelVisible: document.querySelector('.ch1-a--unconscious')?.classList.contains('panel-vis') || false,
+  }));
   if (rootsReferencePressed !== 'true') failures.push(`chapter 1 reference node did not become active: ${rootsReferencePressed}`);
+  if (rootsAnnotationState.egoVisible) failures.push('chapter 1 timed ego annotation stayed visible after selecting roots');
+  if (!rootsAnnotationState.rootsPanelVisible) failures.push('chapter 1 roots annotation did not follow selected panel');
 
   const wholeness = page.getByRole('button', { name: /03\s+Wholeness/ });
   await wholeness.click();
@@ -306,13 +324,6 @@ async function smokeChapterSceneControls(page, failures) {
   if (pressed !== 'true') failures.push(`chapter scene control did not become active: ${pressed}`);
   if (scrollY > 10) failures.push(`chapter scene control unexpectedly scrolled page: ${scrollY}`);
   if (!sceneDescription?.includes('The Self holds the field')) failures.push(`chapter 1 scene description did not follow active panel: ${sceneDescription}`);
-
-  const pauseAnimation = page.getByRole('button', { name: /Pause animation/ });
-  await pauseAnimation.click();
-  await page.waitForTimeout(120);
-  const paused = await page.getByRole('button', { name: /Resume animation/ }).getAttribute('aria-pressed');
-  if (paused !== 'true') failures.push(`chapter animation pause control did not stay pressed: ${paused}`);
-  await page.getByRole('button', { name: /Resume animation/ }).click();
 
   await gotoAppRoute(page, '/journey/chapter/ch2');
   const projection = page.getByRole('button', { name: /02\s+Projection/ });

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -246,9 +246,15 @@ async function smokeReducedMotion(browser, failures) {
   await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
   const fallbackVisible = await page.locator('.scene-host__fallback').isVisible();
   const reducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterReferenceVisible = await page.locator('.chapter-stage__reference-map').isVisible();
+  const chapterPauseControlCount = await page.locator('.scene-host__pause').count();
+  const fallbackText = await page.locator('.scene-host__fallback').textContent();
 
   if (!fallbackVisible) failures.push('reduced-motion fallback is not visible for chapter scene');
   if (reducedMotionAttribute !== 'true') failures.push('chapter did not record reduced-motion state');
+  if (!chapterReferenceVisible) failures.push('reduced-motion chapter reference map is not visible');
+  if (chapterPauseControlCount !== 0) failures.push(`reduced-motion chapter rendered pause controls: ${chapterPauseControlCount}`);
+  if (!fallbackText?.includes('small surface light')) failures.push('reduced-motion chapter fallback lost Chapter 1 teaching summary');
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -281,14 +287,32 @@ async function smokeChapterJump(page, failures) {
 
 async function smokeChapterSceneControls(page, failures) {
   await gotoAppRoute(page, '/journey/chapter/ch1');
+  const chapterOneReferenceCount = await page.locator('.chapter-stage__reference-node').count();
+  if (chapterOneReferenceCount !== 3) failures.push(`chapter 1 reference node count mismatch: ${chapterOneReferenceCount}`);
+
+  const rootsReference = page.locator('.chapter-stage__reference-node[data-panel-id="roots"]');
+  await rootsReference.click();
+  await page.waitForTimeout(200);
+  const rootsReferencePressed = await rootsReference.getAttribute('aria-pressed');
+  if (rootsReferencePressed !== 'true') failures.push(`chapter 1 reference node did not become active: ${rootsReferencePressed}`);
+
   const wholeness = page.getByRole('button', { name: /03\s+Wholeness/ });
   await wholeness.click();
   await page.waitForTimeout(250);
 
   const pressed = await wholeness.getAttribute('aria-pressed');
   const scrollY = await page.evaluate(() => window.scrollY);
+  const sceneDescription = await page.locator('#scene-host-description-ch1').textContent();
   if (pressed !== 'true') failures.push(`chapter scene control did not become active: ${pressed}`);
   if (scrollY > 10) failures.push(`chapter scene control unexpectedly scrolled page: ${scrollY}`);
+  if (!sceneDescription?.includes('The Self holds the field')) failures.push(`chapter 1 scene description did not follow active panel: ${sceneDescription}`);
+
+  const pauseAnimation = page.getByRole('button', { name: /Pause animation/ });
+  await pauseAnimation.click();
+  await page.waitForTimeout(120);
+  const paused = await page.getByRole('button', { name: /Resume animation/ }).getAttribute('aria-pressed');
+  if (paused !== 'true') failures.push(`chapter animation pause control did not stay pressed: ${paused}`);
+  await page.getByRole('button', { name: /Resume animation/ }).click();
 
   await gotoAppRoute(page, '/journey/chapter/ch2');
   const projection = page.getByRole('button', { name: /02\s+Projection/ });
@@ -423,7 +447,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -443,6 +467,21 @@ async function smokeMobile(page, failures) {
     if (navBottom > heroCopyBox.y - 1) {
       failures.push(`mobile nav overlaps home hero copy at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(navBottom)}, copy top ${Math.round(heroCopyBox.y)}`);
     }
+
+    await gotoAppRoute(page, '/journey/chapter/ch1');
+    const chapterNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const referenceCount = await page.locator('.chapter-stage__reference-node').count();
+    if (!chapterNavBox || !chapterHeadingBox) {
+      failures.push(`mobile chapter 1 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterNavBottom = chapterNavBox.y + chapterNavBox.height;
+    if (chapterNavBottom > chapterHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 1 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterNavBottom)}, heading top ${Math.round(chapterHeadingBox.y)}`);
+    }
+    if (referenceCount !== 3) failures.push(`mobile chapter 1 reference node count mismatch at ${viewport.width}x${viewport.height}: ${referenceCount}`);
   }
 }
 

--- a/src/app/components/SceneHost.tsx
+++ b/src/app/components/SceneHost.tsx
@@ -5,6 +5,8 @@ import type { ChapterExperience, ChapterId, ChapterRecord } from '../types';
 
 interface SceneInstance {
   mount?: () => Promise<void> | void;
+  start?: () => void;
+  stop?: () => void;
   setPanelState?: (state: { activePanelId: string; progress: number }) => void;
   setReducedMotion?: (enabled: boolean) => void;
   dispose?: () => void;
@@ -27,6 +29,20 @@ export default function SceneHost({
   const instanceRef = useRef<SceneInstance | null>(null);
   const [state, setState] = useState<'loading' | 'ready' | 'fallback'>('loading');
   const [message, setMessage] = useState('');
+  const [animationPaused, setAnimationPaused] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem('aion:scene-animation-paused') === 'true';
+  });
+  const activePanel = experience.panels.find((panel) => panel.id === activePanelId) || experience.panels[0];
+  const descriptionId = `scene-host-description-${chapter.id}`;
+  const activeDescription = activePanel
+    ? `${experience.visualTheme}. ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`
+    : experience.fallbackSummary;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('aion:scene-animation-paused', String(animationPaused));
+  }, [animationPaused]);
 
   useEffect(() => {
     let disposed = false;
@@ -85,9 +101,37 @@ export default function SceneHost({
     });
   }, [activePanelId, experience.panels, panelProgress, reducedMotion, state]);
 
+  useEffect(() => {
+    if (state !== 'ready' || reducedMotion) return;
+    if (animationPaused) {
+      instanceRef.current?.stop?.();
+    } else {
+      instanceRef.current?.start?.();
+    }
+  }, [animationPaused, reducedMotion, state]);
+
   return (
-    <section className="scene-host" aria-label={`${chapter.title} visualization`}>
-      <div ref={mountRef} className="scene-host__mount" data-state={state} />
+    <section
+      className="scene-host"
+      aria-label={`${chapter.title} visualization`}
+      aria-describedby={descriptionId}
+      role="figure"
+    >
+      <p id={descriptionId} className="sr-only" aria-live="polite">{activeDescription}</p>
+      <div ref={mountRef} className="scene-host__mount" data-state={state} aria-hidden="true" />
+      {state === 'ready' && !reducedMotion && (
+        <div className="scene-host__controls">
+          <button
+            className="scene-host__pause"
+            type="button"
+            onClick={() => setAnimationPaused((current) => !current)}
+            aria-pressed={animationPaused}
+          >
+            <span className="scene-host__pause-icon" aria-hidden="true" />
+            <span>{animationPaused ? 'Resume animation' : 'Pause animation'}</span>
+          </button>
+        </div>
+      )}
       {state === 'loading' && (
         <div className="scene-host__status" role="status">
           <span>Aion</span>

--- a/src/app/components/SceneHost.tsx
+++ b/src/app/components/SceneHost.tsx
@@ -7,6 +7,7 @@ interface SceneInstance {
   mount?: () => Promise<void> | void;
   start?: () => void;
   stop?: () => void;
+  setPaused?: (paused: boolean) => void;
   setPanelState?: (state: { activePanelId: string; progress: number }) => void;
   setReducedMotion?: (enabled: boolean) => void;
   dispose?: () => void;
@@ -103,6 +104,7 @@ export default function SceneHost({
 
   useEffect(() => {
     if (state !== 'ready' || reducedMotion) return;
+    instanceRef.current?.setPaused?.(animationPaused);
     if (animationPaused) {
       instanceRef.current?.stop?.();
     } else {

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -53,6 +53,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const adjacent = getAdjacentChapters(chapter.id);
   const activePanelIndex = Math.max(0, experience.panels.findIndex((panel) => panel.id === activePanelId));
   const panelProgress = experience.panels.length > 1 ? activePanelIndex / (experience.panels.length - 1) : 0;
+  const activePanel = experience.panels[activePanelIndex] || experience.panels[0];
 
   useEffect(() => {
     setActivePanelId(experience.panels[0]?.id || '');
@@ -106,12 +107,35 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
                 type="button"
                 onClick={() => setActivePanelId(panel.id)}
                 aria-pressed={panel.id === activePanelId}
+                aria-controls={`${chapter.id}-${panel.id}`}
               >
                 <span>{String(index + 1).padStart(2, '0')}</span>
                 {panel.kicker}
               </button>
             ))}
           </div>
+          <div className="chapter-stage__reference-map" aria-label={`${chapter.title} visual reference`} role="group">
+            {experience.panels.map((panel, index) => (
+              <button
+                key={panel.id}
+                className={panel.id === activePanelId ? 'chapter-stage__reference-node chapter-stage__reference-node--active' : 'chapter-stage__reference-node'}
+                type="button"
+                onClick={() => setActivePanelId(panel.id)}
+                aria-pressed={panel.id === activePanelId}
+                aria-controls={`${chapter.id}-${panel.id}`}
+                aria-label={`Show ${panel.title}: ${panel.insight}`}
+                data-panel-id={panel.id}
+              >
+                <span className="chapter-stage__reference-mark" aria-hidden="true" />
+                <span className="chapter-stage__reference-label">{String(index + 1).padStart(2, '0')} {panel.kicker}</span>
+              </button>
+            ))}
+          </div>
+          {activePanel && (
+            <p className="sr-only" role="status" aria-live="polite">
+              Active scene state: {activePanel.title}. {activePanel.insight}
+            </p>
+          )}
         </div>
       </section>
 
@@ -123,6 +147,8 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
             className={panel.id === activePanelId ? 'chapter-panel chapter-panel--active' : 'chapter-panel'}
             data-chapter-panel={chapter.id}
             data-panel-id={panel.id}
+            role="region"
+            aria-labelledby={`${chapter.id}-${panel.id}-title`}
           >
             <div className="chapter-panel__symbol" aria-hidden="true">
               <span className="chapter-panel__ring chapter-panel__ring--outer" />
@@ -131,11 +157,13 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="chapter-panel__axis chapter-panel__axis--horizontal" />
               <span className="chapter-panel__spark chapter-panel__spark--one" />
               <span className="chapter-panel__spark chapter-panel__spark--two" />
+              <span className="chapter-panel__depth chapter-panel__depth--one" />
+              <span className="chapter-panel__depth chapter-panel__depth--two" />
             </div>
             <div className="chapter-panel__copy">
               <span className="chapter-panel__count">{String(index + 1).padStart(2, '0')}</span>
               <p className="eyebrow">{panel.kicker}</p>
-              <h2>{panel.title}</h2>
+              <h2 id={`${chapter.id}-${panel.id}-title`}>{panel.title}</h2>
               <p>{panel.body}</p>
               <strong>{panel.insight}</strong>
             </div>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1600,6 +1600,114 @@ h3 {
   transform: translateY(-1px);
 }
 
+.chapter-stage__reference-map {
+  width: min(27rem, 100%);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin-top: 0.8rem;
+}
+
+.chapter-stage__reference-node {
+  position: relative;
+  min-height: 4.35rem;
+  overflow: hidden;
+  border: 1px solid rgba(244, 240, 232, 0.1);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 50% 28%, rgba(244, 240, 232, 0.08), transparent 2.5rem),
+    linear-gradient(180deg, rgba(3, 3, 7, 0.62), rgba(3, 3, 7, 0.34));
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.58rem;
+  text-align: left;
+  transition:
+    border-color 0.45s var(--motion-spring),
+    color 0.45s var(--motion-spring),
+    transform 0.45s var(--motion-spring);
+}
+
+.chapter-stage__reference-node:hover,
+.chapter-stage__reference-node--active {
+  border-color: rgba(212, 175, 55, 0.36);
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+.chapter-stage__reference-mark {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.chapter-stage__reference-mark::before,
+.chapter-stage__reference-mark::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.chapter-stage__reference-mark::before {
+  top: 0.8rem;
+  width: 0.46rem;
+  height: 0.46rem;
+  border-radius: 50%;
+  background: #f4f0e8;
+  box-shadow: 0 0 1.5rem rgba(244, 240, 232, 0.72);
+}
+
+.chapter-stage__reference-mark::after {
+  top: 1.7rem;
+  width: 1px;
+  height: 1.4rem;
+  background: linear-gradient(180deg, rgba(244, 240, 232, 0.34), rgba(212, 175, 55, 0.08), transparent);
+}
+
+.chapter-stage__reference-label {
+  position: relative;
+  z-index: 1;
+  display: block;
+  margin-top: 2.45rem;
+  font-size: 0.66rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.chapter-stage__reference-node[data-panel-id="roots"] .chapter-stage__reference-mark::before {
+  width: 2.4rem;
+  height: 1.8rem;
+  border-radius: 0;
+  background:
+    linear-gradient(120deg, transparent 44%, rgba(204, 109, 134, 0.62) 45%, rgba(204, 109, 134, 0.62) 48%, transparent 49%),
+    linear-gradient(240deg, transparent 44%, rgba(83, 216, 232, 0.58) 45%, rgba(83, 216, 232, 0.58) 48%, transparent 49%);
+  box-shadow: 0 0 1.2rem rgba(83, 216, 232, 0.2);
+}
+
+.chapter-stage__reference-node[data-panel-id="roots"] .chapter-stage__reference-mark::after {
+  height: 2.3rem;
+  background:
+    linear-gradient(180deg, rgba(244, 240, 232, 0.22), rgba(83, 216, 232, 0.1) 46%, transparent),
+    linear-gradient(90deg, rgba(204, 109, 134, 0.35), transparent 42%, transparent 58%, rgba(83, 216, 232, 0.35));
+}
+
+.chapter-stage__reference-node[data-panel-id="self-depth"] .chapter-stage__reference-mark::before {
+  top: 2.15rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  background: radial-gradient(circle, rgba(255, 226, 113, 0.98), rgba(212, 175, 55, 0.34) 46%, transparent 72%);
+  box-shadow:
+    0 0 1.8rem rgba(212, 175, 55, 0.62),
+    0 0 3.8rem rgba(83, 216, 232, 0.15);
+}
+
+.chapter-stage__reference-node[data-panel-id="self-depth"] .chapter-stage__reference-mark::after {
+  top: 0.8rem;
+  height: 2.1rem;
+  background: linear-gradient(180deg, rgba(244, 240, 232, 0.22), rgba(212, 175, 55, 0.44), transparent);
+}
+
 .scene-host__status,
 .scene-host__fallback {
   position: absolute;
@@ -1619,6 +1727,80 @@ h3 {
 .scene-host__status span {
   display: block;
   color: var(--gold);
+}
+
+.scene-host__controls {
+  position: absolute;
+  z-index: 12;
+  right: clamp(1rem, 3vw, 2rem);
+  bottom: clamp(1rem, 3vh, 2rem);
+}
+
+.scene-host__pause {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2.6rem;
+  border: 1px solid rgba(244, 240, 232, 0.16);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.7);
+  color: var(--text);
+  cursor: pointer;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.03em;
+  backdrop-filter: blur(14px);
+  transition:
+    border-color 0.35s var(--motion-spring),
+    transform 0.35s var(--motion-spring);
+}
+
+.scene-host__pause:hover,
+.scene-host__pause[aria-pressed="true"] {
+  border-color: rgba(212, 175, 55, 0.42);
+  transform: translateY(-1px);
+}
+
+.scene-host__pause-icon {
+  position: relative;
+  width: 0.78rem;
+  height: 0.78rem;
+  border: 1px solid rgba(212, 175, 55, 0.56);
+  border-radius: 50%;
+}
+
+.scene-host__pause-icon::before,
+.scene-host__pause-icon::after {
+  content: '';
+  position: absolute;
+  top: 0.2rem;
+  bottom: 0.2rem;
+  width: 1px;
+  background: var(--gold-soft);
+}
+
+.scene-host__pause-icon::before {
+  left: 0.27rem;
+}
+
+.scene-host__pause-icon::after {
+  right: 0.27rem;
+}
+
+.scene-host__pause[aria-pressed="true"] .scene-host__pause-icon::before {
+  top: 0.22rem;
+  bottom: auto;
+  left: 0.3rem;
+  width: 0;
+  height: 0;
+  border-top: 0.17rem solid transparent;
+  border-bottom: 0.17rem solid transparent;
+  border-left: 0.27rem solid var(--gold-soft);
+  background: transparent;
+}
+
+.scene-host__pause[aria-pressed="true"] .scene-host__pause-icon::after {
+  display: none;
 }
 
 .chapter-panels {
@@ -1699,7 +1881,8 @@ h3 {
 
 .chapter-panel__ring,
 .chapter-panel__axis,
-.chapter-panel__spark {
+.chapter-panel__spark,
+.chapter-panel__depth {
   position: absolute;
   pointer-events: none;
 }
@@ -1758,6 +1941,29 @@ h3 {
   top: 30%;
   background: var(--rose);
   box-shadow: 0 0 1.2rem rgba(204, 109, 134, 0.56);
+}
+
+.chapter-panel__depth {
+  left: 50%;
+  width: 1px;
+  height: 36%;
+  background: linear-gradient(180deg, rgba(244, 240, 232, 0.16), rgba(212, 175, 55, 0.24), transparent);
+  transform: translateX(-50%);
+  opacity: 0.7;
+}
+
+.chapter-panel__depth--one {
+  top: 50%;
+}
+
+.chapter-panel__depth--two {
+  top: 57%;
+  width: 34%;
+  height: 34%;
+  border: 1px solid rgba(212, 175, 55, 0.08);
+  border-radius: 50%;
+  background: transparent;
+  box-shadow: inset 0 0 2.4rem rgba(212, 175, 55, 0.05);
 }
 
 .chapter-experience[data-motion-grammar="opposition"] .chapter-panel__symbol {
@@ -1848,6 +2054,117 @@ h3 {
   top: 50%;
   background: var(--gold-soft);
   box-shadow: 0 0 1.35rem rgba(212, 175, 55, 0.65);
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 50% 24%, rgba(244, 240, 232, 0.12), transparent 3.2rem),
+    radial-gradient(circle at 50% 78%, rgba(212, 175, 55, 0.16), transparent 5rem),
+    radial-gradient(circle at 32% 58%, rgba(204, 109, 134, 0.08), transparent 4.2rem),
+    radial-gradient(circle at 68% 58%, rgba(83, 216, 232, 0.08), transparent 4.2rem),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.044), rgba(255, 255, 255, 0.012));
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__symbol::before {
+  inset: 12% 18%;
+  border-color: rgba(212, 175, 55, 0.16);
+  box-shadow:
+    inset 0 -4.5rem 5rem rgba(212, 175, 55, 0.045),
+    inset 0 3rem 4rem rgba(244, 240, 232, 0.025);
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__symbol::after {
+  top: 24%;
+  background: #f4f0e8;
+  box-shadow:
+    0 0 1.6rem rgba(244, 240, 232, 0.72),
+    0 7.8rem 2.4rem rgba(212, 175, 55, 0.58);
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__ring--outer {
+  width: 74%;
+  border-color: rgba(212, 175, 55, 0.16);
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__ring--inner {
+  width: 43%;
+  border-color: rgba(244, 240, 232, 0.12);
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__axis--vertical {
+  background: linear-gradient(180deg, rgba(244, 240, 232, 0.18), rgba(212, 175, 55, 0.3), transparent);
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__axis--horizontal {
+  top: 58%;
+  width: 62%;
+  background: linear-gradient(90deg, transparent, rgba(83, 216, 232, 0.2), rgba(204, 109, 134, 0.2), transparent);
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__spark--one {
+  left: 31%;
+  top: 61%;
+  background: var(--rose);
+  box-shadow: 0 0 1.25rem rgba(204, 109, 134, 0.62);
+}
+
+.chapter-experience[data-motion-grammar="cyclical-return"] .chapter-panel__spark--two {
+  right: 31%;
+  top: 61%;
+  background: var(--cyan);
+  box-shadow: 0 0 1.25rem rgba(83, 216, 232, 0.62);
+}
+
+.chapter-experience[data-chapter-id="ch1"] .chapter-panel[data-panel-id="ego-light"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 50% 34%, rgba(244, 240, 232, 0.18), transparent 3.4rem),
+    radial-gradient(circle at 50% 58%, rgba(83, 216, 232, 0.08), transparent 8rem),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.046), rgba(255, 255, 255, 0.012));
+}
+
+.chapter-experience[data-chapter-id="ch1"] .chapter-panel[data-panel-id="ego-light"] .chapter-panel__symbol::after {
+  top: 32%;
+  width: 0.82rem;
+  height: 0.82rem;
+  background: #f4f0e8;
+  box-shadow:
+    0 0 1.9rem rgba(244, 240, 232, 0.86),
+    0 0 5.5rem rgba(83, 216, 232, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch1"] .chapter-panel[data-panel-id="roots"] .chapter-panel__depth--one {
+  height: 52%;
+  background:
+    linear-gradient(120deg, transparent 45%, rgba(204, 109, 134, 0.46) 46%, rgba(204, 109, 134, 0.46) 49%, transparent 50%),
+    linear-gradient(240deg, transparent 45%, rgba(83, 216, 232, 0.48) 46%, rgba(83, 216, 232, 0.48) 49%, transparent 50%);
+}
+
+.chapter-experience[data-chapter-id="ch1"] .chapter-panel[data-panel-id="roots"] .chapter-panel__depth--two {
+  width: 48%;
+  border-color: rgba(83, 216, 232, 0.16);
+  box-shadow:
+    inset -2rem 0 3rem rgba(204, 109, 134, 0.06),
+    inset 2rem 0 3rem rgba(83, 216, 232, 0.06);
+}
+
+.chapter-experience[data-chapter-id="ch1"] .chapter-panel[data-panel-id="self-depth"] .chapter-panel__symbol::after {
+  top: 73%;
+  width: 1.18rem;
+  height: 1.18rem;
+  background: radial-gradient(circle, #ffe9a0, rgba(212, 175, 55, 0.42) 48%, transparent 74%);
+  box-shadow:
+    0 0 2.2rem rgba(212, 175, 55, 0.78),
+    0 -7.4rem 1.4rem rgba(244, 240, 232, 0.34);
+}
+
+.chapter-experience[data-chapter-id="ch1"] .chapter-panel[data-panel-id="self-depth"] .chapter-panel__depth--two {
+  top: 58%;
+  width: 54%;
+  height: 42%;
+  border-color: rgba(212, 175, 55, 0.2);
+  box-shadow:
+    inset 0 0 3.8rem rgba(212, 175, 55, 0.09),
+    0 0 4rem rgba(212, 175, 55, 0.08);
 }
 
 .chapter-panel__copy {
@@ -1986,13 +2303,15 @@ h3 {
   }
 
   .button:hover,
-  .chapter-card:hover,
-  .path-panel:hover,
-  .chapter-preview:hover,
-  .symbol-panel:hover,
-  .about-principles article:hover {
-    transform: none;
-  }
+	  .chapter-card:hover,
+	  .path-panel:hover,
+	  .chapter-preview:hover,
+	  .chapter-stage__reference-node:hover,
+	  .scene-host__pause:hover,
+	  .symbol-panel:hover,
+	  .about-principles article:hover {
+	    transform: none;
+	  }
 
   .home-chapter-orbit__item a:hover,
   .home-chapter-orbit__item a:focus-visible {
@@ -2005,14 +2324,16 @@ h3 {
   .chapter-jump__sequence a,
   .path-panel,
   .chapter-preview,
-  .chapter-card,
-  .chapter-panel,
-  .chapter-stage__thesis-node,
-  .chapters-orbit__node,
-  .home-chapter-orbit__item a {
-    transition: none;
-  }
-}
+	  .chapter-card,
+	  .chapter-panel,
+	  .chapter-stage__reference-node,
+	  .chapter-stage__thesis-node,
+	  .chapters-orbit__node,
+	  .home-chapter-orbit__item a,
+	  .scene-host__pause {
+	    transition: none;
+	  }
+	}
 
 @media (max-width: 860px) {
   .app-nav {
@@ -2172,12 +2493,64 @@ h3 {
     border-top: 1px solid var(--line);
   }
 
-  .chapter-stage__intro {
-    margin-inline: auto;
-  }
+	  .chapter-stage__intro {
+	    margin-inline: auto;
+	  }
 
-  .chapter-stage__scrim {
-    background:
+	  .chapter-stage__reference-map {
+	    grid-template-columns: 1fr;
+	    width: min(18rem, 100%);
+	  }
+
+	  .chapter-stage__reference-node {
+	    min-height: 3.1rem;
+	    padding-block: 0.45rem;
+	  }
+
+	  .chapter-stage__reference-label {
+	    margin-top: 0;
+	    margin-left: 3.15rem;
+	  }
+
+	  .chapter-stage__reference-mark::before {
+	    left: 1.35rem;
+	    top: 50%;
+	    transform: translateY(-50%);
+	  }
+
+	  .chapter-stage__reference-mark::after {
+	    left: 2.35rem;
+	    top: 50%;
+	    height: 1px;
+	    width: 1.25rem;
+	    transform: translateY(-50%);
+	    background: linear-gradient(90deg, rgba(244, 240, 232, 0.3), rgba(212, 175, 55, 0.1), transparent);
+	  }
+
+	  .chapter-stage__reference-node[data-panel-id="self-depth"] .chapter-stage__reference-mark::before {
+	    top: 50%;
+	  }
+
+	  .chapter-stage__reference-node[data-panel-id="self-depth"] .chapter-stage__reference-mark::after {
+	    top: 50%;
+	    height: 1px;
+	    width: 1.45rem;
+	  }
+
+	  .scene-host__controls {
+	    right: 0.85rem;
+	    top: clamp(11rem, 22vh, 12.25rem);
+	    bottom: auto;
+	  }
+
+	  .scene-host__pause {
+	    min-height: 2.35rem;
+	    padding: 0.38rem 0.66rem;
+	    font-size: 0.72rem;
+	  }
+
+	  .chapter-stage__scrim {
+	    background:
       linear-gradient(180deg, rgba(3, 3, 7, 0.82), rgba(3, 3, 7, 0.36) 48%, rgba(3, 3, 7, 0.78)),
       linear-gradient(90deg, rgba(3, 3, 7, 0.9), rgba(3, 3, 7, 0.48) 64%, rgba(3, 3, 7, 0.34));
   }

--- a/src/app/visualization/chapterScenes.ts
+++ b/src/app/visualization/chapterScenes.ts
@@ -6,12 +6,12 @@ export const CHAPTER_SCENES: Record<ChapterId, ChapterExperience> = {
     visualTheme: 'Ego/Self depth field',
     sceneModule: '../visualizations/chapters/ch1/ThreeEgoViz.js',
     motionGrammar: 'cyclical-return',
-    fallbackSummary: 'A still diagram places the ego above the deeper Self, with somatic and psychic roots held in a dark field.',
-    checkpoints: ['Locate the ego as a small light.', 'Name what exceeds ego control.', 'Connect the Self to the whole sequence.'],
+    fallbackSummary: 'A still depth diagram places the ego as a small surface light, splits its somatic and psychic roots, and sets the deeper Self as the whole field.',
+    checkpoints: ['Locate the ego as a small surface light.', 'Distinguish the somatic root from the psychic root.', 'Explain why the Self is larger than the conscious I.'],
     panels: [
-      { id: 'ego-light', kicker: 'Orientation', title: 'A point of consciousness', body: 'Begin with the ego as the bright center of immediate identity.', insight: 'The ego is necessary, but not total.' },
-      { id: 'roots', kicker: 'Depth', title: 'Two roots feed the I', body: 'Somatic and psychic roots pull the ego into a wider life-field.', insight: 'Consciousness rests on what it cannot fully command.' },
-      { id: 'self-depth', kicker: 'Wholeness', title: 'The Self holds the field', body: 'The final image subordinates ego to a larger ordering center.', insight: 'The journey starts by scaling the I correctly.' },
+      { id: 'ego-light', kicker: 'Orientation', title: 'A point of consciousness', body: 'Begin with the ego as a bright, local center of identity and attention.', insight: 'The ego is necessary, but not total.' },
+      { id: 'roots', kicker: 'Depth', title: 'Two roots feed the I', body: 'Body, instinct, memory, dream, and intuition pull the ego into a deeper life-field.', insight: 'Consciousness rests on what it cannot fully command.' },
+      { id: 'self-depth', kicker: 'Wholeness', title: 'The Self holds the field', body: 'The final view scales the ego against a larger ordering center below it.', insight: 'The journey starts by scaling the I correctly.' },
     ],
   },
   ch2: {

--- a/src/visualizations/chapters/ch1/ThreeEgoViz.js
+++ b/src/visualizations/chapters/ch1/ThreeEgoViz.js
@@ -49,15 +49,32 @@ export default class ThreeEgoViz extends BaseViz {
         this.egoFocus = 1;
         this.rootFocus = 0;
         this.selfFocus = 0;
+        this.guidedAnnotations = true;
+        this.annotationPaused = false;
     }
 
     setPanelState(state = {}) {
+        const previousPanelId = this.panelState?.activePanelId;
         this.panelState = Object.assign(this.panelState || {}, state);
+        const nextPanelId = this.panelState?.activePanelId;
+        if (this._annotationOverlay && previousPanelId && nextPanelId && previousPanelId !== nextPanelId) {
+            this._usePanelAnnotationMode();
+        }
         this._syncPanelAnnotations();
     }
 
     setReducedMotion(enabled) {
         this.reducedMotion = Boolean(enabled);
+    }
+
+    setPaused(paused) {
+        this.annotationPaused = Boolean(paused);
+        if (this.annotationPaused) {
+            this._clearAnnotationTimers();
+        } else if (this.guidedAnnotations) {
+            this._scheduleAnnotations();
+        }
+        this._syncPanelAnnotations();
     }
 
     async init() {
@@ -591,9 +608,7 @@ export default class ThreeEgoViz extends BaseViz {
 
         (this.container || document.body).appendChild(ov);
 
-        /* ── Phased reveal schedule ── */
-        this._annTimers = [];
-        const phases = [
+        this._annPhases = [
             { sel: '[data-phase="1"]', delay: 2000 },
             { sel: '[data-phase="2"]', delay: 5000 },
             { sel: '[data-phase="3"]', delay: 10000 },
@@ -601,14 +616,36 @@ export default class ThreeEgoViz extends BaseViz {
             { sel: '[data-phase="4b"]', delay: 16000 },
             { sel: '[data-phase="5"]', delay: 21000 },
         ];
-        for (const p of phases) {
-            const el = ov.querySelector(p.sel);
+        this._scheduleAnnotations();
+        this._syncPanelAnnotations();
+    }
+
+    _scheduleAnnotations() {
+        this._clearAnnotationTimers();
+        if (!this._annotationOverlay || !this.guidedAnnotations || this.annotationPaused) return;
+        this._annTimers = [];
+        for (const p of this._annPhases || []) {
+            const el = this._annotationOverlay.querySelector(p.sel);
             if (el) {
-                const t = setTimeout(() => el.classList.add('vis'), p.delay);
+                const t = setTimeout(() => {
+                    if (!this.annotationPaused && this.guidedAnnotations) el.classList.add('vis');
+                }, p.delay);
                 this._annTimers.push(t);
             }
         }
-        this._syncPanelAnnotations();
+    }
+
+    _clearAnnotationTimers() {
+        this._annTimers?.forEach(t => clearTimeout(t));
+        this._annTimers = [];
+    }
+
+    _usePanelAnnotationMode() {
+        this.guidedAnnotations = false;
+        this._clearAnnotationTimers();
+        this._annotationOverlay?.querySelectorAll('.ch1-a[data-phase], .ch1-a--self').forEach(el => {
+            el.classList.remove('vis', 'panel-vis');
+        });
     }
 
     _syncPanelAnnotations() {
@@ -616,7 +653,10 @@ export default class ThreeEgoViz extends BaseViz {
         if (!ov) return;
         ov.querySelectorAll('.ch1-a[data-phase], .ch1-a--self').forEach(el => {
             el.classList.remove('panel-vis');
+            if (!this.guidedAnnotations || this.annotationPaused) el.classList.remove('vis');
         });
+
+        if (this.annotationPaused) return;
 
         const panelId = this.panelState?.activePanelId || 'ego-light';
         const panelPhases = {
@@ -758,7 +798,7 @@ export default class ThreeEgoViz extends BaseViz {
 
     dispose() {
         removeEventListener('mousemove', this._onMM);
-        this._annTimers?.forEach(t => clearTimeout(t));
+        this._clearAnnotationTimers();
         this._annotationOverlay?.remove();
         this.renderer?.dispose();
         this.renderer?.forceContextLoss();

--- a/src/visualizations/chapters/ch1/ThreeEgoViz.js
+++ b/src/visualizations/chapters/ch1/ThreeEgoViz.js
@@ -53,6 +53,7 @@ export default class ThreeEgoViz extends BaseViz {
 
     setPanelState(state = {}) {
         this.panelState = Object.assign(this.panelState || {}, state);
+        this._syncPanelAnnotations();
     }
 
     setReducedMotion(enabled) {
@@ -314,29 +315,42 @@ export default class ThreeEgoViz extends BaseViz {
     _buildAnnotations() {
         const ov = this._annotationOverlay = document.createElement('div');
         ov.className = 'ch1-annotations';
+        ov.setAttribute('aria-hidden', 'true');
         ov.innerHTML = `
 <style>
 .ch1-annotations {
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 10;
+    z-index: 2;
     overflow: hidden;
 }
 
 /* ─── Shared annotation base ─── */
 .ch1-a {
     position: absolute;
-    font-family: 'Instrument Serif', serif;
+    font-family: var(--font-serif, 'Instrument Serif', serif);
     opacity: 0;
     transition: opacity 3s cubic-bezier(0.16, 1, 0.3, 1),
                 transform 3s cubic-bezier(0.16, 1, 0.3, 1);
     transform: translateY(8px);
     will-change: opacity, transform;
 }
-.ch1-a.vis {
+.ch1-a.vis,
+.ch1-a.panel-vis {
     opacity: 1;
     transform: translateY(0);
+}
+
+.ch1-concept,
+.ch1-a--root,
+.ch1-a--self {
+    border: 1px solid rgba(244, 240, 232, 0.12);
+    border-radius: 8px;
+    background: rgba(3, 3, 7, 0.64);
+    padding: 0.5rem 0.65rem;
+    text-shadow: 0 0.7rem 1.6rem rgba(0, 0, 0, 0.82);
+    backdrop-filter: blur(12px);
 }
 
 /* ─── Phase 1: Chapter heading ─── */
@@ -345,19 +359,20 @@ export default class ThreeEgoViz extends BaseViz {
     left: 4.5vw;
 }
 .ch1-a--heading .ch1-eyebrow {
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-ui, system-ui, sans-serif);
     font-size: clamp(0.55rem, 0.9vw, 0.7rem);
-    letter-spacing: 0.4em;
+    letter-spacing: 0;
     text-transform: uppercase;
-    color: rgba(176, 176, 208, 0.18);
+    color: rgba(224, 225, 245, 0.72);
     margin-bottom: 0.4em;
 }
 .ch1-a--heading .ch1-title {
     font-size: clamp(1.8rem, 3.8vw, 3rem);
     font-style: italic;
-    color: rgba(176, 176, 208, 0.35);
-    letter-spacing: -0.02em;
+    color: rgba(244, 240, 232, 0.76);
+    letter-spacing: 0;
     line-height: 1.05;
+    text-shadow: 0 0.9rem 2rem rgba(0, 0, 0, 0.8);
 }
 
 /* ─── Phase 2: Ego pointer ─── */
@@ -371,18 +386,18 @@ export default class ThreeEgoViz extends BaseViz {
     display: block;
     width: 50px;
     height: 1px;
-    background: linear-gradient(to right, rgba(176,176,208,0.3), rgba(176,176,208,0));
+    background: linear-gradient(to right, rgba(224,225,245,0.56), rgba(224,225,245,0));
     margin-bottom: 8px;
 }
 .ch1-a--ego .ch1-concept {
     font-size: clamp(0.8rem, 1.3vw, 1.05rem);
     font-style: italic;
-    color: rgba(200, 200, 220, 0.35);
+    color: rgba(232, 232, 240, 0.84);
     line-height: 1.6;
 }
 .ch1-a--ego .ch1-concept em {
     font-style: normal;
-    color: rgba(232, 232, 240, 0.5);
+    color: rgba(255, 255, 255, 0.96);
 }
 
 /* ─── Phase 3: Unconscious label ─── */
@@ -396,17 +411,21 @@ export default class ThreeEgoViz extends BaseViz {
 .ch1-a--unconscious.vis {
     transform: translateX(-50%) translateY(0);
 }
+.ch1-a--unconscious.panel-vis {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
 .ch1-a--unconscious .ch1-pointer-up {
     display: block;
     width: 1px;
     height: 28px;
-    background: linear-gradient(to top, rgba(50,70,120,0.25), rgba(50,70,120,0));
+    background: linear-gradient(to top, rgba(122,154,255,0.48), rgba(122,154,255,0));
     margin: 0 auto 10px;
 }
 .ch1-a--unconscious .ch1-concept {
     font-size: clamp(0.75rem, 1.1vw, 0.95rem);
     font-style: italic;
-    color: rgba(100, 130, 190, 0.3);
+    color: rgba(178, 198, 255, 0.84);
     line-height: 1.65;
 }
 
@@ -419,20 +438,20 @@ export default class ThreeEgoViz extends BaseViz {
 .ch1-a--root-somatic {
     bottom: 42vh;
     left: 8vw;
-    color: rgba(160, 70, 70, 0.35);
+    color: rgba(245, 153, 153, 0.86);
     max-width: 16ch;
 }
 .ch1-a--root-somatic .ch1-rootline {
     display: block;
     width: 30px;
     height: 1px;
-    background: linear-gradient(to right, rgba(160,70,70,0.25), rgba(160,70,70,0));
+    background: linear-gradient(to right, rgba(245,153,153,0.48), rgba(245,153,153,0));
     margin-bottom: 5px;
 }
 .ch1-a--root-psychic {
     bottom: 42vh;
     right: 8vw;
-    color: rgba(80, 100, 180, 0.35);
+    color: rgba(166, 185, 255, 0.86);
     text-align: right;
     max-width: 16ch;
 }
@@ -440,7 +459,7 @@ export default class ThreeEgoViz extends BaseViz {
     display: block;
     width: 30px;
     height: 1px;
-    background: linear-gradient(to left, rgba(80,100,180,0.25), rgba(80,100,180,0));
+    background: linear-gradient(to left, rgba(166,185,255,0.5), rgba(166,185,255,0));
     margin-left: auto;
     margin-bottom: 5px;
 }
@@ -455,17 +474,17 @@ export default class ThreeEgoViz extends BaseViz {
 .ch1-a--insight .ch1-concept {
     font-size: clamp(0.8rem, 1.2vw, 1rem);
     font-style: italic;
-    color: rgba(176, 176, 208, 0.22);
+    color: rgba(224, 225, 245, 0.82);
     line-height: 1.7;
 }
 .ch1-a--insight .ch1-attr {
     display: block;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-ui, system-ui, sans-serif);
     font-style: normal;
     font-size: 0.5em;
-    letter-spacing: 0.25em;
+    letter-spacing: 0;
     text-transform: uppercase;
-    color: rgba(176, 176, 208, 0.1);
+    color: rgba(224, 225, 245, 0.72);
     margin-top: 0.7em;
 }
 
@@ -481,11 +500,12 @@ export default class ThreeEgoViz extends BaseViz {
     font-size: clamp(0.95rem, 1.5vw, 1.2rem);
     font-style: italic;
     color: rgba(212, 175, 55, 0);
-    letter-spacing: 0.06em;
+    letter-spacing: 0;
     transition: color 2.5s ease;
 }
-.ch1-a--self.vis .ch1-self-name {
-    color: rgba(212, 175, 55, 0.35);
+.ch1-a--self.vis .ch1-self-name,
+.ch1-a--self.panel-vis .ch1-self-name {
+    color: rgba(255, 226, 113, 0.9);
 }
 .ch1-a--self .ch1-self-desc {
     font-size: clamp(0.6rem, 0.85vw, 0.72rem);
@@ -495,8 +515,9 @@ export default class ThreeEgoViz extends BaseViz {
     line-height: 1.6;
     transition: color 3s ease 0.5s;
 }
-.ch1-a--self.vis .ch1-self-desc {
-    color: rgba(212, 175, 55, 0.2);
+.ch1-a--self.vis .ch1-self-desc,
+.ch1-a--self.panel-vis .ch1-self-desc {
+    color: rgba(255, 236, 176, 0.82);
 }
 .ch1-a--self.hid .ch1-self-name,
 .ch1-a--self.hid .ch1-self-desc {
@@ -505,9 +526,7 @@ export default class ThreeEgoViz extends BaseViz {
 
 /* ─── Mobile ─── */
 @media (max-width: 768px) {
-    .ch1-a--root-somatic, .ch1-a--root-psychic { display: none; }
-    .ch1-a--insight { max-width: 20ch; bottom: 6vh; }
-    .ch1-a--ego { right: 6vw; max-width: 18ch; }
+    .ch1-annotations { display: none; }
 }
 </style>
 
@@ -588,6 +607,32 @@ export default class ThreeEgoViz extends BaseViz {
                 const t = setTimeout(() => el.classList.add('vis'), p.delay);
                 this._annTimers.push(t);
             }
+        }
+        this._syncPanelAnnotations();
+    }
+
+    _syncPanelAnnotations() {
+        const ov = this._annotationOverlay;
+        if (!ov) return;
+        ov.querySelectorAll('.ch1-a[data-phase], .ch1-a--self').forEach(el => {
+            el.classList.remove('panel-vis');
+        });
+
+        const panelId = this.panelState?.activePanelId || 'ego-light';
+        const panelPhases = {
+            'ego-light': ['1', '2'],
+            roots: ['3', '4a', '4b'],
+            'self-depth': ['5'],
+        }[panelId] || [];
+
+        for (const phase of panelPhases) {
+            ov.querySelector(`[data-phase="${phase}"]`)?.classList.add('panel-vis');
+        }
+
+        if (panelId === 'self-depth') {
+            const selfAnn = ov.querySelector('.ch1-a--self');
+            selfAnn?.classList.add('panel-vis');
+            selfAnn?.classList.remove('hid');
         }
     }
 
@@ -672,7 +717,8 @@ export default class ThreeEgoViz extends BaseViz {
         /* Self annotation sync */
         const selfAnn = this._annotationOverlay?.querySelector('.ch1-a--self');
         if (selfAnn) {
-            if (revealing && selfT > 0.08 && selfT < 0.92) {
+            const panelSelfReveal = panelId === 'self-depth' || this.selfFocus > 0.35;
+            if ((revealing && selfT > 0.08 && selfT < 0.92) || panelSelfReveal) {
                 selfAnn.classList.add('vis');
                 selfAnn.classList.remove('hid');
             } else {


### PR DESCRIPTION
## Summary
- adds a shared visual reference instrument to chapter hero stages and strengthens cyclical-return panel diagrams
- adds a pause/resume animation control and semantic scene description through the shared SceneHost
- polishes Chapter 1 Ego overlay contrast, panel-state synchronization, reduced-motion fallback copy, and smoke coverage

## Verification
- rg -n "^<<<<<<<|^=======$|^>>>>>>>" .
- git diff --check
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- npm run build
- npm run test:e2e:app
- npm run test:a11y:app
- npm run build:pages
- npm run test:pages:artifact
- Visual screenshot pass: /journey/chapter/ch1 at 1440x1000, 390x844, and 320x568

## Notes
- The known large Three.js chunk warning still appears during Vite builds.
- GitHub reports existing Dependabot vulnerabilities on the default branch; this PR does not modify dependency versions.
