### PR TITLE
feat: polish Chapter 5 Christ symbol

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -234,7 +234,7 @@ async function runAccessibilitySmoke() {
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -423,6 +423,27 @@ async function smokeReducedMotion(browser, failures) {
   if (!chapterFourFallbackText?.includes('Concentric mandala rings') || !chapterFourFallbackText?.includes('fourfold ordering image')) {
     failures.push('reduced-motion chapter fallback lost Chapter 4 Self teaching summary');
   }
+
+  await gotoAppRoute(page, '/journey/chapter/ch5');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterFiveFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterFiveReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterFiveReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterFiveReferenceCount = await chapterFiveReferenceNodes.count();
+  const chapterFivePanelIds = await chapterFiveReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterFivePauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterFiveCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterFiveFallbackText = await page.locator('.scene-host__fallback').textContent();
+
+  if (!chapterFiveFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 5 scene');
+  if (chapterFiveReducedMotionAttribute !== 'true') failures.push('Chapter 5 did not record reduced-motion state');
+  if (chapterFiveReferenceCount !== 3) failures.push(`reduced-motion Chapter 5 reference node count mismatch: ${chapterFiveReferenceCount}`);
+  if (chapterFivePanelIds.join(',') !== 'cross,fourth,tree') failures.push(`reduced-motion Chapter 5 reference nodes out of order: ${chapterFivePanelIds.join(',')}`);
+  if (chapterFivePauseControlCount !== 0) failures.push(`reduced-motion Chapter 5 rendered pause controls: ${chapterFivePauseControlCount}`);
+  if (chapterFiveCanvasCount !== 0) failures.push(`reduced-motion Chapter 5 rendered canvas: ${chapterFiveCanvasCount}`);
+  if (!chapterFiveFallbackText?.includes('luminous cross') || !chapterFiveFallbackText?.includes('excluded fourth')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 5 Christ symbol teaching summary');
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -694,14 +715,67 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterFourVisiblePixels <= 8) failures.push(`chapter 4 canvas appears blank: ${chapterFourVisiblePixels}`);
 
   await gotoAppRoute(page, '/journey/chapter/ch5');
-  const depth = page.getByRole('button', { name: /03\s+Depth/ });
-  await depth.click();
+  await page.locator('.scene-host__mount[data-state="ready"]').waitFor({ state: 'visible', timeout: 10_000 });
+  const chapterFiveReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterFiveReferenceCount = await chapterFiveReferenceNodes.count();
+  const chapterFivePanelIds = await chapterFiveReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterFiveFourthGlyphs = await page.locator('.chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant').count();
+  const chapterFivePanelGemPoints = await page.locator('.chapter-panel[data-panel-id="fourth"] .chapter-panel__quaternity-point').count();
+  const chapterFivePanelBands = await page.locator('.chapter-panel[data-panel-id="fourth"] .chapter-panel__mandala-band').count();
+  const chapterFiveTreeRoots = await page.locator('.chapter-panel[data-panel-id="tree"] .chapter-panel__root-line').count();
+  const chapterFiveReferenceGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant').evaluateAll((nodes) => nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterFivePanelGlyphsVisible = await page.locator('.chapter-panel[data-panel-id="fourth"] .chapter-panel__quaternity-point, .chapter-panel[data-panel-id="tree"] .chapter-panel__root-line').evaluateAll((nodes) => nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+
+  if (chapterFiveReferenceCount !== 3) failures.push(`chapter 5 reference node count mismatch: ${chapterFiveReferenceCount}`);
+  if (chapterFivePanelIds.join(',') !== 'cross,fourth,tree') failures.push(`chapter 5 reference nodes out of order: ${chapterFivePanelIds.join(',')}`);
+  if (chapterFiveFourthGlyphs !== 4) failures.push(`chapter 5 reference excluded-fourth glyph count mismatch: ${chapterFiveFourthGlyphs}`);
+  if (chapterFivePanelGemPoints !== 4) failures.push(`chapter 5 panel gem point count mismatch: ${chapterFivePanelGemPoints}`);
+  if (chapterFivePanelBands !== 3) failures.push(`chapter 5 panel ring band count mismatch: ${chapterFivePanelBands}`);
+  if (chapterFiveTreeRoots !== 3) failures.push(`chapter 5 tree root line count mismatch: ${chapterFiveTreeRoots}`);
+  if (!chapterFiveReferenceGlyphsVisible) failures.push('chapter 5 reference fourth glyphs are not visibly rendered');
+  if (!chapterFivePanelGlyphsVisible) failures.push('chapter 5 panel fourth/tree glyphs are not visibly rendered');
+
+  const fourth = page.locator('.chapter-stage__reference-node[data-panel-id="fourth"]');
+  await fourth.click();
   await page.waitForTimeout(250);
 
-  const depthPressed = await depth.getAttribute('aria-pressed');
+  const fourthPressed = await fourth.getAttribute('aria-pressed');
+  const fourthPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="fourth"]').count();
+  const chapterFiveFourthDescription = await page.locator('#scene-host-description-ch5').textContent();
+  if (fourthPressed !== 'true') failures.push(`chapter 5 fourth reference did not become active: ${fourthPressed}`);
+  if (fourthPanelActive !== 1) failures.push(`chapter 5 fourth panel did not become active: ${fourthPanelActive}`);
+  if (!chapterFiveFourthDescription?.includes('Shadow: The fourth is missing')) {
+    failures.push(`chapter 5 scene description did not follow fourth panel: ${chapterFiveFourthDescription}`);
+  }
+
+  const tree = page.locator('.chapter-stage__reference-node[data-panel-id="tree"]');
+  await tree.click();
+  await page.waitForTimeout(250);
+
+  const treePressed = await tree.getAttribute('aria-pressed');
+  const treePanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="tree"]').count();
+  const chapterFiveTreeDescription = await page.locator('#scene-host-description-ch5').textContent();
   const chapterFiveScrollY = await page.evaluate(() => window.scrollY);
-  if (depthPressed !== 'true') failures.push(`chapter 5 scene control did not become active: ${depthPressed}`);
+  if (treePressed !== 'true') failures.push(`chapter 5 tree reference did not become active: ${treePressed}`);
+  if (treePanelActive !== 1) failures.push(`chapter 5 tree panel did not become active: ${treePanelActive}`);
+  if (!chapterFiveTreeDescription?.includes('Depth: The roots go downward')) failures.push(`chapter 5 scene description did not follow tree panel: ${chapterFiveTreeDescription}`);
   if (chapterFiveScrollY > 10) failures.push(`chapter 5 scene control unexpectedly scrolled page: ${chapterFiveScrollY}`);
+
+  const chapterFiveCanvas = page.locator('.scene-host canvas').first();
+  const chapterFiveCanvasBox = await chapterFiveCanvas.boundingBox();
+  const chapterFiveVisiblePixels = await countCanvasPixels(chapterFiveCanvas);
+  if (!chapterFiveCanvasBox || chapterFiveCanvasBox.width < 300 || chapterFiveCanvasBox.height < 300) {
+    failures.push(`chapter 5 canvas geometry too small: ${chapterFiveCanvasBox ? `${Math.round(chapterFiveCanvasBox.width)}x${Math.round(chapterFiveCanvasBox.height)}` : 'missing'}`);
+  }
+  if (chapterFiveVisiblePixels <= 8) failures.push(`chapter 5 canvas appears blank: ${chapterFiveVisiblePixels}`);
 
   await gotoAppRoute(page, '/journey/chapter/ch6');
   const threshold = page.getByRole('button', { name: /03\s+Threshold/ });
@@ -796,7 +870,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -911,6 +985,31 @@ async function smokeMobile(page, failures) {
     if (chapterFourScrollWidth > viewport.width + 2) failures.push(`mobile chapter 4 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterFourScrollWidth}`);
     if (chapterFourReferenceMapBox && chapterFourReferenceMapBox.width > viewport.width + 2) {
       failures.push(`mobile chapter 4 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterFourReferenceMapBox.width)}`);
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch5');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterFiveNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterFiveHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterFiveReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterFiveReferenceCount = await chapterFiveReferenceNodes.count();
+    const chapterFivePanelIds = await chapterFiveReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterFiveScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterFiveReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    if (!chapterFiveNavBox || !chapterFiveHeadingBox) {
+      failures.push(`mobile chapter 5 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterFiveNavBottom = chapterFiveNavBox.y + chapterFiveNavBox.height;
+    if (chapterFiveNavBottom > chapterFiveHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 5 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterFiveNavBottom)}, heading top ${Math.round(chapterFiveHeadingBox.y)}`);
+    }
+    if (chapterFiveReferenceCount !== 3) failures.push(`mobile chapter 5 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterFiveReferenceCount}`);
+    if (chapterFivePanelIds.join(',') !== 'cross,fourth,tree') failures.push(`mobile chapter 5 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterFivePanelIds.join(',')}`);
+    if (chapterFiveScrollWidth > viewport.width + 2) failures.push(`mobile chapter 5 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterFiveScrollWidth}`);
+    if (chapterFiveReferenceMapBox && chapterFiveReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 5 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterFiveReferenceMapBox.width)}`);
     }
   }
 }

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -19,7 +19,7 @@ const canonicalRoutes = [
   ...Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`),
 ];
 
-const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch6', '/journey/chapter/ch14'];
+const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch14'];
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -16,6 +16,7 @@ import { CHAPTER_SCENES } from '../visualization/chapterScenes';
 
 const quaternityDirections = ['north', 'east', 'south', 'west'] as const;
 const mandalaBands = ['outer', 'middle', 'inner'] as const;
+const rootLines = ['left', 'center', 'right'] as const;
 
 function useReducedMotionPreference() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
@@ -171,6 +172,9 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               ))}
               {mandalaBands.map((band) => (
                 <span key={band} className={`chapter-panel__mandala-band chapter-panel__mandala-band--${band}`} />
+              ))}
+              {rootLines.map((line) => (
+                <span key={line} className={`chapter-panel__root-line chapter-panel__root-line--${line}`} />
               ))}
             </div>
             <div className="chapter-panel__copy">

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2448,6 +2448,110 @@ h3 {
     linear-gradient(0deg, transparent 48%, rgba(244, 240, 232, 0.32) 49%, rgba(244, 240, 232, 0.32) 51%, transparent 52%);
 }
 
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node {
+  background:
+    radial-gradient(circle at 50% 23%, rgba(244, 240, 232, 0.1), transparent 2.6rem),
+    radial-gradient(circle at 74% 72%, rgba(204, 109, 134, 0.12), transparent 2.8rem),
+    linear-gradient(145deg, rgba(244, 240, 232, 0.055), rgba(3, 3, 7, 0.24) 48%, rgba(51, 14, 18, 0.28));
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="cross"] .chapter-stage__reference-mark::before {
+  top: 0.72rem;
+  width: 1px;
+  height: 2.92rem;
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.86), rgba(212, 175, 55, 0.28), transparent);
+  box-shadow:
+    0 0 1.35rem rgba(244, 240, 232, 0.5),
+    0 0 2.7rem rgba(212, 175, 55, 0.12);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="cross"] .chapter-stage__reference-mark::after {
+  top: 1.52rem;
+  width: 2.55rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.72), rgba(212, 175, 55, 0.32), transparent);
+  box-shadow: 0 0 1.3rem rgba(244, 240, 232, 0.28);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-mark::before {
+  top: 0.78rem;
+  width: 2.65rem;
+  height: 2.65rem;
+  border-radius: 50%;
+  background:
+    conic-gradient(from 222deg, rgba(212, 175, 55, 0.5) 0 73%, transparent 73% 100%),
+    radial-gradient(circle, transparent 0 1.08rem, rgba(244, 240, 232, 0.08) 1.12rem, transparent 1.17rem);
+  opacity: 0.9;
+  box-shadow: 0 0 1.5rem rgba(212, 175, 55, 0.16);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-mark::after {
+  top: 2.78rem;
+  left: calc(50% + 1.14rem);
+  width: 0.46rem;
+  height: 0.46rem;
+  border: 1px solid rgba(204, 109, 134, 0.42);
+  border-radius: 50%;
+  background: rgba(28, 6, 8, 0.94);
+  box-shadow:
+    0 0 0 0.5rem rgba(204, 109, 134, 0.04),
+    0 0 1.35rem rgba(204, 109, 134, 0.42);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant {
+  display: block;
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant--north {
+  left: calc(50% - 0.92rem);
+  top: 1.05rem;
+  background: var(--gold-soft);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant--east {
+  left: calc(50% + 0.92rem);
+  top: 1.05rem;
+  background: var(--cyan);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant--south {
+  left: calc(50% - 0.92rem);
+  top: 2.8rem;
+  background: var(--rose);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant--west {
+  left: calc(50% + 0.92rem);
+  top: 2.8rem;
+  background: #3b1014;
+  box-shadow: 0 0 0.9rem rgba(204, 109, 134, 0.34);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="tree"] .chapter-stage__reference-mark::before {
+  top: 0.72rem;
+  width: 1px;
+  height: 3.05rem;
+  background:
+    linear-gradient(180deg, rgba(244, 240, 232, 0.7), rgba(212, 175, 55, 0.2) 52%, rgba(204, 109, 134, 0.36));
+  box-shadow:
+    -0.62rem 2.42rem 0 -0.02rem rgba(204, 109, 134, 0.26),
+    0.62rem 2.42rem 0 -0.02rem rgba(204, 109, 134, 0.22),
+    0 0 1.35rem rgba(244, 240, 232, 0.24);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="tree"] .chapter-stage__reference-mark::after {
+  top: 2.48rem;
+  width: 2.9rem;
+  height: 1.55rem;
+  border-right: 1px solid rgba(204, 109, 134, 0.24);
+  border-bottom: 1px solid rgba(204, 109, 134, 0.22);
+  border-left: 1px solid rgba(204, 109, 134, 0.18);
+  border-radius: 0 0 48% 48%;
+  background:
+    linear-gradient(138deg, transparent 48%, rgba(204, 109, 134, 0.24) 49%, transparent 51%),
+    linear-gradient(42deg, transparent 48%, rgba(204, 109, 134, 0.2) 49%, transparent 51%);
+}
+
 .scene-host__status,
 .scene-host__fallback {
   position: absolute;
@@ -2624,7 +2728,8 @@ h3 {
 .chapter-panel__spark,
 .chapter-panel__depth,
 .chapter-panel__quaternity-point,
-.chapter-panel__mandala-band {
+.chapter-panel__mandala-band,
+.chapter-panel__root-line {
   position: absolute;
   pointer-events: none;
 }
@@ -2709,7 +2814,8 @@ h3 {
 }
 
 .chapter-panel__quaternity-point,
-.chapter-panel__mandala-band {
+.chapter-panel__mandala-band,
+.chapter-panel__root-line {
   display: none;
 }
 
@@ -2727,6 +2833,15 @@ h3 {
   border: 1px solid rgba(244, 240, 232, 0.12);
   border-radius: 50%;
   transform: translate(-50%, -50%);
+}
+
+.chapter-panel__root-line {
+  left: 50%;
+  bottom: 14%;
+  width: 1px;
+  height: 30%;
+  background: linear-gradient(180deg, rgba(244, 240, 232, 0.18), rgba(204, 109, 134, 0.34), transparent);
+  transform-origin: top;
 }
 
 .chapter-experience[data-motion-grammar="opposition"] .chapter-panel__symbol {
@@ -3201,6 +3316,171 @@ h3 {
   box-shadow:
     0 0 1.5rem currentColor,
     0 0 3.2rem rgba(212, 175, 55, 0.14);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-stage__scrim {
+  background:
+    radial-gradient(circle at 50% 43%, rgba(244, 240, 232, 0.02), rgba(3, 3, 7, 0.4) 34%, rgba(3, 3, 7, 0.86) 80%),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.88), rgba(3, 3, 7, 0.2) 45%, rgba(36, 6, 10, 0.72));
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 48% 38%, rgba(244, 240, 232, 0.16), transparent 3.8rem),
+    radial-gradient(circle at 68% 68%, rgba(204, 109, 134, 0.16), transparent 5rem),
+    linear-gradient(90deg, rgba(244, 240, 232, 0.045), rgba(3, 3, 7, 0.06) 48%, rgba(54, 9, 13, 0.16)),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.014));
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__symbol::before {
+  inset: 13% 15%;
+  border-color: rgba(244, 240, 232, 0.12);
+  border-radius: 50%;
+  background:
+    conic-gradient(from 224deg, rgba(212, 175, 55, 0.13) 0 73%, rgba(204, 109, 134, 0.03) 73% 100%),
+    radial-gradient(circle, transparent 0 42%, rgba(244, 240, 232, 0.08) 43%, transparent 45%);
+  box-shadow:
+    inset 0 0 3.8rem rgba(212, 175, 55, 0.05),
+    0 0 3.2rem rgba(204, 109, 134, 0.04);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__symbol::after {
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__axis--vertical {
+  height: 76%;
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.64), rgba(212, 175, 55, 0.2), rgba(204, 109, 134, 0.24), transparent);
+  box-shadow: 0 0 1.6rem rgba(244, 240, 232, 0.12);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__axis--horizontal {
+  top: 39%;
+  width: 72%;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.52), rgba(212, 175, 55, 0.18), transparent);
+  box-shadow: 0 0 1.25rem rgba(244, 240, 232, 0.08);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__quaternity-point,
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__mandala-band {
+  display: block;
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__quaternity-point--north {
+  left: 28%;
+  top: 24%;
+  background: var(--gold-soft);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__quaternity-point--east {
+  right: 28%;
+  top: 24%;
+  background: var(--cyan);
+  transform: translate(50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__quaternity-point--south {
+  left: 28%;
+  bottom: 25%;
+  background: var(--rose);
+  transform: translate(-50%, 50%);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__quaternity-point--west {
+  right: 28%;
+  bottom: 25%;
+  background: #3b1014;
+  box-shadow:
+    0 0 0 0.62rem rgba(204, 109, 134, 0.035),
+    0 0 1.6rem rgba(204, 109, 134, 0.48);
+  transform: translate(50%, 50%);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__mandala-band--outer {
+  width: 80%;
+  aspect-ratio: 1;
+  border-color: rgba(244, 240, 232, 0.1);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__mandala-band--middle {
+  width: 66%;
+  aspect-ratio: 1;
+  border: 0;
+  background: conic-gradient(from 224deg, rgba(212, 175, 55, 0.62) 0 73%, rgba(204, 109, 134, 0.11) 73% 81%, transparent 81% 100%);
+  -webkit-mask: radial-gradient(circle, transparent 0 63%, #000 64% 67%, transparent 68%);
+  mask: radial-gradient(circle, transparent 0 63%, #000 64% 67%, transparent 68%);
+  opacity: 0.72;
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel__mandala-band--inner {
+  width: 32%;
+  aspect-ratio: 1;
+  border-color: rgba(212, 175, 55, 0.2);
+  box-shadow:
+    0 0 2rem rgba(212, 175, 55, 0.08),
+    inset 0 0 2rem rgba(244, 240, 232, 0.045);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="cross"] .chapter-panel__quaternity-point--west,
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="cross"] .chapter-panel__mandala-band--middle {
+  opacity: 0.2;
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="fourth"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 68% 68%, rgba(204, 109, 134, 0.22), transparent 5.2rem),
+    radial-gradient(circle at 42% 38%, rgba(212, 175, 55, 0.14), transparent 4rem),
+    linear-gradient(90deg, rgba(244, 240, 232, 0.038), rgba(3, 3, 7, 0.08) 50%, rgba(54, 9, 13, 0.2));
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="fourth"] .chapter-panel__quaternity-point--west {
+  width: 0.9rem;
+  height: 0.9rem;
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="fourth"] .chapter-panel__spark--one {
+  left: 70%;
+  top: 69%;
+  background: #4a1014;
+  box-shadow:
+    0 0 1.7rem rgba(204, 109, 134, 0.62),
+    -1.2rem -1.8rem 2.8rem rgba(212, 175, 55, 0.12);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="tree"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 50% 30%, rgba(244, 240, 232, 0.14), transparent 3.6rem),
+    radial-gradient(circle at 50% 82%, rgba(204, 109, 134, 0.16), transparent 6rem),
+    linear-gradient(180deg, rgba(244, 240, 232, 0.038), rgba(3, 3, 7, 0.08) 52%, rgba(47, 10, 13, 0.18));
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="tree"] .chapter-panel__root-line {
+  display: block;
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="tree"] .chapter-panel__root-line--left {
+  transform: translateX(-50%) rotate(28deg);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="tree"] .chapter-panel__root-line--center {
+  height: 38%;
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="tree"] .chapter-panel__root-line--right {
+  transform: translateX(-50%) rotate(-28deg);
+}
+
+.chapter-experience[data-chapter-id="ch5"] .chapter-panel[data-panel-id="tree"] .chapter-panel__depth--one {
+  top: 49%;
+  height: 46%;
+  background: linear-gradient(180deg, rgba(212, 175, 55, 0.2), rgba(204, 109, 134, 0.34), transparent);
 }
 
 .chapter-panel__copy {
@@ -3780,6 +4060,69 @@ h3 {
   .chapter-experience[data-chapter-id="ch4"] .chapter-stage__reference-quadrant--west {
     left: calc(1.35rem - 0.82rem);
     top: 50%;
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__scrim {
+    background:
+      linear-gradient(180deg, rgba(3, 3, 7, 0.94), rgba(3, 3, 7, 0.8) 54%, rgba(3, 3, 7, 0.88)),
+      radial-gradient(circle at 52% 44%, rgba(54, 9, 13, 0.26), rgba(3, 3, 7, 0.78) 62%);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="cross"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="tree"] .chapter-stage__reference-mark::before {
+    left: 1.35rem;
+    top: 50%;
+    height: 2rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="cross"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.8rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-mark::before {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.82rem;
+    height: 1.82rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-mark::after {
+    left: calc(1.35rem + 0.58rem);
+    top: calc(50% + 0.62rem);
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="tree"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: calc(50% + 0.52rem);
+    width: 1.9rem;
+    height: 1.05rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant--north {
+    left: calc(1.35rem - 0.56rem);
+    top: calc(50% - 0.56rem);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant--east {
+    left: calc(1.35rem + 0.56rem);
+    top: calc(50% - 0.56rem);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant--south {
+    left: calc(1.35rem - 0.56rem);
+    top: calc(50% + 0.56rem);
+  }
+
+  .chapter-experience[data-chapter-id="ch5"] .chapter-stage__reference-node[data-panel-id="fourth"] .chapter-stage__reference-quadrant--west {
+    left: calc(1.35rem + 0.56rem);
+    top: calc(50% + 0.56rem);
   }
 
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__intro {

--- a/src/app/visualization/chapterScenes.ts
+++ b/src/app/visualization/chapterScenes.ts
@@ -58,7 +58,7 @@ export const CHAPTER_SCENES: Record<ChapterId, ChapterExperience> = {
     visualTheme: 'Christ symbol and excluded fourth',
     sceneModule: '../visualizations/chapters/ch5/ThreeChristViz.js',
     motionGrammar: 'opposition',
-    fallbackSummary: 'A luminous cross and three-plus-one gem field reveal the Christ symbol as powerful yet psychologically one-sided.',
+    fallbackSummary: 'A luminous cross and three-plus-one gem field reveal the Christ symbol as powerful, psychologically one-sided, and pressured by the excluded fourth.',
     checkpoints: ['See the bright trinity.', 'Find the excluded fourth.', 'Relate Christ symbol to Self.'],
     panels: [
       { id: 'cross', kicker: 'Axis', title: 'A Western Self image', body: 'The Christ symbol carries the axis of wholeness for Western imagination.', insight: 'A religious image can be read psychologically without reducing it.' },

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -107,6 +107,19 @@ describe('Aion framework data contract', () => {
     expect(CHAPTER_SCENES.ch4.fallbackSummary).toContain('Concentric mandala rings');
     expect(CHAPTER_SCENES.ch4.fallbackSummary).toContain('fourfold ordering image');
   });
+
+  test('keeps Chapter 5 Christ symbol panels tied to the excluded fourth', () => {
+    expect(CHAPTER_SCENES.ch5.panels.map((panel) => panel.id)).toEqual([
+      'cross',
+      'fourth',
+      'tree',
+    ]);
+    expect(CHAPTER_SCENES.ch5.motionGrammar).toBe('opposition');
+    expect(CHAPTER_SCENES.ch5.visualTheme).toContain('Christ symbol');
+    expect(CHAPTER_SCENES.ch5.fallbackSummary).toContain('luminous cross');
+    expect(CHAPTER_SCENES.ch5.fallbackSummary).toContain('excluded fourth');
+    expect(CHAPTER_SCENES.ch5.fallbackSummary).toContain('three-plus-one');
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- Adds Chapter 5-specific symbolic shell visuals for the cross, excluded fourth, and rooted counter-pole.
- Adds reusable root-line primitives to the chapter panel diagram layer without changing other chapters.
- Tightens Chapter 5 reduced-motion fallback copy and expands contract, e2e, mobile, accessibility, and Pages artifact smoke coverage.

## Verification
- npx tsc --noEmit
- npm run test:app
- npm run lint
- npm test
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run build
- npm run test:e2e:app
- AION_A11Y_PORT=4185 npm run test:a11y:app
- npm run build:pages
- npm run test:pages:artifact
- git diff --check

Visual review: inspected `/journey/chapter/ch5` locally in the in-app browser at desktop and mobile sizes; mobile measured `scrollWidth: 390`, `innerWidth: 390`.

Known note: Vite still reports the existing large `three` chunk warning.