### PR TITLE
feat: polish chapter two shadow scene

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -190,7 +190,7 @@ async function runAccessibilitySmoke() {
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -255,6 +255,26 @@ async function smokeReducedMotion(browser, failures) {
   if (!chapterReferenceVisible) failures.push('reduced-motion chapter reference map is not visible');
   if (chapterPauseControlCount !== 0) failures.push(`reduced-motion chapter rendered pause controls: ${chapterPauseControlCount}`);
   if (!fallbackText?.includes('small surface light')) failures.push('reduced-motion chapter fallback lost Chapter 1 teaching summary');
+
+  await gotoAppRoute(page, '/journey/chapter/ch2');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterTwoFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterTwoReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterTwoReferenceCount = await page.locator('.chapter-stage__reference-node').count();
+  const chapterTwoPauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterTwoCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterTwoAnnotationCount = await page.locator('.ch2-annotations').count();
+  const chapterTwoFallbackText = await page.locator('.scene-host__fallback').textContent();
+
+  if (!chapterTwoFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 2 scene');
+  if (chapterTwoReducedMotionAttribute !== 'true') failures.push('Chapter 2 did not record reduced-motion state');
+  if (chapterTwoReferenceCount !== 3) failures.push(`reduced-motion Chapter 2 reference node count mismatch: ${chapterTwoReferenceCount}`);
+  if (chapterTwoPauseControlCount !== 0) failures.push(`reduced-motion Chapter 2 rendered pause controls: ${chapterTwoPauseControlCount}`);
+  if (chapterTwoCanvasCount !== 0) failures.push(`reduced-motion Chapter 2 rendered canvas: ${chapterTwoCanvasCount}`);
+  if (chapterTwoAnnotationCount !== 0) failures.push(`reduced-motion Chapter 2 rendered annotation overlay: ${chapterTwoAnnotationCount}`);
+  if (!chapterTwoFallbackText?.includes('split mirror') || !chapterTwoFallbackText?.includes('projection arcs')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 2 shadow teaching summary');
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -325,15 +345,64 @@ async function smokeChapterSceneControls(page, failures) {
   if (scrollY > 10) failures.push(`chapter scene control unexpectedly scrolled page: ${scrollY}`);
   if (!sceneDescription?.includes('The Self holds the field')) failures.push(`chapter 1 scene description did not follow active panel: ${sceneDescription}`);
 
+  await page.evaluate(() => window.localStorage.removeItem('aion:scene-animation-paused'));
   await gotoAppRoute(page, '/journey/chapter/ch2');
-  const projection = page.getByRole('button', { name: /02\s+Projection/ });
+  await page.locator('.scene-host__mount[data-state="ready"]').waitFor({ state: 'visible', timeout: 10_000 });
+  const chapterTwoReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterTwoReferenceCount = await chapterTwoReferenceNodes.count();
+  const chapterTwoPanelIds = await chapterTwoReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  if (chapterTwoReferenceCount !== 3) failures.push(`chapter 2 reference node count mismatch: ${chapterTwoReferenceCount}`);
+  if (chapterTwoPanelIds.join(',') !== 'mirror,projection,integration') failures.push(`chapter 2 reference nodes out of order: ${chapterTwoPanelIds.join(',')}`);
+
+  const chapterTwoPause = page.getByRole('button', { name: /Pause animation/ });
+  await chapterTwoPause.click();
+  await page.waitForTimeout(5_400);
+  const chapterTwoPaused = await page.getByRole('button', { name: /Resume animation/ }).getAttribute('aria-pressed');
+  const chapterTwoPausedAnnotationCount = await page.locator('.ch2-a--ego.vis, .ch2-micro--ego.vis').count();
+  if (chapterTwoPaused !== 'true') failures.push(`chapter 2 pause control did not stay pressed: ${chapterTwoPaused}`);
+  if (chapterTwoPausedAnnotationCount !== 0) failures.push(`chapter 2 pause allowed timed annotations to reveal: ${chapterTwoPausedAnnotationCount}`);
+  await page.getByRole('button', { name: /Resume animation/ }).click();
+
+  const projection = page.locator('.chapter-stage__reference-node[data-panel-id="projection"]');
   await projection.click();
   await page.waitForTimeout(250);
 
   const projectionPressed = await projection.getAttribute('aria-pressed');
+  const projectionPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="projection"]').count();
+  const projectionPanelAnnotationVisible = await page.locator('.ch2-a--projection.panel-vis').count();
   const chapterTwoScrollY = await page.evaluate(() => window.scrollY);
+  const chapterTwoSceneDescription = await page.locator('#scene-host-description-ch2').textContent();
   if (projectionPressed !== 'true') failures.push(`chapter 2 scene control did not become active: ${projectionPressed}`);
+  if (projectionPanelActive !== 1) failures.push(`chapter 2 projection panel did not become active: ${projectionPanelActive}`);
+  if (projectionPanelAnnotationVisible !== 1) failures.push(`chapter 2 projection annotation did not follow selected panel: ${projectionPanelAnnotationVisible}`);
   if (chapterTwoScrollY > 10) failures.push(`chapter 2 scene control unexpectedly scrolled page: ${chapterTwoScrollY}`);
+  if (!chapterTwoSceneDescription?.includes('Projection: Thrown outward')) failures.push(`chapter 2 scene description did not follow projection panel: ${chapterTwoSceneDescription}`);
+
+  const integration = page.locator('.chapter-stage__reference-node[data-panel-id="integration"]');
+  await integration.click();
+  await page.waitForFunction(() => document.querySelector('.ch2-a--integration')?.classList.contains('vis'), null, { timeout: 2_000 }).catch(() => {});
+  const integrationPressed = await integration.getAttribute('aria-pressed');
+  const integrationAnnotationVisible = await page.locator('.ch2-a--integration.vis').count();
+  if (integrationPressed !== 'true') failures.push(`chapter 2 integration reference did not become active: ${integrationPressed}`);
+  if (integrationAnnotationVisible !== 1) failures.push(`chapter 2 integration annotation did not follow selected panel: ${integrationAnnotationVisible}`);
+
+  const mirror = page.locator('.chapter-stage__reference-node[data-panel-id="mirror"]');
+  await mirror.click();
+  await page.waitForTimeout(850);
+  const integrationAnnotationState = await page.locator('.ch2-a--integration').evaluate((node) => ({
+    visible: node.classList.contains('vis'),
+    hidden: node.classList.contains('hid'),
+  }));
+  if (integrationAnnotationState.visible) failures.push('chapter 2 integration annotation stayed visible after returning to mirror panel');
+  if (!integrationAnnotationState.hidden) failures.push('chapter 2 integration annotation did not enter hidden state after returning to mirror panel');
+
+  const chapterTwoCanvas = page.locator('.scene-host canvas').first();
+  const chapterTwoCanvasBox = await chapterTwoCanvas.boundingBox();
+  const chapterTwoVisiblePixels = await countCanvasPixels(chapterTwoCanvas);
+  if (!chapterTwoCanvasBox || chapterTwoCanvasBox.width < 300 || chapterTwoCanvasBox.height < 300) {
+    failures.push(`chapter 2 canvas geometry too small: ${chapterTwoCanvasBox ? `${Math.round(chapterTwoCanvasBox.width)}x${Math.round(chapterTwoCanvasBox.height)}` : 'missing'}`);
+  }
+  if (chapterTwoVisiblePixels <= 8) failures.push(`chapter 2 canvas appears blank: ${chapterTwoVisiblePixels}`);
 
   await gotoAppRoute(page, '/journey/chapter/ch3');
   const conjunction = page.getByRole('button', { name: /03\s+Conjunction/ });
@@ -458,7 +527,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -493,6 +562,26 @@ async function smokeMobile(page, failures) {
       failures.push(`mobile nav overlaps chapter 1 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterNavBottom)}, heading top ${Math.round(chapterHeadingBox.y)}`);
     }
     if (referenceCount !== 3) failures.push(`mobile chapter 1 reference node count mismatch at ${viewport.width}x${viewport.height}: ${referenceCount}`);
+
+    await gotoAppRoute(page, '/journey/chapter/ch2');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterTwoNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterTwoHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterTwoReferenceCount = await page.locator('.chapter-stage__reference-node').count();
+    const chapterTwoAnnotationDisplay = await page.locator('.ch2-annotations').evaluate((node) => window.getComputedStyle(node).display).catch(() => 'missing');
+    const chapterTwoScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    if (!chapterTwoNavBox || !chapterTwoHeadingBox) {
+      failures.push(`mobile chapter 2 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterTwoNavBottom = chapterTwoNavBox.y + chapterTwoNavBox.height;
+    if (chapterTwoNavBottom > chapterTwoHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 2 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterTwoNavBottom)}, heading top ${Math.round(chapterTwoHeadingBox.y)}`);
+    }
+    if (chapterTwoReferenceCount !== 3) failures.push(`mobile chapter 2 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterTwoReferenceCount}`);
+    if (chapterTwoAnnotationDisplay !== 'none') failures.push(`mobile chapter 2 annotation overlay remains visible at ${viewport.width}x${viewport.height}: ${chapterTwoAnnotationDisplay}`);
+    if (chapterTwoScrollWidth > viewport.width + 2) failures.push(`mobile chapter 2 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterTwoScrollWidth}`);
   }
 }
 

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -19,7 +19,7 @@ const canonicalRoutes = [
   ...Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`),
 ];
 
-const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch6', '/journey/chapter/ch14'];
+const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch6', '/journey/chapter/ch14'];
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],

--- a/src/app/components/SceneHost.tsx
+++ b/src/app/components/SceneHost.tsx
@@ -76,6 +76,10 @@ export default function SceneHost({
         instance.setPanelState?.({ activePanelId: activePanelId || experience.panels[0]?.id || '', progress: panelProgress });
         if (!disposed) setState('ready');
       } catch (error) {
+        instance?.dispose?.();
+        instance = null;
+        instanceRef.current = null;
+        if (mountNode) mountNode.innerHTML = '';
         if (!disposed) {
           setState('fallback');
           setMessage(error instanceof Error ? error.message : experience.fallbackSummary);

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1708,6 +1708,67 @@ h3 {
   background: linear-gradient(180deg, rgba(244, 240, 232, 0.22), rgba(212, 175, 55, 0.44), transparent);
 }
 
+.chapter-experience[data-chapter-id="ch2"] .chapter-stage__reference-node[data-panel-id="mirror"] .chapter-stage__reference-mark::before {
+  top: 0.92rem;
+  width: 2.1rem;
+  height: 1.55rem;
+  border: 1px solid rgba(196, 166, 246, 0.24);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 32% 50%, rgba(232, 216, 192, 0.9), transparent 0.34rem),
+    radial-gradient(circle at 68% 50%, rgba(168, 112, 236, 0.88), transparent 0.42rem),
+    linear-gradient(90deg, rgba(212, 175, 55, 0.08), transparent 48%, rgba(196, 166, 246, 0.12) 52%, rgba(80, 42, 132, 0.12));
+  box-shadow: 0 0 1.6rem rgba(168, 112, 236, 0.26);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-stage__reference-node[data-panel-id="mirror"] .chapter-stage__reference-mark::after {
+  top: 0.66rem;
+  height: 2.55rem;
+  background: linear-gradient(180deg, transparent, rgba(196, 166, 246, 0.52), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-stage__reference-node[data-panel-id="projection"] .chapter-stage__reference-mark::before {
+  top: 1.15rem;
+  left: 35%;
+  width: 0.56rem;
+  height: 0.56rem;
+  background: #e8d8c0;
+  box-shadow:
+    1.3rem -0.52rem 0 -0.18rem rgba(214, 122, 255, 0.92),
+    2.15rem 0.18rem 0 -0.22rem rgba(214, 122, 255, 0.72),
+    0 0 1.4rem rgba(212, 175, 55, 0.38);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-stage__reference-node[data-panel-id="projection"] .chapter-stage__reference-mark::after {
+  top: 1.15rem;
+  left: 56%;
+  width: 2.2rem;
+  height: 1.4rem;
+  border-top: 1px solid rgba(214, 122, 255, 0.58);
+  border-right: 1px solid rgba(214, 122, 255, 0.34);
+  border-radius: 50%;
+  background: transparent;
+  transform: translateX(-50%) rotate(-18deg);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-stage__reference-node[data-panel-id="integration"] .chapter-stage__reference-mark::before {
+  top: 1.22rem;
+  width: 0.58rem;
+  height: 0.58rem;
+  background: #f4f0e8;
+  box-shadow:
+    -1.15rem 0 0 -0.08rem rgba(232, 216, 192, 0.9),
+    1.15rem 0 0 -0.08rem rgba(196, 166, 246, 0.9),
+    0 0 1.8rem rgba(224, 192, 255, 0.48);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-stage__reference-node[data-panel-id="integration"] .chapter-stage__reference-mark::after {
+  top: 1.46rem;
+  width: 2.45rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(232, 216, 192, 0.2), rgba(224, 192, 255, 0.72), rgba(196, 166, 246, 0.2));
+}
+
 .scene-host__status,
 .scene-host__fallback {
   position: absolute;
@@ -2004,6 +2065,99 @@ h3 {
   top: 30%;
   background: #d79a72;
   box-shadow: 0 0 1.4rem rgba(215, 154, 114, 0.56);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="mirror"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 31% 50%, rgba(232, 216, 192, 0.16), transparent 4.1rem),
+    radial-gradient(circle at 69% 50%, rgba(168, 112, 236, 0.17), transparent 4.7rem),
+    linear-gradient(90deg, rgba(212, 175, 55, 0.05), rgba(244, 240, 232, 0.016) 49%, rgba(196, 166, 246, 0.06) 51%, rgba(80, 42, 132, 0.11));
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="mirror"] .chapter-panel__symbol::before {
+  inset: 17% 23%;
+  border-color: rgba(196, 166, 246, 0.2);
+  border-radius: 999px;
+  box-shadow:
+    -3.6rem 0 3.8rem rgba(212, 175, 55, 0.06),
+    3.6rem 0 4rem rgba(168, 112, 236, 0.08);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="mirror"] .chapter-panel__axis--vertical {
+  height: 84%;
+  background: linear-gradient(180deg, transparent, rgba(196, 166, 246, 0.62), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="projection"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 32% 58%, rgba(232, 216, 192, 0.14), transparent 3.6rem),
+    radial-gradient(circle at 75% 35%, rgba(214, 122, 255, 0.16), transparent 4.8rem),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(44, 15, 74, 0.13));
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="projection"] .chapter-panel__symbol::before {
+  inset: 27% 20% 24% 28%;
+  border-color: rgba(214, 122, 255, 0.24);
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+  transform: rotate(-18deg);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="projection"] .chapter-panel__axis--horizontal {
+  width: 58%;
+  left: 56%;
+  background: linear-gradient(90deg, rgba(232, 216, 192, 0.14), rgba(214, 122, 255, 0.45), transparent);
+  transform: translate(-50%, -50%) rotate(-18deg);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="projection"] .chapter-panel__spark--one {
+  left: 30%;
+  top: 58%;
+  background: #e8d8c0;
+  box-shadow: 0 0 1.6rem rgba(232, 216, 192, 0.65);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="projection"] .chapter-panel__spark--two {
+  left: 74%;
+  top: 34%;
+  background: #d67aff;
+  box-shadow: 0 0 1.7rem rgba(214, 122, 255, 0.72);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="integration"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 35% 50%, rgba(232, 216, 192, 0.14), transparent 4rem),
+    radial-gradient(circle at 65% 50%, rgba(168, 112, 236, 0.15), transparent 4rem),
+    radial-gradient(circle at 50% 50%, rgba(224, 192, 255, 0.1), transparent 6rem),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.014));
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="integration"] .chapter-panel__symbol::before {
+  inset: 23% 30%;
+  border-color: rgba(224, 192, 255, 0.24);
+  border-radius: 50%;
+  box-shadow:
+    -3.8rem 0 3.6rem rgba(232, 216, 192, 0.06),
+    3.8rem 0 3.6rem rgba(168, 112, 236, 0.08);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="integration"] .chapter-panel__axis--horizontal {
+  width: 50%;
+  background: linear-gradient(90deg, rgba(232, 216, 192, 0.16), rgba(224, 192, 255, 0.62), rgba(168, 112, 236, 0.18));
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="integration"] .chapter-panel__spark--one {
+  left: 36%;
+  top: 50%;
+  background: #e8d8c0;
+  box-shadow: 0 0 1.4rem rgba(232, 216, 192, 0.58);
+}
+
+.chapter-experience[data-chapter-id="ch2"] .chapter-panel[data-panel-id="integration"] .chapter-panel__spark--two {
+  left: 64%;
+  top: 50%;
+  background: #c4a6f6;
+  box-shadow: 0 0 1.45rem rgba(196, 166, 246, 0.62);
 }
 
 .chapter-experience[data-motion-grammar="integration"] .chapter-panel__symbol {

--- a/src/app/visualization/chapterScenes.ts
+++ b/src/app/visualization/chapterScenes.ts
@@ -19,12 +19,12 @@ export const CHAPTER_SCENES: Record<ChapterId, ChapterExperience> = {
     visualTheme: 'Shadow mirror and projection arcs',
     sceneModule: '../visualizations/chapters/ch2/ThreeShadowViz.js',
     motionGrammar: 'opposition',
-    fallbackSummary: 'A split mirror shows ego and shadow as related opposites, with projection arcs returning to the viewer.',
-    checkpoints: ['Identify the rejected figure.', 'Distinguish shadow from evil.', 'Notice projection returning home.'],
+    fallbackSummary: 'A split mirror sets ego and shadow as related opposites; projection arcs throw the refused image outward, then return it as material for integration.',
+    checkpoints: ['Find the refused likeness in the mirror.', 'Trace projection outward and back.', 'Describe integration without erasing the shadow.'],
     panels: [
-      { id: 'mirror', kicker: 'Opposition', title: 'The refused likeness', body: 'The shadow appears as what the ego would rather not recognize.', insight: 'Recognition begins when the image becomes personal.' },
-      { id: 'projection', kicker: 'Projection', title: 'Thrown outward', body: 'Shadow contents distort the world when they are not owned.', insight: 'Projection makes inner conflict look external.' },
-      { id: 'integration', kicker: 'Integration', title: 'Return without collapse', body: 'Integration does not erase darkness; it gives it relation.', insight: 'The ego grows by admitting what it excludes.' },
+      { id: 'mirror', kicker: 'Opposition', title: 'The refused likeness', body: 'The shadow appears as the ego sees a distorted version of what it rejects.', insight: 'Recognition begins when the image becomes personal.' },
+      { id: 'projection', kicker: 'Projection', title: 'Thrown outward', body: 'Shadow contents look like they belong to the outside world when they are not owned.', insight: 'Projection makes inner conflict look external.' },
+      { id: 'integration', kicker: 'Integration', title: 'Return without collapse', body: 'Integration keeps the darkness visible while placing it back in relation.', insight: 'The ego grows by admitting what it excludes.' },
     ],
   },
   ch3: {

--- a/src/visualizations/chapters/ch2/ThreeShadowViz.js
+++ b/src/visualizations/chapters/ch2/ThreeShadowViz.js
@@ -50,7 +50,7 @@
  *   Phase 2 (5s):   Ego identification + leader line
  *   Phase 3 (10s):  Shadow identification + leader line
  *   Phase 4 (16s):  What "projection" means
- *   Phase 5 (22s):  Jung quote
+     *   Phase 5 (22s):  Relation insight
  *   Phase 6 (cyc):  Integration insight
  */
 import * as THREE from 'three';
@@ -78,14 +78,32 @@ export default class ThreeShadowViz extends BaseViz {
         this.mirrorFocus = 1;
         this.projectionFocus = 0;
         this.integrationFocus = 0;
+        this.guidedAnnotations = true;
+        this.annotationPaused = false;
     }
 
     setPanelState(state = {}) {
+        const previousPanelId = this.panelState?.activePanelId;
         this.panelState = Object.assign(this.panelState || {}, state);
+        const nextPanelId = this.panelState?.activePanelId;
+        if (this._annotationOverlay && previousPanelId && nextPanelId && previousPanelId !== nextPanelId) {
+            this._usePanelAnnotationMode();
+        }
+        this._syncPanelAnnotations();
     }
 
     setReducedMotion(enabled) {
         this.reducedMotion = Boolean(enabled);
+    }
+
+    setPaused(paused) {
+        this.annotationPaused = Boolean(paused);
+        if (this.annotationPaused) {
+            this._clearAnnotationTimers();
+        } else if (this.guidedAnnotations) {
+            this._scheduleAnnotations();
+        }
+        this._syncPanelAnnotations();
     }
 
     async init() {
@@ -108,14 +126,14 @@ export default class ThreeShadowViz extends BaseViz {
         );
         cam.position.set(0, 1.5, 14);
 
-        /* ── Mouse ── */
+        /* ── Pointer ── */
         this.mouse = new THREE.Vector2();
         this.mouseSmooth = new THREE.Vector2();
-        this._onMM = e => {
-            this.mouse.x = (e.clientX / innerWidth) * 2 - 1;
-            this.mouse.y = -(e.clientY / innerHeight) * 2 + 1;
+        this._onPointerMove = e => {
+            this.mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
+            this.mouse.y = -(e.clientY / window.innerHeight) * 2 + 1;
         };
-        addEventListener('mousemove', this._onMM);
+        addEventListener('pointermove', this._onPointerMove, { passive: true });
 
         /* ── Build scene ── */
         this._buildEgo();
@@ -123,6 +141,7 @@ export default class ThreeShadowViz extends BaseViz {
         this._buildMirror();
         this._buildProjections();
         this._buildCocoon();
+        this._buildIntegrationBridge();
         this._buildAtmosphere();
         this._buildGround();
         this._buildAnnotations();
@@ -330,6 +349,18 @@ export default class ThreeShadowViz extends BaseViz {
         );
         this.scene.add(this.mirrorPlane);
 
+        this.mirrorHalo = new THREE.Mesh(
+            new THREE.PlaneGeometry(0.42, 14),
+            new THREE.MeshBasicMaterial({
+                color: MIRROR_CLR,
+                transparent: true,
+                opacity: 0.08,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false
+            })
+        );
+        this.scene.add(this.mirrorHalo);
+
         // Shimmer dots along mirror line
         this.mirrorDots = [];
         for (let i = 0; i < 20; i++) {
@@ -397,8 +428,23 @@ export default class ThreeShadowViz extends BaseViz {
             targetGlow.position.copy(dot.position);
             this.scene.add(targetGlow);
 
+            const returnPts = [
+                new THREE.Vector3(pts[2].x, pts[2].y, pts[2].z),
+                new THREE.Vector3(1.1 + d.x * 0.08, d.y * 0.28, d.z * 0.2),
+                new THREE.Vector3(-3.2, -0.2, d.z * 0.12)
+            ];
+            const returnCurve = new THREE.QuadraticBezierCurve3(...returnPts);
+            const returnLine = new THREE.Line(
+                new THREE.BufferGeometry().setFromPoints(returnCurve.getPoints(36)),
+                new THREE.LineBasicMaterial({
+                    color: INTEG_CLR, transparent: true, opacity: 0,
+                    blending: THREE.AdditiveBlending
+                })
+            );
+            this.scene.add(returnLine);
+
             this.projArcs.push({
-                line, dot, targetGlow,
+                line, dot, targetGlow, returnLine,
                 ph: Math.random() * Math.PI * 2,
                 speed: 0.2 + Math.random() * 0.2
             });
@@ -434,6 +480,28 @@ export default class ThreeShadowViz extends BaseViz {
             this.scene.add(line);
             this.cocoonStrands.push({ line, ph: Math.random() * Math.PI * 2 });
         }
+    }
+
+    _buildIntegrationBridge() {
+        const bridgeGeo = new THREE.BufferGeometry();
+        bridgeGeo.setAttribute(
+            'position',
+            new THREE.Float32BufferAttribute([
+                -3.5, 0, 0,
+                0, 0.35, 0.6,
+                3.5, 0, 0
+            ], 3)
+        );
+        this.integrationBridge = new THREE.Line(
+            bridgeGeo,
+            new THREE.LineBasicMaterial({
+                color: INTEG_CLR,
+                transparent: true,
+                opacity: 0,
+                blending: THREE.AdditiveBlending
+            })
+        );
+        this.scene.add(this.integrationBridge);
     }
 
     /* ══════════════════════════════════════════════════════
@@ -478,35 +546,47 @@ export default class ThreeShadowViz extends BaseViz {
     _buildAnnotations() {
         const ov = this._annotationOverlay = document.createElement('div');
         ov.className = 'ch2-annotations';
+        ov.setAttribute('aria-hidden', 'true');
         ov.innerHTML = `
 <style>
 .ch2-annotations {
     position: absolute;
     inset: 0;
     pointer-events: none;
-    z-index: 10;
+    z-index: 2;
     overflow: hidden;
 }
 
 .ch2-a {
     position: absolute;
-    font-family: 'Instrument Serif', serif;
+    font-family: var(--font-serif, 'Instrument Serif', serif);
     opacity: 0;
-    transition: opacity 2.8s cubic-bezier(0.16, 1, 0.3, 1),
-                transform 2.8s cubic-bezier(0.16, 1, 0.3, 1);
+    transition: opacity 0.9s cubic-bezier(0.16, 1, 0.3, 1),
+                transform 0.9s cubic-bezier(0.16, 1, 0.3, 1);
     transform: translateY(6px);
     will-change: opacity, transform;
 }
-.ch2-a.vis {
+.ch2-a.vis,
+.ch2-a.panel-vis {
     opacity: 1;
     transform: translateY(0);
 }
 
+.ch2-a--heading,
 .ch2-a--ego,
-.ch2-a--shadow,
-.ch2-a--projection,
 .ch2-a--quote {
     display: none;
+}
+
+.ch2-a .ch2-text,
+.ch2-a .ch2-integ-text {
+    display: block;
+    border: 1px solid rgba(244, 240, 232, 0.12);
+    border-radius: 8px;
+    background: rgba(3, 3, 7, 0.64);
+    padding: 0.66rem 0.72rem;
+    backdrop-filter: blur(16px);
+    box-shadow: 0 1rem 2.8rem rgba(0, 0, 0, 0.34);
 }
 
 /* ─── Phase 1: Chapter heading ─── */
@@ -515,19 +595,20 @@ export default class ThreeShadowViz extends BaseViz {
     left: 4.5vw;
 }
 .ch2-a--heading .ch2-eyebrow {
-    font-family: 'Inter', 'Helvetica Neue', sans-serif;
+    font-family: var(--font-ui, Inter, sans-serif);
     font-size: clamp(0.55rem, 0.9vw, 0.72rem);
-    letter-spacing: 0.45em;
+    letter-spacing: 0;
     text-transform: uppercase;
-    color: rgba(140, 100, 180, 0.35);
+    color: rgba(218, 190, 255, 0.84);
     margin-bottom: 0.4em;
 }
 .ch2-a--heading .ch2-title {
     font-size: clamp(2rem, 4vw, 3.4rem);
     font-style: italic;
-    color: rgba(160, 120, 210, 0.45);
-    letter-spacing: -0.02em;
+    color: rgba(244, 240, 232, 0.86);
+    letter-spacing: 0;
     line-height: 1.05;
+    text-shadow: 0 0 2.4rem rgba(140, 100, 220, 0.38);
 }
 
 /* ─── Phase 2: Ego annotation (left, with leader line) ─── */
@@ -540,7 +621,7 @@ export default class ThreeShadowViz extends BaseViz {
     display: block;
     width: 50px;
     height: 1px;
-    background: linear-gradient(to right, rgba(208,176,128,0.5), rgba(208,176,128,0));
+    background: linear-gradient(to right, rgba(232,216,192,0.82), rgba(208,176,128,0));
     margin-bottom: 10px;
     transform-origin: left;
     animation: ch2-leaderPulse 4s ease-in-out infinite;
@@ -552,22 +633,22 @@ export default class ThreeShadowViz extends BaseViz {
 .ch2-a--ego .ch2-text {
     font-size: clamp(0.8rem, 1.2vw, 1rem);
     font-style: italic;
-    color: rgba(220, 210, 190, 0.5);
+    color: rgba(244, 230, 205, 0.92);
     line-height: 1.7;
 }
 .ch2-a--ego .ch2-text em {
     font-style: normal;
-    color: rgba(232, 216, 192, 0.7);
+    color: #ffe6ad;
     font-weight: 400;
 }
 .ch2-a--ego .ch2-note {
     display: block;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-ui, Inter, sans-serif);
     font-style: normal;
     font-size: 0.55em;
-    letter-spacing: 0.2em;
+    letter-spacing: 0;
     text-transform: uppercase;
-    color: rgba(208, 176, 128, 0.2);
+    color: rgba(236, 202, 132, 0.78);
     margin-top: 0.8em;
 }
 
@@ -582,7 +663,7 @@ export default class ThreeShadowViz extends BaseViz {
     display: block;
     width: 50px;
     height: 1px;
-    background: linear-gradient(to left, rgba(120,60,180,0.5), rgba(120,60,180,0));
+    background: linear-gradient(to left, rgba(196,154,255,0.82), rgba(120,60,180,0));
     margin-left: auto;
     margin-bottom: 10px;
     animation: ch2-leaderPulseShadow 4s ease-in-out infinite;
@@ -594,22 +675,22 @@ export default class ThreeShadowViz extends BaseViz {
 .ch2-a--shadow .ch2-text {
     font-size: clamp(0.8rem, 1.2vw, 1rem);
     font-style: italic;
-    color: rgba(160, 100, 220, 0.5);
+    color: rgba(218, 197, 250, 0.92);
     line-height: 1.7;
 }
 .ch2-a--shadow .ch2-text em {
     font-style: normal;
-    color: rgba(180, 120, 240, 0.7);
+    color: #d8b2ff;
     font-weight: 400;
 }
 .ch2-a--shadow .ch2-note {
     display: block;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-ui, Inter, sans-serif);
     font-style: normal;
     font-size: 0.55em;
-    letter-spacing: 0.2em;
+    letter-spacing: 0;
     text-transform: uppercase;
-    color: rgba(140, 80, 200, 0.25);
+    color: rgba(202, 166, 246, 0.78);
     margin-top: 0.8em;
 }
 
@@ -624,22 +705,22 @@ export default class ThreeShadowViz extends BaseViz {
     display: block;
     width: 35px;
     height: 1px;
-    background: linear-gradient(to left, rgba(156,39,176,0.4), rgba(156,39,176,0));
+    background: linear-gradient(to left, rgba(236,156,255,0.84), rgba(156,39,176,0));
     margin-left: auto;
     margin-bottom: 8px;
 }
 .ch2-a--projection .ch2-text {
     font-size: clamp(0.72rem, 1.05vw, 0.88rem);
     font-style: italic;
-    color: rgba(156, 39, 176, 0.4);
+    color: rgba(230, 198, 255, 0.94);
     line-height: 1.7;
 }
 .ch2-a--projection .ch2-text em {
     font-style: normal;
-    color: rgba(180, 60, 210, 0.6);
+    color: #f1a4ff;
 }
 
-/* ─── Phase 5: Jung quote (bottom left) ─── */
+/* ─── Phase 5: Relation insight (bottom left) ─── */
 .ch2-a--quote {
     bottom: 7vh;
     left: 4.5vw;
@@ -647,25 +728,28 @@ export default class ThreeShadowViz extends BaseViz {
 }
 .ch2-a--quote .ch2-quotemark {
     display: block;
-    font-size: 2rem;
-    line-height: 1;
-    color: rgba(140, 100, 200, 0.12);
+    font-family: var(--font-ui, Inter, sans-serif);
+    font-size: 0.58rem;
+    line-height: 1.2;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    color: rgba(198, 166, 246, 0.42);
     margin-bottom: 0.2em;
 }
 .ch2-a--quote .ch2-text {
     font-size: clamp(0.82rem, 1.2vw, 1rem);
     font-style: italic;
-    color: rgba(180, 150, 220, 0.4);
+    color: rgba(230, 215, 255, 0.9);
     line-height: 1.7;
 }
 .ch2-a--quote .ch2-attr {
     display: block;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-ui, Inter, sans-serif);
     font-style: normal;
     font-size: 0.5em;
-    letter-spacing: 0.3em;
+    letter-spacing: 0;
     text-transform: uppercase;
-    color: rgba(140, 110, 190, 0.2);
+    color: rgba(196, 166, 246, 0.76);
     margin-top: 0.8em;
 }
 
@@ -682,6 +766,10 @@ export default class ThreeShadowViz extends BaseViz {
     opacity: 1;
     transform: translate(-50%, -50%) translateY(0);
 }
+.ch2-a--integration.panel-vis {
+    opacity: 1;
+    transform: translate(-50%, -50%) translateY(0);
+}
 .ch2-a--integration.hid {
     opacity: 0;
     transform: translate(-50%, -50%) translateY(6px);
@@ -689,55 +777,54 @@ export default class ThreeShadowViz extends BaseViz {
 .ch2-a--integration .ch2-integ-text {
     font-size: clamp(0.9rem, 1.4vw, 1.15rem);
     font-style: italic;
-    color: rgba(224, 192, 255, 0.55);
+    color: rgba(238, 224, 255, 0.94);
     line-height: 1.65;
-    letter-spacing: 0.03em;
+    letter-spacing: 0;
 }
 .ch2-a--integration .ch2-integ-sub {
     display: block;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-ui, Inter, sans-serif);
     font-style: normal;
     font-size: 0.5em;
-    letter-spacing: 0.25em;
+    letter-spacing: 0;
     text-transform: uppercase;
-    color: rgba(200, 160, 240, 0.2);
+    color: rgba(205, 172, 250, 0.78);
     margin-top: 0.6em;
 }
 
 /* ─── Persistent micro-labels near objects ─── */
 .ch2-micro {
     position: absolute;
-    font-family: 'Inter', sans-serif;
+    font-family: var(--font-ui, Inter, sans-serif);
     font-size: clamp(0.45rem, 0.65vw, 0.55rem);
-    letter-spacing: 0.35em;
+    letter-spacing: 0;
     text-transform: uppercase;
     opacity: 0;
     transition: opacity 3s ease;
 }
-.ch2-micro.vis { opacity: 1; }
+.ch2-micro.vis,
+.ch2-micro.panel-vis { opacity: 1; }
 
 .ch2-micro--ego {
     left: 20%;
     top: 55%;
-    color: rgba(208, 176, 128, 0.2);
+    color: rgba(236, 202, 132, 0.72);
 }
 .ch2-micro--shadow {
     right: 18%;
     top: 55%;
-    color: rgba(140, 80, 200, 0.2);
+    color: rgba(202, 166, 246, 0.72);
 }
 .ch2-micro--mirror {
     left: 50%;
     top: 45%;
     transform: translateX(-50%) rotate(-90deg);
-    color: rgba(80, 60, 120, 0.15);
-    letter-spacing: 0.5em;
+    color: rgba(196, 166, 246, 0.58);
+    letter-spacing: 0;
 }
 
 @media (max-width: 768px) {
-    .ch2-a--projection { bottom: 18vh; right: 3vw; max-width: 20ch; }
-    .ch2-a--ego, .ch2-a--shadow { max-width: 18ch; }
-    .ch2-micro { display: none; }
+    .ch2-annotations { display: none; }
 }
 </style>
 
@@ -754,7 +841,7 @@ export default class ThreeShadowViz extends BaseViz {
         The radiant figure is <em>the Ego</em> —
         the self you know, the face
         you show the world.
-        <span class="ch2-note">Move your mouse — it follows you</span>
+        <span class="ch2-note">Pointer and panel controls move the field</span>
     </div>
 </div>
 
@@ -765,7 +852,7 @@ export default class ThreeShadowViz extends BaseViz {
         Its dark mirror is <em>the Shadow</em> —
         everything about yourself
         you refuse to see.
-        <span class="ch2-note">It mirrors you, but distorted and delayed</span>
+        <span class="ch2-note">Distorted, delayed, and still related</span>
     </div>
 </div>
 
@@ -773,23 +860,20 @@ export default class ThreeShadowViz extends BaseViz {
 <div class="ch2-a ch2-a--projection" data-phase="4">
     <span class="ch2-leader"></span>
     <div class="ch2-text">
-        The arcs flying outward are
-        <em>Projections</em> — you see your
-        shadow in others, blaming them
-        for what you won't face
-        in yourself.
+        <em>Projection</em> throws the refused
+        image outward; the faint return
+        path shows it can be owned again.
     </div>
 </div>
 
-<!-- Phase 5: Jung quote -->
+<!-- Phase 5: Relation insight -->
 <div class="ch2-a ch2-a--quote" data-phase="5">
-    <span class="ch2-quotemark">"</span>
+    <span class="ch2-quotemark">return</span>
     <div class="ch2-text">
-        One does not become enlightened
-        by imagining figures of light,
-        but by making the
-        darkness conscious.
-        <span class="ch2-attr">— C. G. Jung, Aion §14</span>
+        Making darkness conscious turns
+        an outside enemy back into
+        inner relation.
+        <span class="ch2-attr">Shadow as relation</span>
     </div>
 </div>
 
@@ -810,21 +894,77 @@ export default class ThreeShadowViz extends BaseViz {
 
         (this.container || document.body).appendChild(ov);
 
-        /* ── Phased reveal schedule ── */
-        this._annTimers = [];
-        const phases = [
+        this._annPhases = [
             { sel: '[data-phase="1"]', delay: 2000 },
             { sel: '[data-phase="2"]', delay: 5000 },
             { sel: '[data-phase="3"]', delay: 10000 },
             { sel: '[data-phase="4"]', delay: 16000 },
             { sel: '[data-phase="5"]', delay: 22000 },
         ];
-        for (const p of phases) {
-            const els = ov.querySelectorAll(p.sel);
+        this._scheduleAnnotations();
+        this._syncPanelAnnotations();
+    }
+
+    _scheduleAnnotations() {
+        this._clearAnnotationTimers();
+        if (!this._annotationOverlay || !this.guidedAnnotations || this.annotationPaused) return;
+        this._annTimers = [];
+        for (const p of this._annPhases || []) {
+            const els = this._annotationOverlay.querySelectorAll(p.sel);
             els.forEach(el => {
-                const t = setTimeout(() => el.classList.add('vis'), p.delay);
+                const t = setTimeout(() => {
+                    if (!this.annotationPaused && this.guidedAnnotations) el.classList.add('vis');
+                }, p.delay);
                 this._annTimers.push(t);
             });
+        }
+    }
+
+    _clearAnnotationTimers() {
+        this._annTimers?.forEach(t => clearTimeout(t));
+        this._annTimers = [];
+    }
+
+    _usePanelAnnotationMode() {
+        this.guidedAnnotations = false;
+        this._clearAnnotationTimers();
+        this._annotationOverlay?.querySelectorAll('.ch2-a[data-phase], .ch2-a--integration, .ch2-micro').forEach(el => {
+            el.classList.remove('vis', 'panel-vis');
+        });
+    }
+
+    _syncPanelAnnotations() {
+        const ov = this._annotationOverlay;
+        if (!ov) return;
+        ov.querySelectorAll('.ch2-a[data-phase], .ch2-a--integration, .ch2-micro').forEach(el => {
+            el.classList.remove('panel-vis');
+            if (!this.guidedAnnotations || this.annotationPaused) el.classList.remove('vis');
+        });
+
+        const integrationAnn = ov.querySelector('.ch2-a--integration');
+        integrationAnn?.classList.add('hid');
+        if (this.annotationPaused) return;
+
+        const panelId = this.panelState?.activePanelId || 'mirror';
+        const panelPhases = {
+            mirror: ['3'],
+            projection: ['4'],
+            integration: [],
+        }[panelId] || [];
+
+        for (const phase of panelPhases) {
+            ov.querySelectorAll(`[data-phase="${phase}"]`).forEach(el => el.classList.add('panel-vis'));
+        }
+
+        if (panelId === 'mirror') {
+            ov.querySelector('.ch2-micro--ego')?.classList.add('panel-vis');
+            ov.querySelector('.ch2-micro--shadow')?.classList.add('panel-vis');
+            ov.querySelector('.ch2-micro--mirror')?.classList.add('panel-vis');
+        }
+
+        if (panelId === 'integration') {
+            integrationAnn?.classList.add('vis', 'panel-vis');
+            integrationAnn?.classList.remove('hid');
         }
     }
 
@@ -879,6 +1019,9 @@ export default class ThreeShadowViz extends BaseViz {
 
         /* ── Mirror shimmer ── */
         this.mirrorPlane.material.opacity = 0.15 + Math.sin(t * 0.25) * 0.08 + this.mirrorFocus * 0.18 - this.integrationFocus * 0.08;
+        if (this.mirrorHalo) {
+            this.mirrorHalo.material.opacity = 0.05 + this.mirrorFocus * 0.11 - this.integrationFocus * 0.04;
+        }
         for (const md of this.mirrorDots) {
             md.dot.material.opacity = 0.08 + Math.sin(t * 0.6 + md.ph) * 0.1 + this.mirrorFocus * 0.1;
         }
@@ -895,6 +1038,7 @@ export default class ThreeShadowViz extends BaseViz {
             arc.line.material.opacity = projFade * 0.25;
             arc.dot.material.opacity = projFade * 0.5 * pulse;
             arc.targetGlow.material.opacity = projFade * 0.1 * pulse;
+            arc.returnLine.material.opacity = Math.max(this.projectionFocus * 0.18, this.integrationFocus * 0.24) * (0.45 + pulse * 0.55);
         }
 
         /* ── Cocoon wraps ego during projection ── */
@@ -935,9 +1079,18 @@ export default class ThreeShadowViz extends BaseViz {
             3
         );
 
+        if (this.integrationBridge) {
+            const pos = this.integrationBridge.geometry.attributes.position;
+            pos.setXYZ(0, this.egoGroup.position.x, this.egoGroup.position.y, this.egoGroup.position.z);
+            pos.setXYZ(1, 0, 0.35 + Math.sin(t * 0.7) * 0.16, 0.6);
+            pos.setXYZ(2, this.shadowGroup.position.x, this.shadowGroup.position.y, this.shadowGroup.position.z);
+            pos.needsUpdate = true;
+            this.integrationBridge.material.opacity = intPulse * 0.34;
+        }
+
         // Integration annotation sync
         const intAnn = this._annotationOverlay?.querySelector('.ch2-a--integration');
-        if (intAnn) {
+        if (intAnn && this.guidedAnnotations && !this.annotationPaused) {
             if ((integrating && intT > 0.1 && intT < 0.9) || this.integrationFocus > 0.35) {
                 intAnn.classList.add('vis');
                 intAnn.classList.remove('hid');
@@ -989,9 +1142,11 @@ export default class ThreeShadowViz extends BaseViz {
     }
 
     dispose() {
-        removeEventListener('mousemove', this._onMM);
-        this._annTimers?.forEach(t => clearTimeout(t));
+        removeEventListener('pointermove', this._onPointerMove);
+        this._clearAnnotationTimers();
         this._annotationOverlay?.remove();
+        this.bloom?.dispose();
+        this.composer?.dispose();
         this.renderer?.dispose();
         this.renderer?.forceContextLoss();
         this.scene?.traverse(o => {
@@ -1000,7 +1155,7 @@ export default class ThreeShadowViz extends BaseViz {
                 (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => m.dispose());
             }
         });
-        this.composer = null; this.scene = null;
+        this.bloom = null; this.composer = null; this.scene = null;
         this.camera = null; this.renderer = null;
         super.dispose();
     }

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -68,6 +68,16 @@ describe('Aion framework data contract', () => {
       expect(CHAPTER_SCENES[chapter.id].fallbackSummary.length).toBeGreaterThan(20);
     }
   });
+
+  test('keeps Chapter 2 shadow panels in the canonical learning sequence', () => {
+    expect(CHAPTER_SCENES.ch2.panels.map((panel) => panel.id)).toEqual([
+      'mirror',
+      'projection',
+      'integration',
+    ]);
+    expect(CHAPTER_SCENES.ch2.motionGrammar).toBe('opposition');
+    expect(CHAPTER_SCENES.ch2.fallbackSummary).toContain('projection arcs');
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- polish Chapter 2 as a visual-first shadow mirror/projection/integration scene
- add panel-synced Ch2 annotations, pause-safe timer handling, pointer input, return paths, integration bridge, and composer/bloom disposal
- add Ch2-specific reference/panel symbols and tighter reduced-motion fallback copy
- extend smoke coverage for Ch2 controls, pause behavior, reduced motion, mobile shell, Pages artifact, and nonblank canvas

## Verification
- rg -n "^<<<<<<<|^=======$|^>>>>>>>" .
- git diff --check
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- npm run test:e2e:app
- npm run test:a11y:app
- npm run build:pages && npm run test:pages:artifact
- Browser visual inspection: /journey/chapter/ch2 desktop and mobile, Projection control click, no console errors on normal preview

## Notes
- The Vite build still reports the known large Three.js chunk warning; this is unchanged backlog for the performance batch.
- A backup branch exists at backup/ch2-reference-polish-20260602-0004.
