### PR TITLE
feat: make Atlas a concept constellation

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -178,6 +178,45 @@ async function checkRoute(page, route, failures) {
   }
 }
 
+async function checkAtlasDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/atlas`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+
+  const fieldImage = page.getByRole('img', { name: /The Ego Concept Field/ });
+  const search = page.locator('#atlas-search');
+  const chapterRail = page.locator('.atlas-constellation__chapter-rail');
+  const initialRailLabel = await chapterRail.getAttribute('aria-label');
+  const initialCheckedCount = await page.locator('.atlas-constellation__chapter[role="radio"][aria-checked="true"]').count();
+
+  if (!await fieldImage.isVisible()) failures.push('/atlas: constellation image is missing an accessible name');
+  if (initialRailLabel !== '14 chapters in view') failures.push(`/atlas: initial chapter rail label mismatch: ${initialRailLabel}`);
+  if (initialCheckedCount !== 1) failures.push(`/atlas: checked radio count mismatch: ${initialCheckedCount}`);
+
+  await search.fill('syzygy');
+  await page.waitForFunction(() => {
+    const count = document.querySelectorAll('.atlas-constellation__chapter').length;
+    return count > 0 && count < 14;
+  }, null, { timeout: 2_000 }).catch(() => {});
+
+  const filteredChapterCount = await page.locator('.atlas-constellation__chapter').count();
+  const filteredRailLabel = await chapterRail.getAttribute('aria-label');
+  const filteredRailLabelExpected = `${filteredChapterCount} chapter${filteredChapterCount === 1 ? '' : 's'} in view`;
+  const syzygyRadioVisible = await page.getByRole('radio', { name: /Select chapter 3: The Syzygy/ }).isVisible();
+  const filteredImageVisible = await page.getByRole('img', { name: /The Syzygy: Anima and Animus Concept Field/ }).isVisible();
+
+  if (filteredChapterCount <= 0 || filteredChapterCount >= 14) failures.push(`/atlas: filtered chapter count did not narrow: ${filteredChapterCount}`);
+  if (filteredRailLabel !== filteredRailLabelExpected) failures.push(`/atlas: filtered chapter rail label mismatch: ${filteredRailLabel}`);
+  if (!syzygyRadioVisible) failures.push('/atlas: filtered syzygy radio is not visible');
+  if (!filteredImageVisible) failures.push('/atlas: filtered constellation image did not update accessible name');
+
+  await search.fill('not-a-real-term');
+  await page.waitForTimeout(100);
+  const emptyRailLabel = await chapterRail.getAttribute('aria-label');
+  const emptyFieldVisible = await page.getByRole('img', { name: /Empty Atlas Field/ }).isVisible();
+  if (emptyRailLabel !== '0 chapters in view') failures.push(`/atlas: empty chapter rail label mismatch: ${emptyRailLabel}`);
+  if (!emptyFieldVisible) failures.push('/atlas: empty constellation field is missing an accessible name');
+}
+
 async function runAccessibilitySmoke() {
   const server = startPreviewServer();
   const failures = [];
@@ -191,6 +230,7 @@ async function runAccessibilitySmoke() {
     for (const route of [...canonicalRoutes, ...chapterRoutes]) {
       await checkRoute(desktop, route, failures);
     }
+    await checkAtlasDynamicAccessibility(desktop, failures);
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -200,6 +200,96 @@ async function smokeHomeVisualDetail(page, failures) {
   }
 }
 
+async function smokeAtlasVisualSearch(page, failures) {
+  await gotoAppRoute(page, '/atlas');
+
+  const search = page.locator('#atlas-search');
+  const constellation = page.locator('.atlas-constellation');
+  const stage = page.locator('.atlas-constellation__stage[role="img"]');
+  const chapters = page.locator('.atlas-constellation__chapter');
+  const chapterRail = page.locator('.atlas-constellation__chapter-rail');
+
+  await search.waitFor({ state: 'visible', timeout: 10_000 });
+
+  const constellationCount = await constellation.count();
+  const initialChapterCount = await chapters.count();
+  const initialConceptNodeCount = await page.locator('.atlas-constellation__field-node--concept').count();
+  const initialSymbolNodeCount = await page.locator('.atlas-constellation__field-node--symbol').count();
+  const initialRelationCount = await page.locator('.atlas-constellation__relation-band span').count();
+  const initialRailRole = await chapterRail.getAttribute('role');
+  const initialRailLabel = await chapterRail.getAttribute('aria-label');
+  const initiallyChecked = await page.locator('.atlas-constellation__chapter[aria-checked="true"]').count();
+
+  if (constellationCount !== 1) failures.push(`atlas constellation count mismatch: ${constellationCount}`);
+  if (!await stage.isVisible()) failures.push('atlas constellation stage is not visible');
+  if (await page.locator('.atlas-constellation__ring').count() !== 2) failures.push('atlas constellation ring count mismatch');
+  if (initialConceptNodeCount < 1) failures.push(`atlas initial concept nodes missing: ${initialConceptNodeCount}`);
+  if (initialSymbolNodeCount < 1) failures.push(`atlas initial symbol nodes missing: ${initialSymbolNodeCount}`);
+  if (initialChapterCount !== 14) failures.push(`atlas chapter rail count mismatch: ${initialChapterCount}`);
+  if (initialRelationCount < 1) failures.push(`atlas initial relation entries missing: ${initialRelationCount}`);
+  if (initialRailRole !== 'radiogroup') failures.push(`atlas chapter rail role mismatch: ${initialRailRole}`);
+  if (initialRailLabel !== '14 chapters in view') failures.push(`atlas chapter rail label mismatch: ${initialRailLabel}`);
+  if (initiallyChecked !== 1) failures.push(`atlas checked chapter count mismatch: ${initiallyChecked}`);
+
+  await search.fill('syzygy');
+  await page.waitForFunction(() => {
+    const count = document.querySelectorAll('.atlas-constellation__chapter').length;
+    return count > 0 && count < 14;
+  }, null, { timeout: 2_000 }).catch(() => {});
+
+  const searchedChapterCount = await chapters.count();
+  const searchedRailLabel = await chapterRail.getAttribute('aria-label');
+  const searchedRailLabelExpected = `${searchedChapterCount} chapter${searchedChapterCount === 1 ? '' : 's'} in view`;
+  const syzygyRadio = page.getByRole('radio', { name: /Select chapter 3: The Syzygy/ });
+  const syzygyVisible = await syzygyRadio.isVisible();
+
+  if (searchedChapterCount <= 0 || searchedChapterCount >= 14) failures.push(`atlas search did not narrow chapter results: ${searchedChapterCount}`);
+  if (searchedRailLabel !== searchedRailLabelExpected) failures.push(`atlas filtered rail label mismatch: ${searchedRailLabel}`);
+  if (!syzygyVisible) failures.push('atlas search did not expose Chapter 3 syzygy result');
+
+  await syzygyRadio.click();
+  const detailTitle = await page.locator('#atlas-selected-detail h2').textContent();
+  const selectedConceptNodeCount = await page.locator('.atlas-constellation__field-node--concept').count();
+  const selectedSymbolNodeCount = await page.locator('.atlas-constellation__field-node--symbol').count();
+  const selectedRelationCount = await page.locator('.atlas-constellation__relation-band span').count();
+  const syzygyChecked = await syzygyRadio.getAttribute('aria-checked');
+  const scrollYAfterSelect = await page.evaluate(() => window.scrollY);
+
+  if (!detailTitle?.includes('The Syzygy')) failures.push(`atlas detail did not follow selected search result: ${detailTitle}`);
+  if (selectedConceptNodeCount < 1) failures.push(`atlas selected concept nodes missing: ${selectedConceptNodeCount}`);
+  if (selectedSymbolNodeCount < 1) failures.push(`atlas selected symbol nodes missing: ${selectedSymbolNodeCount}`);
+  if (selectedRelationCount < 1) failures.push(`atlas selected relation entries missing: ${selectedRelationCount}`);
+  if (syzygyChecked !== 'true') failures.push(`atlas selected radio did not become checked: ${syzygyChecked}`);
+  if (scrollYAfterSelect > 10) failures.push(`atlas chapter selection unexpectedly scrolled page: ${scrollYAfterSelect}`);
+
+  await search.fill('Relational Psyche');
+  await page.waitForFunction(() => document.querySelectorAll('.atlas-constellation__chapter').length === 1, null, { timeout: 2_000 }).catch(() => {});
+  const relationalChapterCount = await chapters.count();
+  const relationalRadio = page.getByRole('radio', { name: /Select chapter 3: The Syzygy/ });
+  if (relationalChapterCount !== 1) failures.push(`atlas cluster search did not filter to one chapter: ${relationalChapterCount}`);
+
+  await relationalRadio.press('ArrowLeft');
+  await page.waitForTimeout(100);
+  const arrowSelectedTitle = await page.locator('#atlas-selected-detail h2').textContent();
+  if (!arrowSelectedTitle?.includes('The Syzygy')) failures.push(`atlas one-result arrow navigation changed selection: ${arrowSelectedTitle}`);
+
+  await search.fill('not-a-real-term');
+  await page.waitForTimeout(100);
+  const emptyChapterCount = await chapters.count();
+  const emptyVisible = await page.locator('.atlas-constellation__empty').isVisible();
+  const emptyDetailTitle = await page.locator('#atlas-selected-detail h2').textContent();
+  const emptyRailLabel = await chapterRail.getAttribute('aria-label');
+  const emptyFieldNodeCount = await page.locator('.atlas-constellation__field-node').count();
+  const emptyImageVisible = await page.getByRole('img', { name: /Empty Atlas Field/ }).isVisible();
+
+  if (emptyChapterCount !== 0) failures.push(`atlas empty search still rendered chapter buttons: ${emptyChapterCount}`);
+  if (!emptyVisible) failures.push('atlas empty search message is not visible');
+  if (!emptyDetailTitle?.includes('Nothing in the field')) failures.push(`atlas empty detail did not render: ${emptyDetailTitle}`);
+  if (emptyRailLabel !== '0 chapters in view') failures.push(`atlas empty rail label mismatch: ${emptyRailLabel}`);
+  if (emptyFieldNodeCount !== 0) failures.push(`atlas empty field still rendered nodes: ${emptyFieldNodeCount}`);
+  if (!emptyImageVisible) failures.push('atlas empty field did not expose empty accessible name');
+}
+
 async function smokeChapterRoutes(page, failures) {
   for (const route of chapterRoutes) {
     await gotoAppRoute(page, route);
@@ -249,6 +339,12 @@ async function smokeReducedMotion(browser, failures) {
   if (animatedHomeCanvasCount !== 0) failures.push(`reduced-motion home rendered animated canvas: ${animatedHomeCanvasCount}`);
   if (navTransitionProperty !== 'none') failures.push(`reduced-motion nav transition remains active: ${navTransitionProperty}`);
   if (pathTransitionProperty !== 'none') failures.push(`reduced-motion path transition remains active: ${pathTransitionProperty}`);
+
+  await gotoAppRoute(page, '/atlas');
+  const atlasChapterTransitionProperty = await page.locator('.atlas-constellation__chapter').first().evaluate((element) => window.getComputedStyle(element).transitionProperty);
+  const atlasCoreAnimationName = await page.locator('.atlas-constellation__core-glow').evaluate((element) => window.getComputedStyle(element).animationName);
+  if (atlasChapterTransitionProperty !== 'none') failures.push(`reduced-motion atlas chapter transition remains active: ${atlasChapterTransitionProperty}`);
+  if (atlasCoreAnimationName !== 'none') failures.push(`reduced-motion atlas core animation remains active: ${atlasCoreAnimationName}`);
 
   await gotoAppRoute(page, '/journey/chapter/ch1');
   await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
@@ -737,6 +833,7 @@ async function runSmoke() {
 
     await smokeCanonicalRoutes(page, failures);
     await smokeHomeVisualDetail(page, failures);
+    await smokeAtlasVisualSearch(page, failures);
     await smokeChapterRoutes(page, failures);
     await smokeKeyboard(page, failures);
     await smokeLegacyRedirect(page, failures);

--- a/src/app/components/AtlasConstellation.tsx
+++ b/src/app/components/AtlasConstellation.tsx
@@ -1,0 +1,182 @@
+import type { KeyboardEvent } from 'react';
+
+import type { ChapterRecord, ConceptRecord, RelationshipRecord, SymbolRecord } from '../types';
+
+interface AtlasConstellationProps {
+  active: ChapterRecord | null;
+  activeConcepts: ConceptRecord[];
+  filteredChapters: ChapterRecord[];
+  linkedRelationships: RelationshipRecord[];
+  linkedSymbols: SymbolRecord[];
+  entityLabel: (id: string) => string;
+  onSelectChapter: (id: ChapterRecord['id']) => void;
+}
+
+interface FieldNode {
+  id: string;
+  label: string;
+  type: 'concept' | 'symbol';
+  x: number;
+  y: number;
+}
+
+const center = { x: 470, y: 300 };
+
+function trimNodeLabel(label: string) {
+  return label.length > 18 ? `${label.slice(0, 16)}…` : label;
+}
+
+function placeNodes<T extends { id: string; label: string }>(items: T[], radius: number, type: FieldNode['type'], angleOffset: number): FieldNode[] {
+  const count = Math.max(items.length, 1);
+  return items.map((item, index) => {
+    const angle = angleOffset + (index / count) * Math.PI * 2;
+    return {
+      id: item.id,
+      label: item.label,
+      type,
+      x: center.x + Math.cos(angle) * radius,
+      y: center.y + Math.sin(angle) * radius,
+    };
+  });
+}
+
+export default function AtlasConstellation({
+  active,
+  activeConcepts,
+  filteredChapters,
+  linkedRelationships,
+  linkedSymbols,
+  entityLabel,
+  onSelectChapter,
+}: AtlasConstellationProps) {
+  const conceptNodes = placeNodes(activeConcepts.slice(0, 6), 152, 'concept', -Math.PI / 2.1);
+  const symbolNodes = placeNodes(linkedSymbols.slice(0, 5), 238, 'symbol', -Math.PI / 1.18);
+  const fieldNodes = [...conceptNodes, ...symbolNodes];
+  const chapterResultText = `${filteredChapters.length} chapter${filteredChapters.length === 1 ? '' : 's'} in view`;
+  const conceptLabels = activeConcepts.map((concept) => concept.label).join(', ');
+  const symbolLabels = linkedSymbols.map((symbol) => symbol.label).join(', ');
+  const fieldTitle = active ? `${active.title} Concept Field` : 'Empty Atlas Field';
+  const fieldDescription = active
+    ? `The active chapter sits at the center. Inner concepts: ${conceptLabels || 'none curated yet'}. Outer symbols: ${symbolLabels || 'none curated yet'}.`
+    : 'No chapters match the current search, so the constellation is empty.';
+
+  const focusChapterButton = (chapterId: string) => {
+    window.requestAnimationFrame(() => {
+      document.querySelector<HTMLButtonElement>(`[data-atlas-chapter-id="${chapterId}"]`)?.focus();
+    });
+  };
+
+  const handleChapterKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (filteredChapters.length === 0) return;
+
+    const keyToIndex: Record<string, number> = {
+      ArrowRight: (index + 1) % filteredChapters.length,
+      ArrowDown: (index + 1) % filteredChapters.length,
+      ArrowLeft: (index - 1 + filteredChapters.length) % filteredChapters.length,
+      ArrowUp: (index - 1 + filteredChapters.length) % filteredChapters.length,
+      Home: 0,
+      End: filteredChapters.length - 1,
+    };
+    const nextIndex = keyToIndex[event.key];
+    if (nextIndex === undefined) return;
+
+    event.preventDefault();
+    const nextChapter = filteredChapters[nextIndex];
+    onSelectChapter(nextChapter.id);
+    focusChapterButton(nextChapter.id);
+  };
+
+  return (
+    <div className="atlas-constellation" aria-label={active ? `${active.title} concept constellation` : 'Empty Atlas constellation'}>
+      <div className="atlas-constellation__stage" role="img" aria-labelledby="atlas-field-title atlas-field-desc">
+        <svg viewBox="120 20 760 580" aria-hidden="true" focusable="false">
+          <defs>
+            <radialGradient id="atlas-field-core" cx="50%" cy="50%" r="50%">
+              <stop offset="0%" stopColor="#fff4c2" stopOpacity="0.9" />
+              <stop offset="52%" stopColor="#d4af37" stopOpacity="0.28" />
+              <stop offset="100%" stopColor="#050508" stopOpacity="0" />
+            </radialGradient>
+          </defs>
+          <path className="atlas-constellation__grid-line" d="M 96 300 H 844" />
+          <path className="atlas-constellation__grid-line atlas-constellation__grid-line--vertical" d="M 470 70 V 530" />
+          <circle className="atlas-constellation__ring atlas-constellation__ring--outer" cx={center.x} cy={center.y} r="238" />
+          <circle className="atlas-constellation__ring atlas-constellation__ring--inner" cx={center.x} cy={center.y} r="152" />
+          <circle className="atlas-constellation__core-glow" cx={center.x} cy={center.y} r="118" fill="url(#atlas-field-core)" />
+
+          {fieldNodes.map((node) => (
+            <path key={`${node.id}-thread`} className={`atlas-constellation__thread atlas-constellation__thread--${node.type}`} d={`M ${center.x} ${center.y} Q ${(center.x + node.x) / 2} ${node.y - 26}, ${node.x} ${node.y}`} />
+          ))}
+
+          {fieldNodes.map((node) => (
+            <g key={node.id} className={`atlas-constellation__field-node atlas-constellation__field-node--${node.type}`} transform={`translate(${node.x} ${node.y})`}>
+              <title>{node.label}</title>
+              <circle r={node.type === 'symbol' ? 26 : 22} />
+              <text textAnchor="middle" y={node.type === 'symbol' ? 47 : 42}>{trimNodeLabel(node.label)}</text>
+            </g>
+          ))}
+
+          {active ? (
+            <g className="atlas-constellation__center" transform={`translate(${center.x} ${center.y})`}>
+              <circle r="72" />
+              <text className="atlas-constellation__center-order" textAnchor="middle" y="-8">{String(active.order).padStart(2, '0')}</text>
+              <text className="atlas-constellation__center-label" textAnchor="middle" y="22">{active.cluster}</text>
+            </g>
+          ) : (
+            <g className="atlas-constellation__center atlas-constellation__center--empty" transform={`translate(${center.x} ${center.y})`}>
+              <circle r="72" />
+              <text className="atlas-constellation__center-order" textAnchor="middle" y="-8">0</text>
+              <text className="atlas-constellation__center-label" textAnchor="middle" y="22">No match</text>
+            </g>
+          )}
+        </svg>
+
+        <div className="sr-only">
+          <h2 id="atlas-field-title">{fieldTitle}</h2>
+          <p id="atlas-field-desc">{fieldDescription}</p>
+        </div>
+      </div>
+
+      <div className="atlas-constellation__chapter-rail" role="radiogroup" aria-label={chapterResultText}>
+        {filteredChapters.length > 0 ? (
+          filteredChapters.map((chapter, index) => (
+            <button
+              key={chapter.id}
+              type="button"
+              role="radio"
+              className={chapter.id === active?.id ? 'atlas-constellation__chapter atlas-constellation__chapter--active' : 'atlas-constellation__chapter'}
+              data-atlas-chapter-id={chapter.id}
+              onClick={() => onSelectChapter(chapter.id)}
+              onKeyDown={(event) => handleChapterKeyDown(event, index)}
+              aria-controls="atlas-selected-detail"
+              aria-label={`Select chapter ${chapter.order}: ${chapter.title}`}
+              aria-checked={chapter.id === active?.id}
+              tabIndex={chapter.id === active?.id ? 0 : -1}
+            >
+              <span>{String(chapter.order).padStart(2, '0')}</span>
+              <strong>{chapter.title}</strong>
+              <em>{chapter.cluster}</em>
+            </button>
+          ))
+        ) : (
+          <p className="atlas-constellation__empty">No chapters match this search.</p>
+        )}
+      </div>
+
+      <div className="atlas-constellation__relation-band" aria-label="Strongest visible relationships">
+        {filteredChapters.length === 0 ? (
+          <span>No matching chapter is currently in view.</span>
+        ) : linkedRelationships.length > 0 ? (
+          linkedRelationships.map((relationship) => (
+            <span key={relationship.id}>
+              <strong>{entityLabel(relationship.source)}</strong>
+              <em>{relationship.relationType.replaceAll('_', ' ')}</em>
+              <strong>{entityLabel(relationship.target)}</strong>
+            </span>
+          ))
+        ) : (
+          <span>No direct relationships are curated for this selection yet.</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/pages/AtlasPage.tsx
+++ b/src/app/pages/AtlasPage.tsx
@@ -1,15 +1,18 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 
+import AtlasConstellation from '../components/AtlasConstellation';
 import ChapterSigil from '../components/ChapterSigil';
 import {
   getChapterRoute,
   getChapters,
   getConcepts,
   getConceptsForChapter,
+  getLearningObjectsForChapter,
   getRelationships,
   getSymbols,
 } from '../data/aionData';
+import type { ChapterRecord } from '../types';
 
 export default function AtlasPage() {
   const chapters = getChapters();
@@ -17,105 +20,172 @@ export default function AtlasPage() {
   const symbols = getSymbols();
   const relationships = getRelationships();
   const [query, setQuery] = useState('');
-  const [selected, setSelected] = useState(chapters[0].id);
+  const [selected, setSelected] = useState<ChapterRecord['id']>(chapters[0].id);
+
+  const entityLabel = useMemo(() => (id: string) => (
+    concepts.find((concept) => concept.id === id)?.label
+    || symbols.find((symbol) => symbol.id === id)?.label
+    || chapters.find((chapter) => chapter.id === id)?.title
+    || id
+  ), [chapters, concepts, symbols]);
+
+  const getChapterSearchText = (chapter: ChapterRecord) => {
+    const chapterConcepts = getConceptsForChapter(chapter.id);
+    const chapterSymbols = symbols.filter((symbol) => symbol.conceptIds.some((id) => chapter.keyConceptIds.includes(id)));
+    const chapterEntityIds = new Set([
+      chapter.id,
+      ...chapter.keyConceptIds,
+      ...chapter.relatedChapterIds,
+      ...chapterSymbols.map((symbol) => symbol.id),
+    ]);
+    const chapterRelationships = relationships.filter((relationship) => (
+      chapterEntityIds.has(relationship.source) || chapterEntityIds.has(relationship.target)
+    ));
+    const learningObjects = getLearningObjectsForChapter(chapter.id);
+    const relatedChapterTitles = chapter.relatedChapterIds
+      .map((id) => chapters.find((item) => item.id === id)?.title)
+      .filter(Boolean);
+
+    return [
+      chapter.order,
+      chapter.title,
+      chapter.summary,
+      chapter.cluster,
+      ...relatedChapterTitles,
+      ...chapterConcepts.flatMap((concept) => [
+        concept.label,
+        concept.definition,
+        concept.difficulty,
+        ...concept.prerequisites.map(entityLabel),
+      ]),
+      ...chapterSymbols.flatMap((symbol) => [symbol.label, symbol.motif, symbol.historicPeriod]),
+      ...chapterRelationships.flatMap((relationship) => [
+        entityLabel(relationship.source),
+        entityLabel(relationship.target),
+        relationship.relationType.replaceAll('_', ' '),
+        relationship.narrativeNotes,
+      ]),
+      ...learningObjects.flatMap((item) => [item.title, item.prompt, item.type]),
+    ].join(' ');
+  };
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return chapters;
-    return chapters.filter((chapter) => {
-      const conceptText = getConceptsForChapter(chapter.id).map((concept) => concept.label).join(' ');
-      return `${chapter.title} ${chapter.summary} ${chapter.cluster} ${conceptText}`.toLowerCase().includes(q);
-    });
+    return chapters.filter((chapter) => getChapterSearchText(chapter).toLowerCase().includes(q));
   }, [chapters, query]);
 
-  const active = chapters.find((chapter) => chapter.id === selected) || chapters[0];
-  const activeConcepts = getConceptsForChapter(active.id);
-  const linkedSymbols = symbols.filter((symbol) => symbol.conceptIds.some((id) => active.keyConceptIds.includes(id)));
+  const hasNoSearchMatches = query.trim().length > 0 && filtered.length === 0;
+
+  useEffect(() => {
+    if (hasNoSearchMatches || filtered.some((chapter) => chapter.id === selected)) return;
+    setSelected(filtered[0].id);
+  }, [filtered, hasNoSearchMatches, selected]);
+
+  const selectedChapter = chapters.find((chapter) => chapter.id === selected) || chapters[0];
+  const active = hasNoSearchMatches
+    ? null
+    : filtered.find((chapter) => chapter.id === selected) || (query.trim() ? filtered[0] : null) || selectedChapter;
+  const detailChapter = active || selectedChapter;
+  const activeConcepts = active ? getConceptsForChapter(active.id) : [];
+  const linkedSymbols = active ? symbols.filter((symbol) => symbol.conceptIds.some((id) => active.keyConceptIds.includes(id))) : [];
   const relationshipEntityIds = new Set([
-    active.id,
-    ...active.keyConceptIds,
+    ...(active ? [active.id] : []),
+    ...(active?.keyConceptIds || []),
     ...linkedSymbols.map((symbol) => symbol.id),
   ]);
   const linkedRelationships = relationships
     .filter((rel) => relationshipEntityIds.has(rel.source) || relationshipEntityIds.has(rel.target))
     .sort((a, b) => b.weight - a.weight)
     .slice(0, 4);
-  const entityLabel = (id: string) => (
-    concepts.find((concept) => concept.id === id)?.label
-    || symbols.find((symbol) => symbol.id === id)?.label
-    || chapters.find((chapter) => chapter.id === id)?.title
-    || id
-  );
+  const chapterResultText = `${filtered.length} chapter${filtered.length === 1 ? '' : 's'} in view`;
 
   return (
     <div className="page">
-      <section className="atlas-hero section-band">
+      <section className="atlas-hero section-band" aria-labelledby="atlas-title">
         <div className="atlas-hero__copy">
           <p className="eyebrow">Atlas</p>
-          <h1>Chapter, concept, and symbol field</h1>
-          <p className="lede">The missing Atlas becomes the canonical navigation map, joining the old Explore graph with Aion core data.</p>
+          <h1 id="atlas-title">Chapter, concept, and symbol field</h1>
+          <p className="lede">Search the symbolic field. Each selection redraws the chapter at the center, its concepts on the inner ring, and its symbols at the perimeter.</p>
         </div>
 
         <div className="atlas-layout atlas-layout--hero">
-          <div className="atlas-map" aria-label="Aion chapter map">
+          <section className="atlas-map" aria-labelledby="atlas-map-title">
             <div className="atlas-map__controls">
-              <label htmlFor="atlas-search">Search</label>
+              <div>
+                <p className="eyebrow">Field Filter</p>
+                <h2 id="atlas-map-title">Living Atlas Field</h2>
+              </div>
               <input
                 id="atlas-search"
+                name="atlas-search"
+                type="search"
+                autoComplete="off"
+                aria-label="Search Atlas field"
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                placeholder="shadow, fish, quaternity"
+                aria-describedby="atlas-search-status"
+                placeholder="shadow, fish, quaternity…"
               />
+              <output id="atlas-search-status" role="status" aria-live="polite">{chapterResultText}</output>
             </div>
-            <div className="atlas-orbit">
-              {filtered.map((chapter) => (
-                <button
-                  key={chapter.id}
-                  className={chapter.id === selected ? 'atlas-node atlas-node--active' : 'atlas-node'}
-                  type="button"
-                  onClick={() => setSelected(chapter.id)}
-                  style={{ ['--node-index' as string]: chapter.order - 1, ['--node-count' as string]: filtered.length }}
-                  aria-controls="atlas-selected-detail"
-                  aria-label={`Select chapter ${chapter.order}: ${chapter.title}`}
-                  aria-pressed={chapter.id === selected}
-                >
-                  {chapter.order}
-                </button>
-              ))}
-            </div>
-          </div>
+            <AtlasConstellation
+              active={active}
+              activeConcepts={activeConcepts}
+              filteredChapters={filtered}
+              linkedRelationships={linkedRelationships}
+              linkedSymbols={linkedSymbols}
+              entityLabel={entityLabel}
+              onSelectChapter={setSelected}
+            />
+          </section>
 
           <aside id="atlas-selected-detail" className="atlas-detail" aria-label="Selected atlas chapter" aria-live="polite">
-            <ChapterSigil chapter={active} compact />
-            <p className="eyebrow">Chapter {active.order}</p>
-            <h2>{active.title}</h2>
-            <p>{active.summary}</p>
-            <div className="chip-row">
-              {activeConcepts.map((concept) => (
-                <span key={concept.id}>{concept.label}</span>
-              ))}
-            </div>
-            <div className="atlas-detail__section">
-              <h3>Symbols</h3>
-              <p>{linkedSymbols.map((symbol) => symbol.label).join(' · ') || 'No direct symbol links yet.'}</p>
-            </div>
-            <div className="atlas-detail__section">
-              <h3>Relations</h3>
-              {linkedRelationships.length > 0 ? (
-                <div className="relation-stack">
-                  {linkedRelationships.map((rel) => (
-                    <span key={rel.id}>
-                      {entityLabel(rel.source)} <em>{rel.relationType.replaceAll('_', ' ')}</em> {entityLabel(rel.target)}
-                    </span>
+            {hasNoSearchMatches ? (
+              <div className="atlas-detail__empty">
+                <p className="eyebrow">No Match</p>
+                <h2>Nothing in the field</h2>
+                <p>Try a chapter, concept, symbol, relation, or learning prompt such as shadow, fish, coniunctio, or mandala.</p>
+                <button className="button button--primary" type="button" onClick={() => setQuery('')}>
+                  Clear Search
+                </button>
+              </div>
+            ) : (
+              <>
+                <ChapterSigil chapter={detailChapter} compact />
+                <p className="eyebrow">Chapter {detailChapter.order}</p>
+                <h2>{detailChapter.title}</h2>
+                <p>{detailChapter.summary}</p>
+                <div className="chip-row">
+                  {activeConcepts.map((concept) => (
+                    <button key={concept.id} type="button" onClick={() => setQuery(concept.label)} aria-label={`Filter Atlas by ${concept.label}`}>
+                      {concept.label}
+                    </button>
                   ))}
                 </div>
-              ) : (
-                <p>Direct relationships are still being curated for this chapter.</p>
-              )}
-            </div>
-            <Link className="button button--primary" to={getChapterRoute(active.id)}>
-              Open chapter
-            </Link>
+                <div className="atlas-detail__section">
+                  <h3>Symbols</h3>
+                  <p>{linkedSymbols.map((symbol) => symbol.label).join(' · ') || 'No direct symbol links yet.'}</p>
+                </div>
+                <div className="atlas-detail__section">
+                  <h3>Relations</h3>
+                  {linkedRelationships.length > 0 ? (
+                    <div className="relation-stack">
+                      {linkedRelationships.map((rel) => (
+                        <span key={rel.id}>
+                          {entityLabel(rel.source)} <em>{rel.relationType.replaceAll('_', ' ')}</em> {entityLabel(rel.target)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p>Direct relationships are still being curated for this chapter.</p>
+                  )}
+                </div>
+                <Link className="button button--primary" to={getChapterRoute(detailChapter.id)}>
+                  Open chapter
+                </Link>
+              </>
+            )}
           </aside>
         </div>
       </section>
@@ -127,7 +197,9 @@ export default function AtlasPage() {
         </div>
         <div className="concept-cloud">
           {concepts.map((concept) => (
-            <span key={concept.id}>{concept.label}</span>
+            <button key={concept.id} type="button" onClick={() => setQuery(concept.label)} aria-label={`Filter Atlas by ${concept.label}`}>
+              {concept.label}
+            </button>
           ))}
         </div>
       </section>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1575,9 +1575,13 @@ h3 {
 }
 
 .chip-row span,
-.concept-cloud span {
+.chip-row button,
+.concept-cloud span,
+.concept-cloud button {
+  min-height: 2rem;
   border: 1px solid var(--line);
   border-radius: 999px;
+  background: rgba(255, 255, 255, 0.025);
   color: var(--muted);
   font-family: var(--font-ui);
   padding: 0.32rem 0.58rem;
@@ -1588,11 +1592,18 @@ h3 {
     transform 0.38s var(--motion-spring);
 }
 
-.chip-row span:hover,
-.concept-cloud span:hover {
+.chip-row button:hover,
+.chip-row button:focus-visible,
+.concept-cloud button:hover,
+.concept-cloud button:focus-visible {
   border-color: rgba(212, 175, 55, 0.28);
   color: var(--text);
   transform: translateY(-1px);
+}
+
+.chip-row button,
+.concept-cloud button {
+  cursor: pointer;
 }
 
 .atlas-layout,
@@ -1607,19 +1618,20 @@ h3 {
 .atlas-hero {
   min-height: 100dvh;
   display: grid;
-  grid-template-columns: minmax(0, 0.86fr) minmax(36rem, 1.14fr);
+  grid-template-columns: minmax(16rem, 0.58fr) minmax(0, 1.42fr);
   align-items: center;
   gap: clamp(1.5rem, 4vw, 4rem);
   padding-top: 7rem;
 }
 
 .atlas-hero__copy h1 {
-  max-width: 10ch;
-  font-size: clamp(4rem, 9vw, 8rem);
+  max-width: 11ch;
+  font-size: clamp(3.6rem, 8vw, 7rem);
+  text-wrap: balance;
 }
 
 .atlas-layout--hero {
-  grid-template-columns: minmax(0, 1.15fr) minmax(15rem, 0.85fr);
+  grid-template-columns: minmax(0, 1.34fr) minmax(16.5rem, 0.66fr);
   width: 100%;
 }
 
@@ -1629,21 +1641,73 @@ h3 {
 .chapter-knowledge__block {
   border: 1px solid var(--line);
   border-radius: var(--radius);
-  background: var(--surface-machined);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.018)),
+    rgba(5, 5, 8, 0.72);
   box-shadow: var(--shadow-inset);
   padding: 1.2rem;
 }
 
 .atlas-map {
-  min-height: min(66vh, 38rem);
+  min-height: min(72vh, 45rem);
   position: relative;
   overflow: hidden;
+  box-shadow:
+    var(--shadow-inset),
+    0 2rem 6rem rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(20px) saturate(120%);
+}
+
+.atlas-map::before {
+  content: '';
+  position: absolute;
+  inset: 1rem;
+  border: 1px solid rgba(212, 175, 55, 0.11);
+  pointer-events: none;
+}
+
+.atlas-map::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.18;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, rgba(255, 255, 255, 0.08) 1px, transparent 1px),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+  background-size: 4.4rem 4.4rem;
+  mask-image: radial-gradient(circle at 54% 54%, black 0 42%, transparent 78%);
 }
 
 .atlas-map__controls {
-  display: flex;
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: minmax(10rem, 0.8fr) minmax(12rem, 1fr);
   gap: 0.7rem;
-  align-items: center;
+  align-items: end;
+  margin-bottom: 0.65rem;
+}
+
+.atlas-map__controls h2 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.2vw, 2.1rem);
+  text-wrap: balance;
+}
+
+.atlas-map__controls output {
+  grid-column: 1 / -1;
+  justify-self: start;
+  min-height: 2.5rem;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid rgba(83, 216, 232, 0.24);
+  border-radius: 999px;
+  color: var(--ink-cyan);
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  padding: 0.46rem 0.75rem;
+  white-space: nowrap;
 }
 
 .atlas-map input,
@@ -1657,47 +1721,257 @@ h3 {
   padding: 0.5rem 0.75rem;
 }
 
-.atlas-orbit {
-  --node-count: 14;
-  --orbit-radius: min(13vw, 7.6rem);
-  position: absolute;
-  left: 50%;
-  top: 54%;
-  width: min(calc(100% - 5rem), 25rem);
-  aspect-ratio: 1;
-  border: 1px solid rgba(212, 175, 55, 0.14);
-  border-radius: 50%;
-  box-shadow: inset 0 0 5rem rgba(212, 175, 55, 0.04);
-  transform: translate(-50%, -50%);
+.atlas-constellation {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 0.85rem;
 }
 
-.atlas-node {
-  --angle: calc((360deg / var(--node-count)) * var(--node-index));
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 2.5rem;
-  height: 2.5rem;
-  border: 1px solid var(--line);
-  border-radius: 50%;
-  background: #06060b;
+.atlas-constellation__stage {
+  min-height: clamp(24rem, 52vw, 36rem);
+  border-top: 1px solid rgba(212, 175, 55, 0.11);
+  border-bottom: 1px solid rgba(212, 175, 55, 0.11);
+  position: relative;
+  overflow: hidden;
+}
+
+.atlas-constellation__stage svg {
+  width: 100%;
+  height: 100%;
+  min-height: inherit;
+  display: block;
+}
+
+.atlas-constellation__grid-line,
+.atlas-constellation__ring {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.11);
+  stroke-width: 1;
+}
+
+.atlas-constellation__grid-line--vertical {
+  stroke: rgba(83, 216, 232, 0.1);
+}
+
+.atlas-constellation__ring--inner {
+  stroke: rgba(212, 175, 55, 0.35);
+  stroke-dasharray: 2 10;
+}
+
+.atlas-constellation__ring--outer {
+  stroke: rgba(83, 216, 232, 0.23);
+  stroke-dasharray: 1 13;
+}
+
+.atlas-constellation__core-glow {
+  animation: atlas-core-breathe 7.5s ease-in-out infinite;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.atlas-constellation__thread {
+  fill: none;
+  stroke-width: 1.4;
+  opacity: 0.72;
+}
+
+.atlas-constellation__thread--concept {
+  stroke: rgba(212, 175, 55, 0.42);
+}
+
+.atlas-constellation__thread--symbol {
+  stroke: rgba(83, 216, 232, 0.34);
+}
+
+.atlas-constellation__field-node circle,
+.atlas-constellation__center circle {
+  stroke-width: 1.1;
+  filter: drop-shadow(0 1rem 1.2rem rgba(0, 0, 0, 0.36));
+}
+
+.atlas-constellation__field-node--concept circle {
+  fill: rgba(212, 175, 55, 0.11);
+  stroke: rgba(255, 227, 156, 0.72);
+}
+
+.atlas-constellation__field-node--symbol circle {
+  fill: rgba(83, 216, 232, 0.09);
+  stroke: rgba(143, 231, 237, 0.68);
+}
+
+.atlas-constellation__field-node text {
+  fill: var(--text);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  paint-order: stroke;
+  stroke: #050508;
+  stroke-linejoin: round;
+  stroke-width: 4px;
+}
+
+.atlas-constellation__center circle {
+  fill: rgba(5, 5, 8, 0.74);
+  stroke: rgba(212, 175, 55, 0.76);
+}
+
+.atlas-constellation__center--empty circle {
+  fill: rgba(5, 5, 8, 0.58);
+  stroke: rgba(255, 255, 255, 0.2);
+}
+
+.atlas-constellation__center-order {
+  fill: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: 34px;
+  font-variant-numeric: tabular-nums;
+}
+
+.atlas-constellation__center-label {
+  fill: var(--muted);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.atlas-constellation__chapter-rail {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(12rem, 1fr);
+  gap: 0.55rem;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  padding: 0.2rem 0.1rem 0.45rem;
+  scrollbar-width: none;
+}
+
+.atlas-constellation__chapter-rail::-webkit-scrollbar {
+  display: none;
+}
+
+.atlas-constellation__chapter,
+.atlas-constellation__empty {
+  min-height: 5.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.035);
   color: var(--text);
-  cursor: pointer;
-  transform: rotate(var(--angle)) translateX(var(--orbit-radius)) rotate(calc(-1 * var(--angle)));
-  transition:
-    transform 0.45s var(--motion-spring),
-    border-color 0.45s var(--motion-spring),
-    background 0.45s var(--motion-spring);
+  display: grid;
+  gap: 0.1rem;
+  justify-items: start;
+  padding: 0.72rem;
 }
 
-.atlas-node--active {
-  background: var(--gold);
-  border-color: var(--gold);
-  color: #050508;
+.atlas-constellation__chapter {
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.38s var(--motion-spring),
+    border-color 0.38s var(--motion-spring),
+    transform 0.38s var(--motion-spring);
+}
+
+.atlas-constellation__chapter:hover,
+.atlas-constellation__chapter:focus-visible {
+  border-color: rgba(212, 175, 55, 0.35);
+  transform: translateY(-1px);
+}
+
+.atlas-constellation__chapter--active {
+  border-color: rgba(212, 175, 55, 0.74);
+  background: linear-gradient(145deg, rgba(212, 175, 55, 0.18), rgba(83, 216, 232, 0.055));
+}
+
+.atlas-constellation__chapter span {
+  color: var(--gold-soft);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.atlas-constellation__chapter strong {
+  font-family: var(--font-display);
+  font-size: 1.02rem;
+  font-weight: 550;
+  line-height: 1.05;
+}
+
+.atlas-constellation__chapter em {
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.68rem;
+  font-style: normal;
+  text-transform: uppercase;
+}
+
+.atlas-constellation__relation-band {
+  display: flex;
+  gap: 0.45rem;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+}
+
+.atlas-constellation__relation-band::-webkit-scrollbar {
+  display: none;
+}
+
+.atlas-constellation__relation-band span {
+  flex: 0 0 min(21rem, 82vw);
+  min-height: 3.1rem;
+  border: 1px solid rgba(83, 216, 232, 0.15);
+  border-radius: var(--radius);
+  background: rgba(83, 216, 232, 0.035);
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.58rem 0.7rem;
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+}
+
+.atlas-constellation__relation-band strong {
+  color: var(--text);
+  font-weight: 520;
+}
+
+.atlas-constellation__relation-band em {
+  color: var(--gold-soft);
+  font-style: normal;
+  white-space: nowrap;
 }
 
 .concept-cloud {
   max-width: 58rem;
+}
+
+.atlas-detail {
+  min-height: 100%;
+  display: grid;
+  align-content: start;
+  gap: 0.9rem;
+}
+
+.atlas-detail .chapter-sigil {
+  justify-self: start;
+}
+
+.atlas-detail h2 {
+  margin-block: -0.35rem 0;
+  font-size: clamp(1.7rem, 3vw, 2.6rem);
+  text-wrap: balance;
+}
+
+.atlas-detail__empty {
+  display: grid;
+  gap: 0.8rem;
+  align-content: center;
+  min-height: 23rem;
+}
+
+.atlas-detail__empty h2 {
+  max-width: 10ch;
 }
 
 .relation-stack {
@@ -2811,6 +3085,19 @@ h3 {
   font-size: 1.8rem;
 }
 
+@keyframes atlas-core-breathe {
+  0%,
+  100% {
+    opacity: 0.7;
+    transform: scale(0.95);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.04);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
@@ -2819,6 +3106,9 @@ h3 {
   .button:hover,
 	  .chapter-card:hover,
 	  .path-panel:hover,
+  .chip-row button:hover,
+  .concept-cloud button:hover,
+  .atlas-constellation__chapter:hover,
 	  .chapter-preview:hover,
 	  .chapter-stage__reference-node:hover,
 	  .scene-host__pause:hover,
@@ -2838,6 +3128,9 @@ h3 {
   .chapter-jump__sequence a,
   .path-panel,
   .chapter-preview,
+  .chip-row button,
+  .concept-cloud button,
+  .atlas-constellation__chapter,
 	  .chapter-card,
 		  .home-narrative__legend-item a,
 		  .chapter-panel,
@@ -2848,7 +3141,36 @@ h3 {
 	  .scene-host__pause {
 	    transition: none;
 	  }
+
+  .atlas-constellation__core-glow {
+    animation: none;
+  }
 	}
+
+@media (max-width: 1120px) {
+  .atlas-hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+    padding-top: 9rem;
+  }
+
+  .atlas-hero__copy h1 {
+    max-width: 11ch;
+    font-size: clamp(4rem, 10vw, 6.4rem);
+  }
+
+  .atlas-hero__copy .lede {
+    max-width: 33rem;
+  }
+
+  .atlas-layout--hero {
+    grid-template-columns: 1fr;
+  }
+
+  .atlas-map {
+    min-height: 40rem;
+  }
+}
 
 @media (max-width: 860px) {
   .app-nav {
@@ -3016,7 +3338,7 @@ h3 {
 
   .atlas-hero {
     display: grid;
-    padding-top: 7rem;
+    padding-top: 11.5rem;
   }
 
   .atlas-layout--hero {
@@ -3024,13 +3346,28 @@ h3 {
   }
 
   .atlas-map {
-    min-height: 29rem;
+    min-height: auto;
   }
 
-  .atlas-orbit {
-    --orbit-radius: min(31vw, 7.4rem);
-    width: min(calc(100% - 4rem), 20rem);
-    top: 58%;
+  .atlas-map__controls {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .atlas-map__controls output {
+    justify-self: start;
+  }
+
+  .atlas-constellation__stage {
+    min-height: clamp(17.5rem, 78vw, 25rem);
+  }
+
+  .atlas-constellation__chapter-rail {
+    grid-auto-columns: minmax(10.5rem, 76vw);
+  }
+
+  .atlas-constellation__relation-band span {
+    flex-basis: 78vw;
   }
 
   .timeline-orbit,
@@ -3053,7 +3390,12 @@ h3 {
   }
 
   .atlas-hero__copy h1 {
-    font-size: 4.4rem;
+    max-width: 11ch;
+    font-size: clamp(2.85rem, 13.5vw, 4.2rem);
+  }
+
+  .atlas-hero__copy .lede {
+    display: none;
   }
 
   .path-grid,


### PR DESCRIPTION
## Summary
- replace the Atlas chapter picker with a visual concept-symbol-chapter constellation
- expand Atlas search across chapters, concepts, symbols, relationships, related chapters, and learning prompts
- add semantic radiogroup chapter selection, empty constellation state, reduced-motion handling, and tablet/mobile layout fixes
- extend app shell and accessibility smoke coverage for Atlas search, selection, empty state, and reduced-motion behavior

## Verification
- npx tsc --noEmit
- npm run test:app
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run build
- npm run test:e2e:app
- npm run test:a11y:app
- npm run lint
- npm test
- npm run build:pages
- npm run test:pages:artifact

Note: Vite still reports the known large Three.js chunk warning; this Atlas slice does not add new Three/WebGL runtime weight.