### PR TITLE
ci: extend browser smoke timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,16 +47,16 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run app shell smoke
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: npm run test:e2e:app
 
       - name: Run app accessibility smoke
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: npm run test:a11y:app
 
       - name: Build GitHub Pages artifact
         run: npm run build:pages
 
       - name: Run Pages artifact smoke
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: npm run test:pages:artifact

--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -34,24 +34,28 @@ function startPreviewServer() {
   return { child, getOutput: () => output };
 }
 
+function terminateProcess(server, signal) {
+  const pid = server.child.pid;
+  try {
+    if (pid && process.platform !== 'win32') {
+      process.kill(-pid, signal);
+    } else {
+      server.child.kill(signal);
+    }
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
+  }
+}
+
 async function stopPreviewServer(server) {
   if (server.child.exitCode !== null) return;
 
-  const pid = server.child.pid;
-  if (pid && process.platform !== 'win32') {
-    process.kill(-pid, 'SIGTERM');
-  } else {
-    server.child.kill('SIGTERM');
-  }
+  terminateProcess(server, 'SIGTERM');
 
   await Promise.race([once(server.child, 'exit'), delay(2_000)]);
   if (server.child.exitCode !== null) return;
 
-  if (pid && process.platform !== 'win32') {
-    process.kill(-pid, 'SIGKILL');
-  } else {
-    server.child.kill('SIGKILL');
-  }
+  terminateProcess(server, 'SIGKILL');
 }
 
 async function waitForServer(server) {

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -42,24 +42,28 @@ function startPreviewServer() {
   return { child, getOutput: () => output };
 }
 
+function terminateProcess(server, signal) {
+  const pid = server.child.pid;
+  try {
+    if (pid && process.platform !== 'win32') {
+      process.kill(-pid, signal);
+    } else {
+      server.child.kill(signal);
+    }
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
+  }
+}
+
 async function stopPreviewServer(server) {
   if (server.child.exitCode !== null) return;
 
-  const pid = server.child.pid;
-  if (pid && process.platform !== 'win32') {
-    process.kill(-pid, 'SIGTERM');
-  } else {
-    server.child.kill('SIGTERM');
-  }
+  terminateProcess(server, 'SIGTERM');
 
   await Promise.race([once(server.child, 'exit'), delay(2_000)]);
   if (server.child.exitCode !== null) return;
 
-  if (pid && process.platform !== 'win32') {
-    process.kill(-pid, 'SIGKILL');
-  } else {
-    server.child.kill('SIGKILL');
-  }
+  terminateProcess(server, 'SIGKILL');
 }
 
 async function waitForServer(server) {


### PR DESCRIPTION
## Summary
- raise app shell, accessibility, and Pages artifact smoke timeout caps from 5 to 10 minutes
- fixes the post-merge main CI case where app shell smoke passed at ~5:01 but GitHub killed the step at the 5 minute cap

## Verification
- previous PR #148 quality gate passed
- main CI failure log showed: "Aion app shell smoke passed" immediately before timeout
- this PR should validate the same workflow path with the raised timeout