### PR TITLE
feat: polish chapter three relation lab

### DIFF
--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -597,8 +597,8 @@ async function smokeChapterSceneControls(page, failures) {
 
   const orbitPressed = await orbit.getAttribute('aria-pressed');
   const orbitPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="orbit"]').count();
-  const orbitPanelAnnotationVisible = await page.locator('.ch3-a--dance.panel-vis').count();
-  const orbitAnnotationDisplay = await page.locator('.ch3-a--dance.panel-vis').evaluate((node) => window.getComputedStyle(node).display).catch(() => 'missing');
+  const orbitPanelAnnotationVisible = await page.locator('.ch3-panel-note--orbit.panel-vis').count();
+  const orbitAnnotationDisplay = await page.locator('.ch3-panel-note--orbit.panel-vis').evaluate((node) => window.getComputedStyle(node).display).catch(() => 'missing');
   const chapterThreeOrbitScrollY = await page.evaluate(() => window.scrollY);
   const chapterThreeOrbitDescription = await page.locator('#scene-host-description-ch3').textContent();
   if (orbitPressed !== 'true') failures.push(`chapter 3 orbit reference did not become active: ${orbitPressed}`);
@@ -606,7 +606,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (orbitPanelAnnotationVisible !== 1) failures.push(`chapter 3 orbit annotation did not follow selected panel: ${orbitPanelAnnotationVisible}`);
   if (orbitAnnotationDisplay === 'none' || orbitAnnotationDisplay === 'missing') failures.push(`chapter 3 orbit annotation display is not visible: ${orbitAnnotationDisplay}`);
   if (chapterThreeOrbitScrollY > 10) failures.push(`chapter 3 orbit control unexpectedly scrolled page: ${chapterThreeOrbitScrollY}`);
-  if (!chapterThreeOrbitDescription?.includes('Relation: Neither pole stands alone')) failures.push(`chapter 3 scene description did not follow orbit panel: ${chapterThreeOrbitDescription}`);
+  if (!chapterThreeOrbitDescription?.includes('Relation: Projection becomes orbit')) failures.push(`chapter 3 scene description did not follow orbit panel: ${chapterThreeOrbitDescription}`);
 
   const conjunction = page.locator('.chapter-stage__reference-node[data-panel-id="union"]');
   await conjunction.click();
@@ -633,7 +633,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (conjunctionAnnotationState.display === 'none') failures.push('chapter 3 conjunction annotation is still display none');
   if (conjunctionAnnotationState.opacity <= 0) failures.push(`chapter 3 conjunction annotation opacity stayed hidden: ${conjunctionAnnotationState.opacity}`);
   if (chapterThreeUnionScrollY > 10) failures.push(`chapter 3 union control unexpectedly scrolled page: ${chapterThreeUnionScrollY}`);
-  if (!chapterThreeUnionDescription?.includes('Conjunction: A brief union')) failures.push(`chapter 3 scene description did not follow union panel: ${chapterThreeUnionDescription}`);
+  if (!chapterThreeUnionDescription?.includes('Conjunction: Union flashes, then moves')) failures.push(`chapter 3 scene description did not follow union panel: ${chapterThreeUnionDescription}`);
 
   const pair = page.locator('.chapter-stage__reference-node[data-panel-id="pair"]');
   await pair.click();

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2065,6 +2065,51 @@ h3 {
   font-size: clamp(3rem, 6.2vw, 6rem);
 }
 
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__scrim {
+  background:
+    radial-gradient(circle at 56% 48%, rgba(83, 216, 232, 0.08), transparent 18rem),
+    radial-gradient(circle at 74% 46%, rgba(212, 175, 55, 0.09), transparent 18rem),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.78), rgba(3, 3, 7, 0.18) 39%, rgba(3, 3, 7, 0.5) 100%);
+}
+
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__intro {
+  width: min(34rem, calc(100% - 2rem));
+  justify-content: flex-end;
+  margin-left: clamp(1rem, 4.8vw, 4rem);
+  padding-bottom: clamp(2.8rem, 7vh, 5.25rem);
+}
+
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__intro h1 {
+  max-width: 9.8ch;
+  font-size: clamp(3.25rem, 6.4vw, 5.85rem);
+}
+
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__intro p:not(.eyebrow) {
+  max-width: 34ch;
+  font-size: clamp(1rem, 1.35vw, 1.08rem);
+}
+
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__thesis-map {
+  max-width: 28rem;
+  margin-top: 1.25rem;
+}
+
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__reference-map {
+  width: min(24rem, 100%);
+}
+
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__reference-node {
+  min-height: 3.9rem;
+  background:
+    radial-gradient(circle at 50% 30%, rgba(255, 224, 240, 0.08), transparent 2.1rem),
+    linear-gradient(180deg, rgba(7, 7, 18, 0.48), rgba(7, 7, 18, 0.18));
+  backdrop-filter: blur(8px);
+}
+
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__reference-label {
+  margin-top: 2.15rem;
+}
+
 .chapter-stage__thesis-map {
   display: flex;
   flex-wrap: wrap;

--- a/src/app/visualization/chapterScenes.ts
+++ b/src/app/visualization/chapterScenes.ts
@@ -32,12 +32,12 @@ export const CHAPTER_SCENES: Record<ChapterId, ChapterExperience> = {
     visualTheme: 'Anima/animus orbital relation',
     sceneModule: '../visualizations/chapters/ch3/ThreeSyzygyViz.js',
     motionGrammar: 'integration',
-    fallbackSummary: 'Two luminous poles orbit one another: projection makes the inner image appear outside, relation keeps the pair in motion, and conjunction flashes as a brief symbolic union.',
-    checkpoints: ['Distinguish anima and animus as symbolic poles.', 'Trace projection into relationship.', 'Find conjunction without freezing the orbit.'],
+    fallbackSummary: 'A relation lab sets anima and animus as two symbolic poles: projection makes the inner image appear outside, orbit keeps the tension readable, and conjunction appears as a brief symbolic union rather than a final fusion.',
+    checkpoints: ['Name anima and animus as symbolic poles, not fixed identities.', 'Trace projection outward and back into relation.', 'Explain why conjunction flashes and then releases into motion.'],
     panels: [
-      { id: 'pair', kicker: 'Syzygy', title: 'The inner pair', body: 'Anima and animus appear as symbolic poles mediating relation to the unconscious.', insight: 'The psyche thinks in living opposites.' },
-      { id: 'orbit', kicker: 'Relation', title: 'Neither pole stands alone', body: 'The orbit is the lesson: projection, attraction, and resistance become intelligible through relation.', insight: 'Wholeness needs tension, not sameness.' },
-      { id: 'union', kicker: 'Conjunction', title: 'A brief union', body: 'Alignment flashes as a symbolic marriage, then releases back into motion.', insight: 'Integration is rhythmic, not static.' },
+      { id: 'pair', kicker: 'Syzygy', title: 'Two poles, one psyche', body: 'Anima and animus mediate relation to the unconscious without becoming fixed identities.', insight: 'The psyche thinks in living opposites.' },
+      { id: 'orbit', kicker: 'Relation', title: 'Projection becomes orbit', body: 'Attraction, resistance, and return become readable only when the image stays in relation.', insight: 'Wholeness needs tension, not sameness.' },
+      { id: 'union', kicker: 'Conjunction', title: 'Union flashes, then moves', body: 'Alignment forms a symbolic mandorla, then releases back into motion.', insight: 'Integration is rhythmic, not static.' },
     ],
   },
   ch4: {

--- a/src/visualizations/chapters/ch3/ThreeSyzygyViz.js
+++ b/src/visualizations/chapters/ch3/ThreeSyzygyViz.js
@@ -71,7 +71,7 @@ export default class ThreeSyzygyViz extends BaseViz {
         this.pairFocus = 1;
         this.orbitFocus = 0;
         this.unionFocus = 0;
-        this.guidedAnnotations = true;
+        this.guidedAnnotations = false;
         this.annotationPaused = false;
     }
 
@@ -544,9 +544,60 @@ export default class ThreeSyzygyViz extends BaseViz {
     transition-delay: 0s;
 }
 .ch3-a.panel-hidden,
+.ch3-panel-note.panel-hidden,
 .ch3-micro.panel-hidden,
 .ch3-quat-label.panel-hidden {
     display: none;
+}
+
+.ch3-panel-note {
+    position: absolute;
+    right: clamp(1rem, 4vw, 4.5rem);
+    bottom: clamp(4.8rem, 10vh, 7rem);
+    width: min(23rem, calc(100vw - 2rem));
+    border-top: 1px solid rgba(255, 224, 160, 0.36);
+    padding-top: 0.85rem;
+    font-family: 'Instrument Serif', serif;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(8px);
+    transition: opacity 1.2s cubic-bezier(0.16, 1, 0.3, 1),
+                transform 1.2s cubic-bezier(0.16, 1, 0.3, 1),
+                visibility 0s linear 1.2s;
+}
+
+.ch3-panel-note.panel-vis {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    transition-delay: 0s;
+}
+
+.ch3-panel-note__index {
+    display: block;
+    margin-bottom: 0.38rem;
+    font-family: 'Outfit', 'Helvetica Neue', sans-serif;
+    font-size: clamp(0.54rem, 0.75vw, 0.66rem);
+    font-weight: 700;
+    letter-spacing: 0.34em;
+    text-transform: uppercase;
+    color: rgba(255, 213, 120, 0.74);
+}
+
+.ch3-panel-note__title {
+    display: block;
+    margin-bottom: 0.34rem;
+    color: rgba(255, 244, 224, 0.9);
+    font-size: clamp(1.28rem, 2vw, 1.85rem);
+    font-style: italic;
+    line-height: 1.03;
+}
+
+.ch3-panel-note__body {
+    display: block;
+    color: rgba(212, 206, 224, 0.68);
+    font-size: clamp(0.82rem, 1.05vw, 0.95rem);
+    line-height: 1.55;
 }
 
 /* ─── Phase 1: Chapter heading ─── */
@@ -754,7 +805,7 @@ export default class ThreeSyzygyViz extends BaseViz {
     transform: translate(-50%, -50%) translateY(6px);
 }
 .ch3-a--conjunction .ch3-conj-text {
-    font-size: clamp(0.88rem, 1.3vw, 1.1rem);
+    font-size: clamp(0.82rem, 1.15vw, 1rem);
     font-style: italic;
     color: rgba(255, 236, 246, 0.86);
     line-height: 1.65;
@@ -870,6 +921,7 @@ export default class ThreeSyzygyViz extends BaseViz {
 
 @media (max-width: 768px) {
     .ch3-annotations { display: none; }
+    .ch3-panel-note { display: none; }
     .ch3-a--dance { max-width: 24ch; bottom: 16vh; }
     .ch3-a--anima, .ch3-a--animus { max-width: 18ch; }
     .ch3-a--projection, .ch3-a--quaternio { max-width: 22ch; }
@@ -942,10 +994,29 @@ export default class ThreeSyzygyViz extends BaseViz {
 <div class="ch3-a ch3-a--conjunction">
     <div class="ch3-conj-text">
         Conjunction<br>
-        two poles overlap into a <em>mandorla</em><br>
-        a brief image of wholeness
+        a brief <em>mandorla</em><br>
+        not a final fusion
         <span class="ch3-conj-sub">Glimpsed, not possessed</span>
     </div>
+</div>
+
+<!-- Panel-led lab notes -->
+<div class="ch3-panel-note ch3-panel-note--pair" data-panel-note="pair">
+    <span class="ch3-panel-note__index">01 / Inner Pair</span>
+    <span class="ch3-panel-note__title">Two poles, one psyche</span>
+    <span class="ch3-panel-note__body">Anima and animus mediate relation to the unconscious without becoming fixed identities.</span>
+</div>
+
+<div class="ch3-panel-note ch3-panel-note--orbit" data-panel-note="orbit">
+    <span class="ch3-panel-note__index">02 / Relation Field</span>
+    <span class="ch3-panel-note__title">Projection becomes orbit</span>
+    <span class="ch3-panel-note__body">The image first appears outside, then returns as a pattern the ego can recognize.</span>
+</div>
+
+<div class="ch3-panel-note ch3-panel-note--union" data-panel-note="union">
+    <span class="ch3-panel-note__index">03 / Conjunction</span>
+    <span class="ch3-panel-note__title">Union flashes, then moves</span>
+    <span class="ch3-panel-note__body">Wholeness is glimpsed as rhythm: contact, separation, relation.</span>
 </div>
 
 <!-- Quaternio cardinal labels -->
@@ -969,7 +1040,7 @@ export default class ThreeSyzygyViz extends BaseViz {
             { sel: '[data-phase="5"]', delay: 35000 },
             { sel: '[data-phase="6"]', delay: 42000 },
         ];
-        this._scheduleAnnotations();
+        if (this.guidedAnnotations) this._scheduleAnnotations();
         this._syncPanelAnnotations();
     }
 
@@ -997,7 +1068,7 @@ export default class ThreeSyzygyViz extends BaseViz {
     _usePanelAnnotationMode() {
         this.guidedAnnotations = false;
         this._clearAnnotationTimers();
-        this._annotationOverlay?.querySelectorAll('.ch3-a[data-phase], .ch3-a--conjunction, .ch3-micro, .ch3-quat-label').forEach(el => {
+        this._annotationOverlay?.querySelectorAll('.ch3-a[data-phase], .ch3-a--conjunction, .ch3-panel-note, .ch3-micro, .ch3-quat-label').forEach(el => {
             el.classList.remove('vis', 'panel-vis');
             el.classList.add('panel-hidden');
         });
@@ -1007,7 +1078,7 @@ export default class ThreeSyzygyViz extends BaseViz {
         const ov = this._annotationOverlay;
         if (!ov) return;
 
-        ov.querySelectorAll('.ch3-a[data-phase], .ch3-a--conjunction, .ch3-micro, .ch3-quat-label').forEach(el => {
+        ov.querySelectorAll('.ch3-a[data-phase], .ch3-a--conjunction, .ch3-panel-note, .ch3-micro, .ch3-quat-label').forEach(el => {
             el.classList.remove('panel-vis');
             if (!this.guidedAnnotations || this.annotationPaused) el.classList.remove('vis');
             if (!this.guidedAnnotations) {
@@ -1019,14 +1090,16 @@ export default class ThreeSyzygyViz extends BaseViz {
 
         const conjAnn = ov.querySelector('.ch3-a--conjunction');
         conjAnn?.classList.add('hid');
-        if (this.annotationPaused) return;
 
         const panelId = this.panelState?.activePanelId || 'pair';
         const panelPhases = {
             pair: [],
-            orbit: ['3', '5', '6'],
+            orbit: [],
             union: [],
         }[panelId] || [];
+
+        ov.querySelector(`[data-panel-note="${panelId}"]`)?.classList.remove('panel-hidden');
+        ov.querySelector(`[data-panel-note="${panelId}"]`)?.classList.add('panel-vis');
 
         for (const phase of panelPhases) {
             ov.querySelectorAll(`[data-phase="${phase}"]`).forEach(el => {


### PR DESCRIPTION
## Summary
- recast Chapter 3 as a panel-driven syzygy relation lab instead of timed annotation buildup
- open the Chapter 3 stage composition so the Three.js orbit owns the viewport
- tighten Chapter 3 accessible/fallback copy and update app-shell smoke coverage for the new lab-note contract

## Verification
- node --check src/visualizations/chapters/ch3/ThreeSyzygyViz.js
- node --check scripts/testing/app-shell-smoke.mjs
- npm run test:app
- npm run build
- npm run test:e2e:app
- npm run test:a11y:app
- npm test
- npm run validate:consistency
- npm run ci:chapter-shell
- npx tsc --noEmit
- npm run lint
- npm run build:pages
- npm run test:pages:artifact

## Notes
- Vite still reports the existing large three.js chunk warning; this pass does not add a new heavy dependency.
- Browser review covered desktop, orbit/union panel states, mobile 390x844, and reduced-motion fallback.