### PR TITLE
feat: polish Chapter 4 Self mandala

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -234,7 +234,7 @@ async function runAccessibilitySmoke() {
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -402,6 +402,27 @@ async function smokeReducedMotion(browser, failures) {
   if (!chapterThreeFallbackText?.includes('projection makes the inner image appear outside') || !chapterThreeFallbackText?.includes('brief symbolic union')) {
     failures.push('reduced-motion chapter fallback lost Chapter 3 syzygy teaching summary');
   }
+
+  await gotoAppRoute(page, '/journey/chapter/ch4');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterFourFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterFourReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterFourReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterFourReferenceCount = await chapterFourReferenceNodes.count();
+  const chapterFourPanelIds = await chapterFourReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterFourPauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterFourCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterFourFallbackText = await page.locator('.scene-host__fallback').textContent();
+
+  if (!chapterFourFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 4 scene');
+  if (chapterFourReducedMotionAttribute !== 'true') failures.push('Chapter 4 did not record reduced-motion state');
+  if (chapterFourReferenceCount !== 3) failures.push(`reduced-motion Chapter 4 reference node count mismatch: ${chapterFourReferenceCount}`);
+  if (chapterFourPanelIds.join(',') !== 'seed,quaternity,mandala') failures.push(`reduced-motion Chapter 4 reference nodes out of order: ${chapterFourPanelIds.join(',')}`);
+  if (chapterFourPauseControlCount !== 0) failures.push(`reduced-motion Chapter 4 rendered pause controls: ${chapterFourPauseControlCount}`);
+  if (chapterFourCanvasCount !== 0) failures.push(`reduced-motion Chapter 4 rendered canvas: ${chapterFourCanvasCount}`);
+  if (!chapterFourFallbackText?.includes('Concentric mandala rings') || !chapterFourFallbackText?.includes('fourfold ordering image')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 4 Self teaching summary');
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -612,14 +633,65 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterThreeVisiblePixels <= 8) failures.push(`chapter 3 canvas appears blank: ${chapterThreeVisiblePixels}`);
 
   await gotoAppRoute(page, '/journey/chapter/ch4');
-  const mandala = page.getByRole('button', { name: /03\s+Mandala/ });
+  await page.locator('.scene-host__mount[data-state="ready"]').waitFor({ state: 'visible', timeout: 10_000 });
+  const chapterFourReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterFourReferenceCount = await chapterFourReferenceNodes.count();
+  const chapterFourPanelIds = await chapterFourReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterFourQuaternityGlyphs = await page.locator('.chapter-stage__reference-node[data-panel-id="quaternity"] .chapter-stage__reference-quadrant').count();
+  const chapterFourPanelQuaternityPoints = await page.locator('.chapter-panel[data-panel-id="quaternity"] .chapter-panel__quaternity-point').count();
+  const chapterFourPanelMandalaBands = await page.locator('.chapter-panel[data-panel-id="mandala"] .chapter-panel__mandala-band').count();
+  const chapterFourQuaternityGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="quaternity"] .chapter-stage__reference-quadrant').evaluateAll((nodes) => nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterFourPanelGlyphsVisible = await page.locator('.chapter-panel[data-panel-id="quaternity"] .chapter-panel__quaternity-point, .chapter-panel[data-panel-id="mandala"] .chapter-panel__mandala-band').evaluateAll((nodes) => nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+
+  if (chapterFourReferenceCount !== 3) failures.push(`chapter 4 reference node count mismatch: ${chapterFourReferenceCount}`);
+  if (chapterFourPanelIds.join(',') !== 'seed,quaternity,mandala') failures.push(`chapter 4 reference nodes out of order: ${chapterFourPanelIds.join(',')}`);
+  if (chapterFourQuaternityGlyphs !== 4) failures.push(`chapter 4 reference quaternity glyph count mismatch: ${chapterFourQuaternityGlyphs}`);
+  if (chapterFourPanelQuaternityPoints !== 4) failures.push(`chapter 4 panel quaternity point count mismatch: ${chapterFourPanelQuaternityPoints}`);
+  if (chapterFourPanelMandalaBands !== 3) failures.push(`chapter 4 panel mandala band count mismatch: ${chapterFourPanelMandalaBands}`);
+  if (!chapterFourQuaternityGlyphsVisible) failures.push('chapter 4 reference quaternity glyphs are not visibly rendered');
+  if (!chapterFourPanelGlyphsVisible) failures.push('chapter 4 panel quaternity/mandala glyphs are not visibly rendered');
+
+  const quaternity = page.locator('.chapter-stage__reference-node[data-panel-id="quaternity"]');
+  await quaternity.click();
+  await page.waitForTimeout(250);
+
+  const quaternityPressed = await quaternity.getAttribute('aria-pressed');
+  const quaternityPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="quaternity"]').count();
+  const chapterFourQuaternityDescription = await page.locator('#scene-host-description-ch4').textContent();
+  if (quaternityPressed !== 'true') failures.push(`chapter 4 quaternity reference did not become active: ${quaternityPressed}`);
+  if (quaternityPanelActive !== 1) failures.push(`chapter 4 quaternity panel did not become active: ${quaternityPanelActive}`);
+  if (!chapterFourQuaternityDescription?.includes('Fourfold: Wholeness takes four directions')) {
+    failures.push(`chapter 4 scene description did not follow quaternity panel: ${chapterFourQuaternityDescription}`);
+  }
+
+  const mandala = page.locator('.chapter-stage__reference-node[data-panel-id="mandala"]');
   await mandala.click();
   await page.waitForTimeout(250);
 
   const mandalaPressed = await mandala.getAttribute('aria-pressed');
+  const mandalaPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="mandala"]').count();
+  const chapterFourMandalaDescription = await page.locator('#scene-host-description-ch4').textContent();
   const chapterFourScrollY = await page.evaluate(() => window.scrollY);
   if (mandalaPressed !== 'true') failures.push(`chapter 4 scene control did not become active: ${mandalaPressed}`);
+  if (mandalaPanelActive !== 1) failures.push(`chapter 4 mandala panel did not become active: ${mandalaPanelActive}`);
+  if (!chapterFourMandalaDescription?.includes('Mandala: Chaos receives a form')) failures.push(`chapter 4 scene description did not follow mandala panel: ${chapterFourMandalaDescription}`);
   if (chapterFourScrollY > 10) failures.push(`chapter 4 scene control unexpectedly scrolled page: ${chapterFourScrollY}`);
+
+  const chapterFourCanvas = page.locator('.scene-host canvas').first();
+  const chapterFourCanvasBox = await chapterFourCanvas.boundingBox();
+  const chapterFourVisiblePixels = await countCanvasPixels(chapterFourCanvas);
+  if (!chapterFourCanvasBox || chapterFourCanvasBox.width < 300 || chapterFourCanvasBox.height < 300) {
+    failures.push(`chapter 4 canvas geometry too small: ${chapterFourCanvasBox ? `${Math.round(chapterFourCanvasBox.width)}x${Math.round(chapterFourCanvasBox.height)}` : 'missing'}`);
+  }
+  if (chapterFourVisiblePixels <= 8) failures.push(`chapter 4 canvas appears blank: ${chapterFourVisiblePixels}`);
 
   await gotoAppRoute(page, '/journey/chapter/ch5');
   const depth = page.getByRole('button', { name: /03\s+Depth/ });
@@ -724,7 +796,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -814,6 +886,31 @@ async function smokeMobile(page, failures) {
         const chapterThreeVisiblePixels = await countCanvasPixels(chapterThreeCanvas);
         if (chapterThreeVisiblePixels <= 8) failures.push(`mobile chapter 3 canvas appears blank at ${viewport.width}x${viewport.height}: ${chapterThreeVisiblePixels}`);
       }
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch4');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterFourNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterFourHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterFourReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterFourReferenceCount = await chapterFourReferenceNodes.count();
+    const chapterFourPanelIds = await chapterFourReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterFourScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterFourReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    if (!chapterFourNavBox || !chapterFourHeadingBox) {
+      failures.push(`mobile chapter 4 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterFourNavBottom = chapterFourNavBox.y + chapterFourNavBox.height;
+    if (chapterFourNavBottom > chapterFourHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 4 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterFourNavBottom)}, heading top ${Math.round(chapterFourHeadingBox.y)}`);
+    }
+    if (chapterFourReferenceCount !== 3) failures.push(`mobile chapter 4 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterFourReferenceCount}`);
+    if (chapterFourPanelIds.join(',') !== 'seed,quaternity,mandala') failures.push(`mobile chapter 4 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterFourPanelIds.join(',')}`);
+    if (chapterFourScrollWidth > viewport.width + 2) failures.push(`mobile chapter 4 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterFourScrollWidth}`);
+    if (chapterFourReferenceMapBox && chapterFourReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 4 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterFourReferenceMapBox.width)}`);
     }
   }
 }

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -14,6 +14,9 @@ import {
 import type { ChapterRecord } from '../types';
 import { CHAPTER_SCENES } from '../visualization/chapterScenes';
 
+const quaternityDirections = ['north', 'east', 'south', 'west'] as const;
+const mandalaBands = ['outer', 'middle', 'inner'] as const;
+
 function useReducedMotionPreference() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
@@ -126,7 +129,11 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
                 aria-label={`Show ${panel.title}: ${panel.insight}`}
                 data-panel-id={panel.id}
               >
-                <span className="chapter-stage__reference-mark" aria-hidden="true" />
+                <span className="chapter-stage__reference-mark" aria-hidden="true">
+                  {quaternityDirections.map((direction) => (
+                    <span key={direction} className={`chapter-stage__reference-quadrant chapter-stage__reference-quadrant--${direction}`} />
+                  ))}
+                </span>
                 <span className="chapter-stage__reference-label">{String(index + 1).padStart(2, '0')} {panel.kicker}</span>
               </button>
             ))}
@@ -159,6 +166,12 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="chapter-panel__spark chapter-panel__spark--two" />
               <span className="chapter-panel__depth chapter-panel__depth--one" />
               <span className="chapter-panel__depth chapter-panel__depth--two" />
+              {quaternityDirections.map((direction) => (
+                <span key={direction} className={`chapter-panel__quaternity-point chapter-panel__quaternity-point--${direction}`} />
+              ))}
+              {mandalaBands.map((band) => (
+                <span key={band} className={`chapter-panel__mandala-band chapter-panel__mandala-band--${band}`} />
+              ))}
             </div>
             <div className="chapter-panel__copy">
               <span className="chapter-panel__count">{String(index + 1).padStart(2, '0')}</span>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2185,6 +2185,19 @@ h3 {
   text-transform: uppercase;
 }
 
+.chapter-stage__reference-quadrant {
+  display: none;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0.32rem;
+  height: 0.32rem;
+  border-radius: 50%;
+  background: var(--gold-soft);
+  box-shadow: 0 0 0.85rem rgba(212, 175, 55, 0.48);
+  transform: translate(-50%, -50%);
+}
+
 .chapter-stage__reference-node[data-panel-id="roots"] .chapter-stage__reference-mark::before {
   width: 2.4rem;
   height: 1.8rem;
@@ -2339,6 +2352,100 @@ h3 {
   width: 1px;
   height: 2.35rem;
   background: linear-gradient(180deg, transparent, rgba(255, 236, 246, 0.66), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node {
+  background:
+    radial-gradient(circle at 50% 28%, rgba(212, 175, 55, 0.12), transparent 2.6rem),
+    conic-gradient(from 45deg, rgba(83, 216, 232, 0.07), rgba(212, 175, 55, 0.08), rgba(204, 109, 134, 0.07), rgba(132, 201, 155, 0.07), rgba(83, 216, 232, 0.07)),
+    linear-gradient(180deg, rgba(3, 3, 7, 0.68), rgba(3, 3, 7, 0.34));
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="seed"] .chapter-stage__reference-mark::before {
+  top: 1.05rem;
+  width: 0.42rem;
+  height: 0.42rem;
+  background: #f4f0e8;
+  box-shadow:
+    0 0 1.4rem rgba(244, 240, 232, 0.72),
+    0 0 2.8rem rgba(212, 175, 55, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="seed"] .chapter-stage__reference-mark::after {
+  top: 1.62rem;
+  width: 1px;
+  height: 1.7rem;
+  background: linear-gradient(180deg, rgba(244, 240, 232, 0.44), rgba(212, 175, 55, 0.22), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="quaternity"] .chapter-stage__reference-mark::before {
+  top: 1.38rem;
+  width: 0.48rem;
+  height: 0.48rem;
+  background: var(--gold-soft);
+  box-shadow: 0 0 1.25rem rgba(212, 175, 55, 0.52);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="quaternity"] .chapter-stage__reference-mark::after {
+  top: 0.82rem;
+  width: 2.6rem;
+  height: 2.6rem;
+  border: 1px solid rgba(212, 175, 55, 0.2);
+  border-radius: 50%;
+  background:
+    linear-gradient(90deg, transparent 48%, rgba(244, 240, 232, 0.42) 49%, rgba(244, 240, 232, 0.42) 51%, transparent 52%),
+    linear-gradient(0deg, transparent 48%, rgba(244, 240, 232, 0.42) 49%, rgba(244, 240, 232, 0.42) 51%, transparent 52%);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="quaternity"] .chapter-stage__reference-quadrant {
+  display: block;
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--north {
+  top: 0.88rem;
+  background: var(--cyan);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--east {
+  left: calc(50% + 1.28rem);
+  top: 1.92rem;
+  background: var(--gold-soft);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--south {
+  top: 2.96rem;
+  background: var(--rose);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--west {
+  left: calc(50% - 1.28rem);
+  top: 1.92rem;
+  background: var(--green);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="mandala"] .chapter-stage__reference-mark::before {
+  top: 0.78rem;
+  width: 2.55rem;
+  height: 2.55rem;
+  border: 1px solid rgba(212, 175, 55, 0.34);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle, rgba(255, 227, 156, 0.9) 0 0.22rem, transparent 0.24rem),
+    radial-gradient(circle, transparent 0.78rem, rgba(83, 216, 232, 0.22) 0.82rem, transparent 0.86rem),
+    radial-gradient(circle, transparent 1.24rem, rgba(212, 175, 55, 0.24) 1.28rem, transparent 1.32rem);
+  box-shadow:
+    0 0 1.8rem rgba(212, 175, 55, 0.22),
+    inset 0 0 1.1rem rgba(83, 216, 232, 0.09);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="mandala"] .chapter-stage__reference-mark::after {
+  top: 0.78rem;
+  width: 2.55rem;
+  height: 2.55rem;
+  border-radius: 50%;
+  background:
+    linear-gradient(90deg, transparent 48%, rgba(244, 240, 232, 0.32) 49%, rgba(244, 240, 232, 0.32) 51%, transparent 52%),
+    linear-gradient(0deg, transparent 48%, rgba(244, 240, 232, 0.32) 49%, rgba(244, 240, 232, 0.32) 51%, transparent 52%);
 }
 
 .scene-host__status,
@@ -2515,7 +2622,9 @@ h3 {
 .chapter-panel__ring,
 .chapter-panel__axis,
 .chapter-panel__spark,
-.chapter-panel__depth {
+.chapter-panel__depth,
+.chapter-panel__quaternity-point,
+.chapter-panel__mandala-band {
   position: absolute;
   pointer-events: none;
 }
@@ -2597,6 +2706,27 @@ h3 {
   border-radius: 50%;
   background: transparent;
   box-shadow: inset 0 0 2.4rem rgba(212, 175, 55, 0.05);
+}
+
+.chapter-panel__quaternity-point,
+.chapter-panel__mandala-band {
+  display: none;
+}
+
+.chapter-panel__quaternity-point {
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 50%;
+  background: var(--gold-soft);
+  box-shadow: 0 0 1.4rem rgba(212, 175, 55, 0.64);
+}
+
+.chapter-panel__mandala-band {
+  left: 50%;
+  top: 50%;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .chapter-experience[data-motion-grammar="opposition"] .chapter-panel__symbol {
@@ -2953,6 +3083,124 @@ h3 {
   box-shadow:
     inset 0 0 3.8rem rgba(212, 175, 55, 0.09),
     0 0 4rem rgba(212, 175, 55, 0.08);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-stage__scrim {
+  background:
+    radial-gradient(circle at 50% 50%, rgba(3, 3, 7, 0.04), rgba(3, 3, 7, 0.46) 36%, rgba(3, 3, 7, 0.8) 78%),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.86), rgba(3, 3, 7, 0.18) 44%, rgba(3, 3, 7, 0.62));
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 50% 50%, rgba(255, 227, 156, 0.2), transparent 3rem),
+    conic-gradient(from 45deg, rgba(83, 216, 232, 0.14), rgba(212, 175, 55, 0.15), rgba(204, 109, 134, 0.13), rgba(132, 201, 155, 0.13), rgba(83, 216, 232, 0.14)),
+    radial-gradient(circle at 50% 50%, rgba(3, 3, 7, 0.12), rgba(3, 3, 7, 0.78) 68%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.052), rgba(255, 255, 255, 0.014));
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__symbol::before {
+  inset: 13%;
+  border-color: rgba(212, 175, 55, 0.24);
+  background:
+    linear-gradient(90deg, transparent 49%, rgba(244, 240, 232, 0.22) 50%, transparent 51%),
+    linear-gradient(0deg, transparent 49%, rgba(244, 240, 232, 0.22) 50%, transparent 51%);
+  box-shadow:
+    inset 0 0 3.8rem rgba(212, 175, 55, 0.06),
+    0 0 4rem rgba(83, 216, 232, 0.05);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__symbol::after {
+  width: 0.82rem;
+  height: 0.82rem;
+  background: radial-gradient(circle, #fff4c2, rgba(212, 175, 55, 0.72) 44%, transparent 72%);
+  box-shadow:
+    0 0 1.8rem rgba(212, 175, 55, 0.86),
+    0 0 4.6rem rgba(244, 240, 232, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__quaternity-point,
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__mandala-band {
+  display: block;
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__quaternity-point--north {
+  left: 50%;
+  top: 18%;
+  background: var(--cyan);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__quaternity-point--east {
+  right: 18%;
+  top: 50%;
+  background: var(--gold-soft);
+  transform: translate(50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__quaternity-point--south {
+  left: 50%;
+  bottom: 18%;
+  background: var(--rose);
+  transform: translate(-50%, 50%);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__quaternity-point--west {
+  left: 18%;
+  top: 50%;
+  background: var(--green);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__mandala-band--outer {
+  width: 78%;
+  aspect-ratio: 1;
+  border-color: rgba(212, 175, 55, 0.22);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__mandala-band--middle {
+  width: 54%;
+  aspect-ratio: 1;
+  border-color: rgba(83, 216, 232, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel__mandala-band--inner {
+  width: 28%;
+  aspect-ratio: 1;
+  border-color: rgba(244, 240, 232, 0.18);
+  box-shadow:
+    0 0 2rem rgba(212, 175, 55, 0.12),
+    inset 0 0 1.8rem rgba(212, 175, 55, 0.08);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel[data-panel-id="seed"] .chapter-panel__quaternity-point {
+  opacity: 0.22;
+  transform: translate(-50%, -50%) scale(0.68);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel[data-panel-id="seed"] .chapter-panel__mandala-band--outer,
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel[data-panel-id="seed"] .chapter-panel__mandala-band--middle {
+  opacity: 0.28;
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel[data-panel-id="quaternity"] .chapter-panel__axis--vertical,
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel[data-panel-id="quaternity"] .chapter-panel__axis--horizontal {
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.42), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel[data-panel-id="quaternity"] .chapter-panel__mandala-band--middle {
+  border-style: dashed;
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel[data-panel-id="mandala"] .chapter-panel__mandala-band {
+  border-color: rgba(212, 175, 55, 0.32);
+  box-shadow: 0 0 2.4rem rgba(212, 175, 55, 0.08);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .chapter-panel[data-panel-id="mandala"] .chapter-panel__quaternity-point {
+  box-shadow:
+    0 0 1.5rem currentColor,
+    0 0 3.2rem rgba(212, 175, 55, 0.14);
 }
 
 .chapter-panel__copy {
@@ -3474,6 +3722,64 @@ h3 {
 	    background:
       linear-gradient(180deg, rgba(3, 3, 7, 0.82), rgba(3, 3, 7, 0.36) 48%, rgba(3, 3, 7, 0.78)),
       linear-gradient(90deg, rgba(3, 3, 7, 0.9), rgba(3, 3, 7, 0.48) 64%, rgba(3, 3, 7, 0.34));
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__scrim {
+    background:
+      linear-gradient(180deg, rgba(3, 3, 7, 0.92), rgba(3, 3, 7, 0.78) 54%, rgba(3, 3, 7, 0.86)),
+      radial-gradient(circle at 50% 44%, rgba(3, 3, 7, 0.28), rgba(3, 3, 7, 0.78) 62%);
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="seed"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="quaternity"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="mandala"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="mandala"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="seed"] .chapter-stage__reference-mark::after {
+    left: 2.08rem;
+    top: 50%;
+    width: 1.2rem;
+    height: 1px;
+    transform: translateY(-50%);
+    background: linear-gradient(90deg, rgba(244, 240, 232, 0.42), rgba(212, 175, 55, 0.16), transparent);
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="quaternity"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.72rem;
+    height: 1.72rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="mandala"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-node[data-panel-id="mandala"] .chapter-stage__reference-mark::after {
+    width: 1.85rem;
+    height: 1.85rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--north {
+    left: 1.35rem;
+    top: calc(50% - 0.82rem);
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--east {
+    left: calc(1.35rem + 0.82rem);
+    top: 50%;
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--south {
+    left: 1.35rem;
+    top: calc(50% + 0.82rem);
+  }
+
+  .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--west {
+    left: calc(1.35rem - 0.82rem);
+    top: 50%;
   }
 
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__intro {

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -95,6 +95,18 @@ describe('Aion framework data contract', () => {
       'animus',
     ]);
   });
+
+  test('keeps Chapter 4 Self panels tied to mandala and quaternity learning', () => {
+    expect(CHAPTER_SCENES.ch4.panels.map((panel) => panel.id)).toEqual([
+      'seed',
+      'quaternity',
+      'mandala',
+    ]);
+    expect(CHAPTER_SCENES.ch4.motionGrammar).toBe('cyclical-return');
+    expect(CHAPTER_SCENES.ch4.visualTheme).toContain('Self mandala');
+    expect(CHAPTER_SCENES.ch4.fallbackSummary).toContain('Concentric mandala rings');
+    expect(CHAPTER_SCENES.ch4.fallbackSummary).toContain('fourfold ordering image');
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- Adds reusable quaternity/mandala visual primitives to the chapter shell and applies them to Chapter 4.
- Gives Chapter 4 bespoke Self, fourfold, and mandala reference/panel diagrams with mobile-specific composition fixes.
- Extends app contract, e2e, mobile, reduced-motion, and accessibility smoke coverage for the Chapter 4 Self route.

## Verification
- npx tsc --noEmit
- npm run lint
- npm run test:app
- npm test
- npm run build
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:e2e:app
- AION_A11Y_PORT=4185 npm run test:a11y:app
- npm run build:pages
- npm run test:pages:artifact
- git diff --check

Known note: Vite still reports the existing large `three` chunk warning.