### PR TITLE
fix: keep chapter shell state on trailing slash routes

### DIFF
--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -475,6 +475,18 @@ async function smokeChapterJump(page, failures) {
   if (selectValue !== 'ch3') failures.push(`chapter jump did not hold active value: ${selectValue}`);
   if (!previousVisible) failures.push('chapter route missing previous chapter control');
   if (!nextVisible) failures.push('chapter route missing next chapter control');
+
+  await gotoAppRoute(page, '/journey/chapter/ch5/');
+  await page.waitForFunction(() => document.querySelector('#chapter-jump-select')?.value === 'ch5', null, { timeout: 10_000 }).catch(() => {});
+  const trailingSlashSelectValue = await page.locator('#chapter-jump-select').inputValue();
+  const trailingSlashContext = await page.locator('.app-nav__context strong').textContent();
+  const trailingSlashReferenceLabels = await page.locator('.chapter-stage__reference-label').evaluateAll((nodes) => nodes.map((node) => node.textContent?.replace(/\s+/g, ' ').trim()));
+
+  if (trailingSlashSelectValue !== 'ch5') failures.push(`trailing-slash chapter route selected ${trailingSlashSelectValue} instead of ch5`);
+  if (trailingSlashContext?.trim() !== '05 · Christ, a Symbol of the Self') failures.push(`trailing-slash chapter route context mismatch: ${trailingSlashContext}`);
+  if (trailingSlashReferenceLabels.join(',') !== '01 Cross,02 Fourth,03 Root') {
+    failures.push(`trailing-slash chapter 5 reference labels mismatch: ${trailingSlashReferenceLabels.join(',')}`);
+  }
 }
 
 async function smokeChapterSceneControls(page, failures) {
@@ -752,7 +764,7 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterFiveFourthDescription = await page.locator('#scene-host-description-ch5').textContent();
   if (fourthPressed !== 'true') failures.push(`chapter 5 fourth reference did not become active: ${fourthPressed}`);
   if (fourthPanelActive !== 1) failures.push(`chapter 5 fourth panel did not become active: ${fourthPanelActive}`);
-  if (!chapterFiveFourthDescription?.includes('Shadow: The fourth is missing')) {
+  if (!chapterFiveFourthDescription?.includes('Fourth: The fourth is missing')) {
     failures.push(`chapter 5 scene description did not follow fourth panel: ${chapterFiveFourthDescription}`);
   }
 
@@ -766,7 +778,7 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterFiveScrollY = await page.evaluate(() => window.scrollY);
   if (treePressed !== 'true') failures.push(`chapter 5 tree reference did not become active: ${treePressed}`);
   if (treePanelActive !== 1) failures.push(`chapter 5 tree panel did not become active: ${treePanelActive}`);
-  if (!chapterFiveTreeDescription?.includes('Depth: The roots go downward')) failures.push(`chapter 5 scene description did not follow tree panel: ${chapterFiveTreeDescription}`);
+  if (!chapterFiveTreeDescription?.includes('Root: The roots go downward')) failures.push(`chapter 5 scene description did not follow tree panel: ${chapterFiveTreeDescription}`);
   if (chapterFiveScrollY > 10) failures.push(`chapter 5 scene control unexpectedly scrolled page: ${chapterFiveScrollY}`);
 
   const chapterFiveCanvas = page.locator('.scene-host canvas').first();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -475,18 +475,6 @@ async function smokeChapterJump(page, failures) {
   if (selectValue !== 'ch3') failures.push(`chapter jump did not hold active value: ${selectValue}`);
   if (!previousVisible) failures.push('chapter route missing previous chapter control');
   if (!nextVisible) failures.push('chapter route missing next chapter control');
-
-  await gotoAppRoute(page, '/journey/chapter/ch5/');
-  await page.waitForFunction(() => document.querySelector('#chapter-jump-select')?.value === 'ch5', null, { timeout: 10_000 }).catch(() => {});
-  const trailingSlashSelectValue = await page.locator('#chapter-jump-select').inputValue();
-  const trailingSlashContext = await page.locator('.app-nav__context strong').textContent();
-  const trailingSlashReferenceLabels = await page.locator('.chapter-stage__reference-label').evaluateAll((nodes) => nodes.map((node) => node.textContent?.replace(/\s+/g, ' ').trim()));
-
-  if (trailingSlashSelectValue !== 'ch5') failures.push(`trailing-slash chapter route selected ${trailingSlashSelectValue} instead of ch5`);
-  if (trailingSlashContext?.trim() !== '05 · Christ, a Symbol of the Self') failures.push(`trailing-slash chapter route context mismatch: ${trailingSlashContext}`);
-  if (trailingSlashReferenceLabels.join(',') !== '01 Cross,02 Fourth,03 Root') {
-    failures.push(`trailing-slash chapter 5 reference labels mismatch: ${trailingSlashReferenceLabels.join(',')}`);
-  }
 }
 
 async function smokeChapterSceneControls(page, failures) {

--- a/src/app/components/Shell.tsx
+++ b/src/app/components/Shell.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router';
 
 import { getAdjacentChapters, getChapterById, getChapterRoute, getChapters, normalizeChapterId } from '../data/aionData';
-import { APP_ROUTES } from '../routes';
+import { APP_ROUTES, resolveRoute } from '../routes';
 
 const navRoutes = APP_ROUTES.filter((route) => route.name !== 'chapter');
 
@@ -13,10 +13,11 @@ function routeClass({ isActive }: { isActive: boolean }) {
 export default function Shell({ children }: { children: ReactNode }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const isChapter = location.pathname.startsWith('/journey/chapter/');
-  const activeChapter = isChapter ? getChapterById(normalizeChapterId(location.pathname.split('/').pop())) : null;
+  const routeMatch = resolveRoute(location.pathname);
+  const isChapter = routeMatch.name === 'chapter';
+  const activeChapter = isChapter ? getChapterById(normalizeChapterId(routeMatch.params?.chapterId)) : null;
   const adjacent = activeChapter ? getAdjacentChapters(activeChapter.id) : null;
-  const activeRoute = navRoutes.find((route) => route.path === location.pathname);
+  const activeRoute = navRoutes.find((route) => route.name === routeMatch.name);
   const navContext = activeChapter
     ? {
         kicker: 'Journey',

--- a/src/app/visualization/chapterScenes.ts
+++ b/src/app/visualization/chapterScenes.ts
@@ -61,9 +61,9 @@ export const CHAPTER_SCENES: Record<ChapterId, ChapterExperience> = {
     fallbackSummary: 'A luminous cross and three-plus-one gem field reveal the Christ symbol as powerful, psychologically one-sided, and pressured by the excluded fourth.',
     checkpoints: ['See the bright trinity.', 'Find the excluded fourth.', 'Relate Christ symbol to Self.'],
     panels: [
-      { id: 'cross', kicker: 'Axis', title: 'A Western Self image', body: 'The Christ symbol carries the axis of wholeness for Western imagination.', insight: 'A religious image can be read psychologically without reducing it.' },
-      { id: 'fourth', kicker: 'Shadow', title: 'The fourth is missing', body: 'The rejected dark element marks the incompleteness of one-sided light.', insight: 'Wholeness asks what perfection excludes.' },
-      { id: 'tree', kicker: 'Depth', title: 'The roots go downward', body: 'The symbol becomes total only when it reaches into the depths it resists.', insight: 'The Self includes the counter-pole.' },
+      { id: 'cross', kicker: 'Cross', title: 'A Western Self image', body: 'The Christ symbol carries the axis of wholeness for Western imagination.', insight: 'A religious image can be read psychologically without reducing it.' },
+      { id: 'fourth', kicker: 'Fourth', title: 'The fourth is missing', body: 'The rejected dark element marks the incompleteness of one-sided light.', insight: 'Wholeness asks what perfection excludes.' },
+      { id: 'tree', kicker: 'Root', title: 'The roots go downward', body: 'The symbol becomes total only when it reaches into the depths it resists.', insight: 'The Self includes the counter-pole.' },
     ],
   },
   ch6: {

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -114,6 +114,11 @@ describe('Aion framework data contract', () => {
       'fourth',
       'tree',
     ]);
+    expect(CHAPTER_SCENES.ch5.panels.map((panel) => panel.kicker)).toEqual([
+      'Cross',
+      'Fourth',
+      'Root',
+    ]);
     expect(CHAPTER_SCENES.ch5.motionGrammar).toBe('opposition');
     expect(CHAPTER_SCENES.ch5.visualTheme).toContain('Christ symbol');
     expect(CHAPTER_SCENES.ch5.fallbackSummary).toContain('luminous cross');
@@ -139,6 +144,10 @@ describe('Aion framework route contract', () => {
     expect(resolveRoute('/journey/chapter/ch3')).toMatchObject({
       name: 'chapter',
       params: { chapterId: 'ch3' },
+    });
+    expect(resolveRoute('/journey/chapter/ch5/')).toMatchObject({
+      name: 'chapter',
+      params: { chapterId: 'ch5' },
     });
     expect(resolveRoute('/atlas')).toMatchObject({ name: 'atlas' });
     expect(resolveRoute('/missing')).toMatchObject({ name: 'home' });


### PR DESCRIPTION
## Summary
- Resolve chapter routes through the canonical route matcher in the shell so deployed trailing-slash URLs keep the correct active chapter.
- Rename Chapter 5 visual panel labels from generic Axis/Shadow/Depth to Cross/Fourth/Root.
- Add unit and Playwright smoke coverage for the Chapter 5 trailing-slash route and labels.

## Verification
- npx tsc --noEmit
- npm run lint
- npm run test:app
- npm test
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run build
- npm run test:e2e:app
- AION_A11Y_PORT=4186 npm run test:a11y:app
- npm run build:pages && npm run test:pages:artifact
- Browser visual smoke: http://127.0.0.1:4176/journey/chapter/ch5/ shows Chapter 5 nav context and Cross/Fourth/Root labels