### PR TITLE
feat: polish Atlas constellation instrument

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -1,22 +1,28 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
+import { dirname, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
 
 import { chromium } from 'playwright';
 
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const port = Number(process.env.AION_A11Y_PORT || 4175);
 const baseUrl = `http://127.0.0.1:${port}`;
 const canonicalRoutes = ['/', '/chapters', '/atlas', '/timeline', '/symbols', '/about'];
 const chapterRoutes = Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`);
 const desktopViewport = { width: 1440, height: 1000 };
 const mobileViewport = { width: 390, height: 844 };
+const viteBin = process.platform === 'win32'
+  ? resolve(repoRoot, 'node_modules/.bin/vite.cmd')
+  : resolve(repoRoot, 'node_modules/.bin/vite');
 
 function startPreviewServer() {
   const child = spawn(
-    'npx',
-    ['vite', 'preview', '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
+    viteBin,
+    ['preview', '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
     {
-      cwd: process.cwd(),
+      cwd: repoRoot,
       env: process.env,
       detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -59,7 +65,7 @@ async function stopPreviewServer(server) {
 }
 
 async function waitForServer(server) {
-  const deadline = Date.now() + 30_000;
+  const deadline = Date.now() + 60_000;
   while (Date.now() < deadline) {
     if (server.child.exitCode !== null) {
       throw new Error(`Vite preview exited early.\n${server.getOutput()}`);

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -1,9 +1,12 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
+import { dirname, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
 
 import { chromium } from 'playwright';
 
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const port = Number(process.env.AION_SMOKE_PORT || 4174);
 const baseUrl = `http://127.0.0.1:${port}`;
 const canonicalRoutes = ['/', '/chapters', '/atlas', '/timeline', '/symbols', '/about'];
@@ -18,13 +21,21 @@ const canonicalRouteLabels = new Map([
 const chapterRoutes = Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`);
 const desktopViewport = { width: 1440, height: 1000 };
 const mobileViewport = { width: 390, height: 844 };
+const debugSmoke = process.env.AION_SMOKE_DEBUG === 'true';
+const viteBin = process.platform === 'win32'
+  ? resolve(repoRoot, 'node_modules/.bin/vite.cmd')
+  : resolve(repoRoot, 'node_modules/.bin/vite');
+
+function smokeLog(message) {
+  if (debugSmoke) console.log(`[smoke] ${message}`);
+}
 
 function startPreviewServer() {
   const child = spawn(
-    'npx',
-    ['vite', 'preview', '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
+    viteBin,
+    ['preview', '--host', '127.0.0.1', '--port', String(port), '--strictPort'],
     {
-      cwd: process.cwd(),
+      cwd: repoRoot,
       env: process.env,
       detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -67,7 +78,7 @@ async function stopPreviewServer(server) {
 }
 
 async function waitForServer(server) {
-  const deadline = Date.now() + 30_000;
+  const deadline = Date.now() + 60_000;
   while (Date.now() < deadline) {
     if (server.child.exitCode !== null) {
       throw new Error(`Vite preview exited early.\n${server.getOutput()}`);
@@ -107,8 +118,14 @@ function watchForRouteFailures(page) {
 }
 
 async function gotoAppRoute(page, route) {
-  await page.goto(`${baseUrl}${route}`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
-  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  smokeLog(`goto ${route}`);
+  await page.goto(`${baseUrl}${route}`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  try {
+    await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 30_000 });
+  } catch (error) {
+    throw new Error(`main#main-content did not become visible for ${route}: ${error.message}`);
+  }
+  smokeLog(`ready ${route}`);
 }
 
 async function assertHealthyShell(page, route, failures) {
@@ -129,7 +146,15 @@ async function assertHealthyShell(page, route, failures) {
 
 async function countCanvasPixels(canvas) {
   return canvas.evaluate((element) => new Promise((resolve) => {
+    let timedOut = false;
+    const timeout = window.setTimeout(() => {
+      timedOut = true;
+      resolve({ timedOut: true, visiblePixels: 0 });
+    }, 2_500);
+
     requestAnimationFrame(() => {
+      if (timedOut) return;
+      window.clearTimeout(timeout);
       const gl = element.getContext('webgl2')
         || element.getContext('webgl')
         || element.getContext('experimental-webgl');
@@ -150,13 +175,23 @@ async function countCanvasPixels(canvas) {
           }
         }
 
-        resolve(visiblePixels);
+        resolve({ timedOut: false, visiblePixels });
         return;
       }
 
-      resolve(0);
+      resolve({ timedOut: false, visiblePixels: 0 });
     });
   }));
+}
+
+function recordCanvasPixelFailure(failures, label, result) {
+  if (result.timedOut) {
+    failures.push(`${label} canvas pixel sampling timed out`);
+    return;
+  }
+  if (result.visiblePixels <= 8) {
+    failures.push(`${label} canvas appears blank: ${result.visiblePixels}`);
+  }
 }
 
 async function smokeCanonicalRoutes(page, failures) {
@@ -291,16 +326,33 @@ async function smokeAtlasVisualSearch(page, failures) {
 }
 
 async function smokeChapterRoutes(page, failures) {
-  for (const route of chapterRoutes) {
-    await gotoAppRoute(page, route);
-    await assertHealthyShell(page, route, failures);
+  const browser = page.context().browser();
 
-    const canvas = page.locator('.scene-host canvas').first();
-    await canvas.waitFor({ state: 'visible', timeout: 15_000 });
-    await page.waitForTimeout(500);
-    const visiblePixels = await countCanvasPixels(canvas);
-    if (visiblePixels <= 8) {
-      failures.push(`blank or near-blank chapter canvas: ${route} (${visiblePixels} sampled pixels)`);
+  for (const route of chapterRoutes) {
+    if (!browser) throw new Error('Chapter route smoke requires a browser instance.');
+
+    const chapterContext = await browser.newContext({ viewport: desktopViewport });
+    const chapterPage = await chapterContext.newPage();
+    const routeFailures = watchForRouteFailures(chapterPage);
+
+    try {
+      await gotoAppRoute(chapterPage, route);
+      await assertHealthyShell(chapterPage, route, failures);
+
+      const canvas = chapterPage.locator('.scene-host canvas').first();
+      await canvas.waitFor({ state: 'visible', timeout: 15_000 });
+      await chapterPage.waitForTimeout(500);
+      const { timedOut, visiblePixels } = await countCanvasPixels(canvas);
+      if (timedOut) {
+        failures.push(`chapter canvas pixel sampling timed out: ${route}`);
+      } else if (visiblePixels <= 8) {
+        failures.push(`blank or near-blank chapter canvas: ${route} (${visiblePixels} sampled pixels)`);
+      }
+      await chapterPage.waitForTimeout(250);
+      failures.push(...routeFailures.notFound.map((url) => `404 response: ${url}`));
+      failures.push(...routeFailures.consoleErrors.map((message) => `console error: ${message}`));
+    } finally {
+      await chapterContext.close();
     }
   }
 }
@@ -465,7 +517,11 @@ async function smokeChapterJump(page, failures) {
   await page.locator('#chapter-jump-select').waitFor({ state: 'visible', timeout: 10_000 });
   await page.selectOption('#chapter-jump-select', 'ch3');
   await page.waitForURL(/\/journey\/chapter\/ch3$/, { timeout: 10_000 });
-  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  try {
+    await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 30_000 });
+  } catch (error) {
+    throw new Error(`main#main-content did not become visible after chapter jump: ${error.message}`);
+  }
   await page.waitForFunction(() => document.querySelector('#chapter-jump-select')?.value === 'ch3', null, { timeout: 10_000 }).catch(() => {});
 
   const selectValue = await page.locator('#chapter-jump-select').inputValue();
@@ -477,22 +533,28 @@ async function smokeChapterJump(page, failures) {
   if (!nextVisible) failures.push('chapter route missing next chapter control');
 }
 
+async function activateSceneButton(locator) {
+  await locator.waitFor({ state: 'visible', timeout: 30_000 });
+  await locator.scrollIntoViewIfNeeded({ timeout: 10_000 });
+  await locator.click({ timeout: 30_000 });
+}
+
 async function smokeChapterSceneControls(page, failures) {
   await gotoAppRoute(page, '/journey/chapter/ch1');
   const chapterOneReferenceCount = await page.locator('.chapter-stage__reference-node').count();
   if (chapterOneReferenceCount !== 3) failures.push(`chapter 1 reference node count mismatch: ${chapterOneReferenceCount}`);
 
   const pauseAnimation = page.getByRole('button', { name: /Pause animation/ });
-  await pauseAnimation.click();
+  await activateSceneButton(pauseAnimation);
   await page.waitForTimeout(5_400);
   const paused = await page.getByRole('button', { name: /Resume animation/ }).getAttribute('aria-pressed');
   const pausedAnnotationCount = await page.locator('.ch1-a.vis').count();
   if (paused !== 'true') failures.push(`chapter animation pause control did not stay pressed: ${paused}`);
   if (pausedAnnotationCount !== 0) failures.push(`chapter animation pause allowed timed annotations to reveal: ${pausedAnnotationCount}`);
-  await page.getByRole('button', { name: /Resume animation/ }).click();
+  await activateSceneButton(page.getByRole('button', { name: /Resume animation/ }));
 
   const rootsReference = page.locator('.chapter-stage__reference-node[data-panel-id="roots"]');
-  await rootsReference.click();
+  await activateSceneButton(rootsReference);
   await page.waitForTimeout(5_400);
   const rootsReferencePressed = await rootsReference.getAttribute('aria-pressed');
   const rootsAnnotationState = await page.evaluate(() => ({
@@ -504,7 +566,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (!rootsAnnotationState.rootsPanelVisible) failures.push('chapter 1 roots annotation did not follow selected panel');
 
   const wholeness = page.getByRole('button', { name: /03\s+Wholeness/ });
-  await wholeness.click();
+  await activateSceneButton(wholeness);
   await page.waitForTimeout(250);
 
   const pressed = await wholeness.getAttribute('aria-pressed');
@@ -524,16 +586,16 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterTwoPanelIds.join(',') !== 'mirror,projection,integration') failures.push(`chapter 2 reference nodes out of order: ${chapterTwoPanelIds.join(',')}`);
 
   const chapterTwoPause = page.getByRole('button', { name: /Pause animation/ });
-  await chapterTwoPause.click();
+  await activateSceneButton(chapterTwoPause);
   await page.waitForTimeout(5_400);
   const chapterTwoPaused = await page.getByRole('button', { name: /Resume animation/ }).getAttribute('aria-pressed');
   const chapterTwoPausedAnnotationCount = await page.locator('.ch2-a--ego.vis, .ch2-micro--ego.vis').count();
   if (chapterTwoPaused !== 'true') failures.push(`chapter 2 pause control did not stay pressed: ${chapterTwoPaused}`);
   if (chapterTwoPausedAnnotationCount !== 0) failures.push(`chapter 2 pause allowed timed annotations to reveal: ${chapterTwoPausedAnnotationCount}`);
-  await page.getByRole('button', { name: /Resume animation/ }).click();
+  await activateSceneButton(page.getByRole('button', { name: /Resume animation/ }));
 
   const projection = page.locator('.chapter-stage__reference-node[data-panel-id="projection"]');
-  await projection.click();
+  await activateSceneButton(projection);
   await page.waitForTimeout(250);
 
   const projectionPressed = await projection.getAttribute('aria-pressed');
@@ -548,7 +610,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (!chapterTwoSceneDescription?.includes('Projection: Thrown outward')) failures.push(`chapter 2 scene description did not follow projection panel: ${chapterTwoSceneDescription}`);
 
   const integration = page.locator('.chapter-stage__reference-node[data-panel-id="integration"]');
-  await integration.click();
+  await activateSceneButton(integration);
   await page.waitForFunction(() => document.querySelector('.ch2-a--integration')?.classList.contains('vis'), null, { timeout: 2_000 }).catch(() => {});
   const integrationPressed = await integration.getAttribute('aria-pressed');
   const integrationAnnotationVisible = await page.locator('.ch2-a--integration.vis').count();
@@ -556,7 +618,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (integrationAnnotationVisible !== 1) failures.push(`chapter 2 integration annotation did not follow selected panel: ${integrationAnnotationVisible}`);
 
   const mirror = page.locator('.chapter-stage__reference-node[data-panel-id="mirror"]');
-  await mirror.click();
+  await activateSceneButton(mirror);
   await page.waitForTimeout(850);
   const integrationAnnotationState = await page.locator('.ch2-a--integration').evaluate((node) => ({
     visible: node.classList.contains('vis'),
@@ -567,11 +629,11 @@ async function smokeChapterSceneControls(page, failures) {
 
   const chapterTwoCanvas = page.locator('.scene-host canvas').first();
   const chapterTwoCanvasBox = await chapterTwoCanvas.boundingBox();
-  const chapterTwoVisiblePixels = await countCanvasPixels(chapterTwoCanvas);
+  const chapterTwoPixelSample = await countCanvasPixels(chapterTwoCanvas);
   if (!chapterTwoCanvasBox || chapterTwoCanvasBox.width < 300 || chapterTwoCanvasBox.height < 300) {
     failures.push(`chapter 2 canvas geometry too small: ${chapterTwoCanvasBox ? `${Math.round(chapterTwoCanvasBox.width)}x${Math.round(chapterTwoCanvasBox.height)}` : 'missing'}`);
   }
-  if (chapterTwoVisiblePixels <= 8) failures.push(`chapter 2 canvas appears blank: ${chapterTwoVisiblePixels}`);
+  recordCanvasPixelFailure(failures, 'chapter 2', chapterTwoPixelSample);
 
   await page.evaluate(() => window.localStorage.removeItem('aion:scene-animation-paused'));
   await gotoAppRoute(page, '/journey/chapter/ch3');
@@ -583,16 +645,16 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterThreePanelIds.join(',') !== 'pair,orbit,union') failures.push(`chapter 3 reference nodes out of order: ${chapterThreePanelIds.join(',')}`);
 
   const chapterThreePause = page.getByRole('button', { name: /Pause animation/ });
-  await chapterThreePause.click();
+  await activateSceneButton(chapterThreePause);
   await page.waitForTimeout(5_400);
   const chapterThreePaused = await page.getByRole('button', { name: /Resume animation/ }).getAttribute('aria-pressed');
   const chapterThreePausedAnnotationCount = await page.locator('.ch3-a--anima.vis, .ch3-micro--anima.vis').count();
   if (chapterThreePaused !== 'true') failures.push(`chapter 3 pause control did not stay pressed: ${chapterThreePaused}`);
   if (chapterThreePausedAnnotationCount !== 0) failures.push(`chapter 3 pause allowed timed annotations to reveal: ${chapterThreePausedAnnotationCount}`);
-  await page.getByRole('button', { name: /Resume animation/ }).click();
+  await activateSceneButton(page.getByRole('button', { name: /Resume animation/ }));
 
   const orbit = page.locator('.chapter-stage__reference-node[data-panel-id="orbit"]');
-  await orbit.click();
+  await activateSceneButton(orbit);
   await page.waitForTimeout(250);
 
   const orbitPressed = await orbit.getAttribute('aria-pressed');
@@ -609,7 +671,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (!chapterThreeOrbitDescription?.includes('Relation: Projection becomes orbit')) failures.push(`chapter 3 scene description did not follow orbit panel: ${chapterThreeOrbitDescription}`);
 
   const conjunction = page.locator('.chapter-stage__reference-node[data-panel-id="union"]');
-  await conjunction.click();
+  await activateSceneButton(conjunction);
   await page.waitForFunction(() => {
     const node = document.querySelector('.ch3-a--conjunction');
     return node?.classList.contains('vis') && Number(window.getComputedStyle(node).opacity) > 0.01;
@@ -636,7 +698,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (!chapterThreeUnionDescription?.includes('Conjunction: Union flashes, then moves')) failures.push(`chapter 3 scene description did not follow union panel: ${chapterThreeUnionDescription}`);
 
   const pair = page.locator('.chapter-stage__reference-node[data-panel-id="pair"]');
-  await pair.click();
+  await activateSceneButton(pair);
   await page.waitForTimeout(250);
   const conjunctionHiddenAfterPair = await page.locator('.ch3-a--conjunction').evaluate((node) => ({
     visible: node.classList.contains('vis'),
@@ -647,11 +709,11 @@ async function smokeChapterSceneControls(page, failures) {
 
   const chapterThreeCanvas = page.locator('.scene-host canvas').first();
   const chapterThreeCanvasBox = await chapterThreeCanvas.boundingBox();
-  const chapterThreeVisiblePixels = await countCanvasPixels(chapterThreeCanvas);
+  const chapterThreePixelSample = await countCanvasPixels(chapterThreeCanvas);
   if (!chapterThreeCanvasBox || chapterThreeCanvasBox.width < 300 || chapterThreeCanvasBox.height < 300) {
     failures.push(`chapter 3 canvas geometry too small: ${chapterThreeCanvasBox ? `${Math.round(chapterThreeCanvasBox.width)}x${Math.round(chapterThreeCanvasBox.height)}` : 'missing'}`);
   }
-  if (chapterThreeVisiblePixels <= 8) failures.push(`chapter 3 canvas appears blank: ${chapterThreeVisiblePixels}`);
+  recordCanvasPixelFailure(failures, 'chapter 3', chapterThreePixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch4');
   await page.locator('.scene-host__mount[data-state="ready"]').waitFor({ state: 'visible', timeout: 10_000 });
@@ -681,7 +743,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (!chapterFourPanelGlyphsVisible) failures.push('chapter 4 panel quaternity/mandala glyphs are not visibly rendered');
 
   const quaternity = page.locator('.chapter-stage__reference-node[data-panel-id="quaternity"]');
-  await quaternity.click();
+  await activateSceneButton(quaternity);
   await page.waitForTimeout(250);
 
   const quaternityPressed = await quaternity.getAttribute('aria-pressed');
@@ -694,7 +756,7 @@ async function smokeChapterSceneControls(page, failures) {
   }
 
   const mandala = page.locator('.chapter-stage__reference-node[data-panel-id="mandala"]');
-  await mandala.click();
+  await activateSceneButton(mandala);
   await page.waitForTimeout(250);
 
   const mandalaPressed = await mandala.getAttribute('aria-pressed');
@@ -708,11 +770,11 @@ async function smokeChapterSceneControls(page, failures) {
 
   const chapterFourCanvas = page.locator('.scene-host canvas').first();
   const chapterFourCanvasBox = await chapterFourCanvas.boundingBox();
-  const chapterFourVisiblePixels = await countCanvasPixels(chapterFourCanvas);
+  const chapterFourPixelSample = await countCanvasPixels(chapterFourCanvas);
   if (!chapterFourCanvasBox || chapterFourCanvasBox.width < 300 || chapterFourCanvasBox.height < 300) {
     failures.push(`chapter 4 canvas geometry too small: ${chapterFourCanvasBox ? `${Math.round(chapterFourCanvasBox.width)}x${Math.round(chapterFourCanvasBox.height)}` : 'missing'}`);
   }
-  if (chapterFourVisiblePixels <= 8) failures.push(`chapter 4 canvas appears blank: ${chapterFourVisiblePixels}`);
+  recordCanvasPixelFailure(failures, 'chapter 4', chapterFourPixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch5');
   await page.locator('.scene-host__mount[data-state="ready"]').waitFor({ state: 'visible', timeout: 10_000 });
@@ -744,7 +806,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (!chapterFivePanelGlyphsVisible) failures.push('chapter 5 panel fourth/tree glyphs are not visibly rendered');
 
   const fourth = page.locator('.chapter-stage__reference-node[data-panel-id="fourth"]');
-  await fourth.click();
+  await activateSceneButton(fourth);
   await page.waitForTimeout(250);
 
   const fourthPressed = await fourth.getAttribute('aria-pressed');
@@ -757,7 +819,7 @@ async function smokeChapterSceneControls(page, failures) {
   }
 
   const tree = page.locator('.chapter-stage__reference-node[data-panel-id="tree"]');
-  await tree.click();
+  await activateSceneButton(tree);
   await page.waitForTimeout(250);
 
   const treePressed = await tree.getAttribute('aria-pressed');
@@ -771,15 +833,15 @@ async function smokeChapterSceneControls(page, failures) {
 
   const chapterFiveCanvas = page.locator('.scene-host canvas').first();
   const chapterFiveCanvasBox = await chapterFiveCanvas.boundingBox();
-  const chapterFiveVisiblePixels = await countCanvasPixels(chapterFiveCanvas);
+  const chapterFivePixelSample = await countCanvasPixels(chapterFiveCanvas);
   if (!chapterFiveCanvasBox || chapterFiveCanvasBox.width < 300 || chapterFiveCanvasBox.height < 300) {
     failures.push(`chapter 5 canvas geometry too small: ${chapterFiveCanvasBox ? `${Math.round(chapterFiveCanvasBox.width)}x${Math.round(chapterFiveCanvasBox.height)}` : 'missing'}`);
   }
-  if (chapterFiveVisiblePixels <= 8) failures.push(`chapter 5 canvas appears blank: ${chapterFiveVisiblePixels}`);
+  recordCanvasPixelFailure(failures, 'chapter 5', chapterFivePixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch6');
   const threshold = page.getByRole('button', { name: /03\s+Threshold/ });
-  await threshold.click();
+  await activateSceneButton(threshold);
   await page.waitForTimeout(250);
 
   const thresholdPressed = await threshold.getAttribute('aria-pressed');
@@ -789,7 +851,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   await gotoAppRoute(page, '/journey/chapter/ch7');
   const chapterSevenThreshold = page.getByRole('button', { name: /03\s+Threshold/ });
-  await chapterSevenThreshold.click();
+  await activateSceneButton(chapterSevenThreshold);
   await page.waitForTimeout(250);
 
   const chapterSevenPressed = await chapterSevenThreshold.getAttribute('aria-pressed');
@@ -799,7 +861,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   await gotoAppRoute(page, '/journey/chapter/ch8');
   const afterlife = page.getByRole('button', { name: /03\s+Afterlife/ });
-  await afterlife.click();
+  await activateSceneButton(afterlife);
   await page.waitForTimeout(250);
 
   const afterlifePressed = await afterlife.getAttribute('aria-pressed');
@@ -809,7 +871,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   await gotoAppRoute(page, '/journey/chapter/ch9');
   const shadowFish = page.getByRole('button', { name: /03\s+Shadow/ });
-  await shadowFish.click();
+  await activateSceneButton(shadowFish);
   await page.waitForTimeout(250);
 
   const shadowFishPressed = await shadowFish.getAttribute('aria-pressed');
@@ -819,7 +881,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   await gotoAppRoute(page, '/journey/chapter/ch10');
   const opus = page.getByRole('button', { name: /03\s+Opus/ });
-  await opus.click();
+  await activateSceneButton(opus);
   await page.waitForTimeout(250);
 
   const opusPressed = await opus.getAttribute('aria-pressed');
@@ -829,7 +891,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   await gotoAppRoute(page, '/journey/chapter/ch11');
   const stone = page.getByRole('button', { name: /03\s+Stone/ });
-  await stone.click();
+  await activateSceneButton(stone);
   await page.waitForTimeout(250);
 
   const stonePressed = await stone.getAttribute('aria-pressed');
@@ -839,7 +901,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   await gotoAppRoute(page, '/journey/chapter/ch12');
   const bridge = page.getByRole('button', { name: /03\s+Bridge/ });
-  await bridge.click();
+  await activateSceneButton(bridge);
   await page.waitForTimeout(250);
 
   const bridgePressed = await bridge.getAttribute('aria-pressed');
@@ -849,7 +911,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   await gotoAppRoute(page, '/journey/chapter/ch13');
   const paradox = page.getByRole('button', { name: /03\s+Paradox/ });
-  await paradox.click();
+  await activateSceneButton(paradox);
   await page.waitForTimeout(250);
 
   const paradoxPressed = await paradox.getAttribute('aria-pressed');
@@ -859,7 +921,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   await gotoAppRoute(page, '/journey/chapter/ch14');
   const aeon = page.getByRole('button', { name: /03\s+Aeon/ });
-  await aeon.click();
+  await activateSceneButton(aeon);
   await page.waitForTimeout(250);
 
   const aeonPressed = await aeon.getAttribute('aria-pressed');
@@ -957,8 +1019,8 @@ async function smokeMobile(page, failures) {
       const chapterThreeCanvas = page.locator('.scene-host canvas').first();
       const chapterThreeCanvasCount = await chapterThreeCanvas.count();
       if (chapterThreeCanvasCount > 0) {
-        const chapterThreeVisiblePixels = await countCanvasPixels(chapterThreeCanvas);
-        if (chapterThreeVisiblePixels <= 8) failures.push(`mobile chapter 3 canvas appears blank at ${viewport.width}x${viewport.height}: ${chapterThreeVisiblePixels}`);
+        const chapterThreePixelSample = await countCanvasPixels(chapterThreeCanvas);
+        recordCanvasPixelFailure(failures, `mobile chapter 3 at ${viewport.width}x${viewport.height}`, chapterThreePixelSample);
       }
     }
 
@@ -1024,7 +1086,7 @@ async function runSmoke() {
     browser = await chromium.launch({ headless: true });
     await smokeReducedMotion(browser, failures);
 
-    const page = await browser.newPage({ viewport: desktopViewport });
+    let page = await browser.newPage({ viewport: desktopViewport });
     const routeFailures = watchForRouteFailures(page);
 
     await smokeCanonicalRoutes(page, failures);
@@ -1034,8 +1096,20 @@ async function runSmoke() {
     await smokeKeyboard(page, failures);
     await smokeLegacyRedirect(page, failures);
     await smokeChapterJump(page, failures);
+    await page.close();
+
+    page = await browser.newPage({ viewport: desktopViewport });
+    const sceneRouteFailures = watchForRouteFailures(page);
     await smokeChapterSceneControls(page, failures);
+    failures.push(...sceneRouteFailures.notFound.map((url) => `404 response: ${url}`));
+    failures.push(...sceneRouteFailures.consoleErrors.map((message) => `console error: ${message}`));
+    await page.close();
+
+    page = await browser.newPage({ viewport: desktopViewport });
+    const mobileRouteFailures = watchForRouteFailures(page);
     await smokeMobile(page, failures);
+    failures.push(...mobileRouteFailures.notFound.map((url) => `404 response: ${url}`));
+    failures.push(...mobileRouteFailures.consoleErrors.map((message) => `console error: ${message}`));
 
     failures.push(...routeFailures.notFound.map((url) => `404 response: ${url}`));
     failures.push(...routeFailures.consoleErrors.map((message) => `console error: ${message}`));

--- a/src/app/components/AtlasConstellation.tsx
+++ b/src/app/components/AtlasConstellation.tsx
@@ -20,10 +20,37 @@ interface FieldNode {
   y: number;
 }
 
-const center = { x: 470, y: 300 };
+const center = { x: 500, y: 324 };
+const viewBox = { x: 40, y: 0, width: 920, height: 660 };
+
+const quadrants = [
+  { id: 'ego-axis', label: 'ego', radius: 318, start: -150, end: -34, x: 188, y: 126 },
+  { id: 'shadow-axis', label: 'shadow', radius: 318, start: -30, end: 86, x: 746, y: 126 },
+  { id: 'symbol-axis', label: 'symbol', radius: 318, start: 90, end: 206, x: 758, y: 568 },
+  { id: 'self-axis', label: 'self', radius: 318, start: 210, end: 326, x: 188, y: 568 },
+];
 
 function trimNodeLabel(label: string) {
   return label.length > 18 ? `${label.slice(0, 16)}…` : label;
+}
+
+function toRadians(degrees: number) {
+  return (degrees * Math.PI) / 180;
+}
+
+function polarPoint(radius: number, degrees: number) {
+  const angle = toRadians(degrees);
+  return {
+    x: center.x + Math.cos(angle) * radius,
+    y: center.y + Math.sin(angle) * radius,
+  };
+}
+
+function arcPath(radius: number, startDegrees: number, endDegrees: number) {
+  const start = polarPoint(radius, startDegrees);
+  const end = polarPoint(radius, endDegrees);
+  const largeArc = Math.abs(endDegrees - startDegrees) > 180 ? 1 : 0;
+  return `M ${start.x} ${start.y} A ${radius} ${radius} 0 ${largeArc} 1 ${end.x} ${end.y}`;
 }
 
 function placeNodes<T extends { id: string; label: string }>(items: T[], radius: number, type: FieldNode['type'], angleOffset: number): FieldNode[] {
@@ -49,15 +76,15 @@ export default function AtlasConstellation({
   entityLabel,
   onSelectChapter,
 }: AtlasConstellationProps) {
-  const conceptNodes = placeNodes(activeConcepts.slice(0, 6), 152, 'concept', -Math.PI / 2.1);
-  const symbolNodes = placeNodes(linkedSymbols.slice(0, 5), 238, 'symbol', -Math.PI / 1.18);
+  const conceptNodes = placeNodes(activeConcepts.slice(0, 6), 184, 'concept', -Math.PI / 2.18);
+  const symbolNodes = placeNodes(linkedSymbols.slice(0, 5), 286, 'symbol', -Math.PI / 1.14);
   const fieldNodes = [...conceptNodes, ...symbolNodes];
   const chapterResultText = `${filteredChapters.length} chapter${filteredChapters.length === 1 ? '' : 's'} in view`;
   const conceptLabels = activeConcepts.map((concept) => concept.label).join(', ');
   const symbolLabels = linkedSymbols.map((symbol) => symbol.label).join(', ');
   const fieldTitle = active ? `${active.title} Concept Field` : 'Empty Atlas Field';
   const fieldDescription = active
-    ? `The active chapter sits at the center. Inner concepts: ${conceptLabels || 'none curated yet'}. Outer symbols: ${symbolLabels || 'none curated yet'}.`
+    ? `The active chapter sits at the center. Inner concepts: ${conceptLabels || 'none curated yet'}. Outer symbols: ${symbolLabels || 'none curated yet'}. The four visible axes frame the field as ego, shadow, symbol, and Self.`
     : 'No chapters match the current search, so the constellation is empty.';
 
   const focusChapterButton = (chapterId: string) => {
@@ -89,41 +116,57 @@ export default function AtlasConstellation({
   return (
     <div className="atlas-constellation" aria-label={active ? `${active.title} concept constellation` : 'Empty Atlas constellation'}>
       <div className="atlas-constellation__stage" role="img" aria-labelledby="atlas-field-title atlas-field-desc">
-        <svg viewBox="120 20 760 580" aria-hidden="true" focusable="false">
+        <svg viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`} aria-hidden="true" focusable="false">
           <defs>
             <radialGradient id="atlas-field-core" cx="50%" cy="50%" r="50%">
               <stop offset="0%" stopColor="#fff4c2" stopOpacity="0.9" />
               <stop offset="52%" stopColor="#d4af37" stopOpacity="0.28" />
               <stop offset="100%" stopColor="#050508" stopOpacity="0" />
             </radialGradient>
+            <radialGradient id="atlas-field-plate" cx="50%" cy="48%" r="62%">
+              <stop offset="0%" stopColor="#221d11" stopOpacity="0.35" />
+              <stop offset="58%" stopColor="#0b1118" stopOpacity="0.32" />
+              <stop offset="100%" stopColor="#050508" stopOpacity="0" />
+            </radialGradient>
           </defs>
-          <path className="atlas-constellation__grid-line" d="M 96 300 H 844" />
-          <path className="atlas-constellation__grid-line atlas-constellation__grid-line--vertical" d="M 470 70 V 530" />
-          <circle className="atlas-constellation__ring atlas-constellation__ring--outer" cx={center.x} cy={center.y} r="238" />
-          <circle className="atlas-constellation__ring atlas-constellation__ring--inner" cx={center.x} cy={center.y} r="152" />
-          <circle className="atlas-constellation__core-glow" cx={center.x} cy={center.y} r="118" fill="url(#atlas-field-core)" />
+          <rect className="atlas-constellation__plate" x="76" y="40" width="848" height="584" rx="8" />
+          <circle className="atlas-constellation__plate-glow" cx={center.x} cy={center.y} r="326" fill="url(#atlas-field-plate)" />
+          <path className="atlas-constellation__grid-line" d="M 96 324 H 904" />
+          <path className="atlas-constellation__grid-line atlas-constellation__grid-line--vertical" d="M 500 52 V 608" />
+          {quadrants.map((quadrant) => (
+            <g key={quadrant.id} className="atlas-constellation__quadrant">
+              <path d={arcPath(quadrant.radius, quadrant.start, quadrant.end)} />
+              <text x={quadrant.x} y={quadrant.y}>{quadrant.label}</text>
+            </g>
+          ))}
+          <circle className="atlas-constellation__ring atlas-constellation__ring--outer" cx={center.x} cy={center.y} r="286" />
+          <circle className="atlas-constellation__ring atlas-constellation__ring--inner" cx={center.x} cy={center.y} r="184" />
+          <circle className="atlas-constellation__core-aura" cx={center.x} cy={center.y} r="164" />
+          <circle className="atlas-constellation__core-glow" cx={center.x} cy={center.y} r="132" fill="url(#atlas-field-core)" />
 
           {fieldNodes.map((node) => (
-            <path key={`${node.id}-thread`} className={`atlas-constellation__thread atlas-constellation__thread--${node.type}`} d={`M ${center.x} ${center.y} Q ${(center.x + node.x) / 2} ${node.y - 26}, ${node.x} ${node.y}`} />
+            <path key={`${node.id}-thread`} className={`atlas-constellation__thread atlas-constellation__thread--${node.type}`} d={`M ${center.x} ${center.y} Q ${(center.x + node.x) / 2} ${node.y - 42}, ${node.x} ${node.y}`} />
           ))}
 
           {fieldNodes.map((node) => (
             <g key={node.id} className={`atlas-constellation__field-node atlas-constellation__field-node--${node.type}`} transform={`translate(${node.x} ${node.y})`}>
               <title>{node.label}</title>
-              <circle r={node.type === 'symbol' ? 26 : 22} />
-              <text textAnchor="middle" y={node.type === 'symbol' ? 47 : 42}>{trimNodeLabel(node.label)}</text>
+              <circle className="atlas-constellation__node-orb" r={node.type === 'symbol' ? 31 : 25} />
+              <circle className="atlas-constellation__node-kernel" r={node.type === 'symbol' ? 8 : 6} />
+              <text textAnchor="middle" y={node.type === 'symbol' ? 55 : 48}>{trimNodeLabel(node.label)}</text>
             </g>
           ))}
 
           {active ? (
             <g className="atlas-constellation__center" transform={`translate(${center.x} ${center.y})`}>
-              <circle r="72" />
-              <text className="atlas-constellation__center-order" textAnchor="middle" y="-8">{String(active.order).padStart(2, '0')}</text>
-              <text className="atlas-constellation__center-label" textAnchor="middle" y="22">{active.cluster}</text>
+              <circle r="88" />
+              <text className="atlas-constellation__center-order" textAnchor="middle" y="-20">{String(active.order).padStart(2, '0')}</text>
+              <text className="atlas-constellation__center-title" textAnchor="middle" y="14">{trimNodeLabel(active.title)}</text>
+              <text className="atlas-constellation__center-label" textAnchor="middle" y="40">{active.cluster}</text>
             </g>
           ) : (
             <g className="atlas-constellation__center atlas-constellation__center--empty" transform={`translate(${center.x} ${center.y})`}>
-              <circle r="72" />
+              <circle r="88" />
               <text className="atlas-constellation__center-order" textAnchor="middle" y="-8">0</text>
               <text className="atlas-constellation__center-label" textAnchor="middle" y="22">No match</text>
             </g>

--- a/src/app/pages/AtlasPage.tsx
+++ b/src/app/pages/AtlasPage.tsx
@@ -14,6 +14,18 @@ import {
 } from '../data/aionData';
 import type { ChapterRecord } from '../types';
 
+const symbolGlyphs: Record<string, string> = {
+  fish: 'F',
+  mandala: 'M',
+  dragon: 'D',
+  sophia: 'S',
+  sword: 'L',
+  lapis: 'P',
+  cross: 'C',
+  ouroboros: 'O',
+  zodiac: 'Z',
+};
+
 export default function AtlasPage() {
   const chapters = getChapters();
   const concepts = getConcepts();
@@ -105,8 +117,22 @@ export default function AtlasPage() {
       <section className="atlas-hero section-band" aria-labelledby="atlas-title">
         <div className="atlas-hero__copy">
           <p className="eyebrow">Atlas</p>
-          <h1 id="atlas-title">Chapter, concept, and symbol field</h1>
-          <p className="lede">Search the symbolic field. Each selection redraws the chapter at the center, its concepts on the inner ring, and its symbols at the perimeter.</p>
+          <h1 id="atlas-title">Aion as a living field</h1>
+          <p className="lede">Search or select a chapter; the constellation redraws its concepts, symbols, and relations.</p>
+          <div className="atlas-hero__metrics" aria-label="Atlas inventory">
+            <span>
+              <strong>{chapters.length}</strong>
+              <em>Chapters</em>
+            </span>
+            <span>
+              <strong>{concepts.length}</strong>
+              <em>Concepts</em>
+            </span>
+            <span>
+              <strong>{symbols.length}</strong>
+              <em>Symbols</em>
+            </span>
+          </div>
         </div>
 
         <div className="atlas-layout atlas-layout--hero">
@@ -114,19 +140,21 @@ export default function AtlasPage() {
             <div className="atlas-map__controls">
               <div>
                 <p className="eyebrow">Field Filter</p>
-                <h2 id="atlas-map-title">Living Atlas Field</h2>
+                <h2 id="atlas-map-title">Concept Field</h2>
               </div>
-              <input
-                id="atlas-search"
-                name="atlas-search"
-                type="search"
-                autoComplete="off"
-                aria-label="Search Atlas field"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                aria-describedby="atlas-search-status"
-                placeholder="shadow, fish, quaternity…"
-              />
+              <div className="atlas-map__search">
+                <label htmlFor="atlas-search">Search Atlas Field</label>
+                <input
+                  id="atlas-search"
+                  name="atlas-search"
+                  type="search"
+                  autoComplete="off"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  aria-describedby="atlas-search-status"
+                  placeholder="shadow, fish, quaternity…"
+                />
+              </div>
               <output id="atlas-search-status" role="status" aria-live="polite">{chapterResultText}</output>
             </div>
             <AtlasConstellation
@@ -153,6 +181,20 @@ export default function AtlasPage() {
             ) : (
               <>
                 <ChapterSigil chapter={detailChapter} compact />
+                <div className="atlas-detail__meta" aria-label="Selected chapter field counts">
+                  <span>
+                    <strong>{String(detailChapter.order).padStart(2, '0')}</strong>
+                    <em>Chapter</em>
+                  </span>
+                  <span>
+                    <strong>{activeConcepts.length}</strong>
+                    <em>Concepts</em>
+                  </span>
+                  <span>
+                    <strong>{linkedSymbols.length}</strong>
+                    <em>Symbols</em>
+                  </span>
+                </div>
                 <p className="eyebrow">Chapter {detailChapter.order}</p>
                 <h2>{detailChapter.title}</h2>
                 <p>{detailChapter.summary}</p>
@@ -165,7 +207,19 @@ export default function AtlasPage() {
                 </div>
                 <div className="atlas-detail__section">
                   <h3>Symbols</h3>
-                  <p>{linkedSymbols.map((symbol) => symbol.label).join(' · ') || 'No direct symbol links yet.'}</p>
+                  {linkedSymbols.length > 0 ? (
+                    <div className="atlas-symbol-strip">
+                      {linkedSymbols.map((symbol) => (
+                        <button key={symbol.id} type="button" onClick={() => setQuery(symbol.label)} aria-label={`Filter Atlas by ${symbol.label}`}>
+                          <span aria-hidden="true">{symbolGlyphs[symbol.id] || symbol.label[0]}</span>
+                          <strong>{symbol.label}</strong>
+                          <em>{symbol.historicPeriod}</em>
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p>No direct symbol links yet.</p>
+                  )}
                 </div>
                 <div className="atlas-detail__section">
                   <h3>Relations</h3>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1618,21 +1618,80 @@ h3 {
 .atlas-hero {
   min-height: 100dvh;
   display: grid;
-  grid-template-columns: minmax(16rem, 0.58fr) minmax(0, 1.42fr);
+  grid-template-columns: minmax(13rem, 0.33fr) minmax(0, 1.67fr);
   align-items: center;
-  gap: clamp(1.5rem, 4vw, 4rem);
-  padding-top: 7rem;
+  gap: clamp(1rem, 2.6vw, 2.4rem);
+  padding-top: 6.5rem;
+  position: relative;
+}
+
+.atlas-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0 52% 0 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 20% 42%, rgba(212, 175, 55, 0.14), transparent 21rem),
+    linear-gradient(90deg, rgba(5, 5, 8, 0.96), rgba(5, 5, 8, 0));
+}
+
+.atlas-hero__copy {
+  position: relative;
+  z-index: 2;
 }
 
 .atlas-hero__copy h1 {
-  max-width: 11ch;
-  font-size: clamp(3.6rem, 8vw, 7rem);
+  max-width: 9.5ch;
+  font-size: clamp(2.95rem, 4.7vw, 4.9rem);
   text-wrap: balance;
 }
 
+.atlas-hero__copy .lede {
+  max-width: 29rem;
+}
+
+.atlas-hero__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  max-width: 28rem;
+  margin-top: clamp(1.25rem, 3vw, 2.2rem);
+  border-top: 1px solid rgba(212, 175, 55, 0.22);
+  border-bottom: 1px solid rgba(212, 175, 55, 0.14);
+}
+
+.atlas-hero__metrics span {
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.75rem 0.55rem 0.72rem 0;
+}
+
+.atlas-hero__metrics span + span {
+  border-left: 1px solid rgba(212, 175, 55, 0.11);
+  padding-left: 0.75rem;
+}
+
+.atlas-hero__metrics strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.atlas-hero__metrics em {
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.68rem;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
 .atlas-layout--hero {
-  grid-template-columns: minmax(0, 1.34fr) minmax(16.5rem, 0.66fr);
+  grid-template-columns: minmax(0, 1.55fr) minmax(15.5rem, 0.45fr);
   width: 100%;
+  align-items: stretch;
 }
 
 .atlas-map,
@@ -1649,13 +1708,14 @@ h3 {
 }
 
 .atlas-map {
-  min-height: min(72vh, 45rem);
+  min-height: min(78vh, 52rem);
   position: relative;
   overflow: hidden;
   box-shadow:
     var(--shadow-inset),
-    0 2rem 6rem rgba(0, 0, 0, 0.24);
+    0 2rem 6rem rgba(0, 0, 0, 0.32);
   backdrop-filter: blur(20px) saturate(120%);
+  padding: 0.95rem;
 }
 
 .atlas-map::before {
@@ -1683,10 +1743,15 @@ h3 {
   position: relative;
   z-index: 2;
   display: grid;
-  grid-template-columns: minmax(10rem, 0.8fr) minmax(12rem, 1fr);
-  gap: 0.7rem;
-  align-items: end;
-  margin-bottom: 0.65rem;
+  grid-template-columns: minmax(10rem, 0.62fr) minmax(14rem, 0.82fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+  border: 1px solid rgba(212, 175, 55, 0.12);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.012)),
+    rgba(5, 5, 8, 0.48);
+  box-shadow: var(--shadow-inset);
+  padding: 0.72rem;
 }
 
 .atlas-map__controls h2 {
@@ -1696,8 +1761,7 @@ h3 {
 }
 
 .atlas-map__controls output {
-  grid-column: 1 / -1;
-  justify-self: start;
+  justify-self: end;
   min-height: 2.5rem;
   display: inline-grid;
   place-items: center;
@@ -1708,6 +1772,20 @@ h3 {
   font-size: 0.78rem;
   padding: 0.46rem 0.75rem;
   white-space: nowrap;
+}
+
+.atlas-map__search {
+  display: grid;
+  gap: 0.32rem;
+}
+
+.atlas-map__search label {
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
 }
 
 .atlas-map input,
@@ -1729,11 +1807,12 @@ h3 {
 }
 
 .atlas-constellation__stage {
-  min-height: clamp(24rem, 52vw, 36rem);
-  border-top: 1px solid rgba(212, 175, 55, 0.11);
+  min-height: clamp(30rem, 43vw, 37rem);
   border-bottom: 1px solid rgba(212, 175, 55, 0.11);
+  border-top: 0;
   position: relative;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .atlas-constellation__stage svg {
@@ -1746,8 +1825,39 @@ h3 {
 .atlas-constellation__grid-line,
 .atlas-constellation__ring {
   fill: none;
-  stroke: rgba(255, 255, 255, 0.11);
+  stroke: rgba(255, 255, 255, 0.105);
   stroke-width: 1;
+}
+
+.atlas-constellation__plate {
+  fill: rgba(5, 5, 8, 0.035);
+  stroke: rgba(212, 175, 55, 0.075);
+  stroke-width: 1;
+}
+
+.atlas-constellation__plate-glow {
+  opacity: 0.82;
+}
+
+.atlas-constellation__quadrant path {
+  fill: none;
+  stroke: rgba(212, 175, 55, 0.24);
+  stroke-dasharray: 1 12;
+  stroke-linecap: round;
+  stroke-width: 1.3;
+}
+
+.atlas-constellation__quadrant:nth-of-type(2n) path {
+  stroke: rgba(83, 216, 232, 0.2);
+}
+
+.atlas-constellation__quadrant text {
+  fill: rgba(244, 240, 232, 0.36);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
 
 .atlas-constellation__grid-line--vertical {
@@ -1755,13 +1865,19 @@ h3 {
 }
 
 .atlas-constellation__ring--inner {
-  stroke: rgba(212, 175, 55, 0.35);
-  stroke-dasharray: 2 10;
+  stroke: rgba(212, 175, 55, 0.42);
+  stroke-dasharray: 2 9;
 }
 
 .atlas-constellation__ring--outer {
-  stroke: rgba(83, 216, 232, 0.23);
-  stroke-dasharray: 1 13;
+  stroke: rgba(83, 216, 232, 0.28);
+  stroke-dasharray: 1 12;
+}
+
+.atlas-constellation__core-aura {
+  fill: none;
+  stroke: rgba(255, 227, 156, 0.1);
+  stroke-width: 26;
 }
 
 .atlas-constellation__core-glow {
@@ -1772,38 +1888,52 @@ h3 {
 
 .atlas-constellation__thread {
   fill: none;
-  stroke-width: 1.4;
-  opacity: 0.72;
+  stroke-width: 1.8;
+  opacity: 0.76;
 }
 
 .atlas-constellation__thread--concept {
-  stroke: rgba(212, 175, 55, 0.42);
+  stroke: rgba(212, 175, 55, 0.5);
 }
 
 .atlas-constellation__thread--symbol {
-  stroke: rgba(83, 216, 232, 0.34);
+  stroke: rgba(83, 216, 232, 0.42);
 }
 
-.atlas-constellation__field-node circle,
+.atlas-constellation__field-node .atlas-constellation__node-orb,
 .atlas-constellation__center circle {
   stroke-width: 1.1;
   filter: drop-shadow(0 1rem 1.2rem rgba(0, 0, 0, 0.36));
 }
 
-.atlas-constellation__field-node--concept circle {
+.atlas-constellation__field-node--concept .atlas-constellation__node-orb {
   fill: rgba(212, 175, 55, 0.11);
   stroke: rgba(255, 227, 156, 0.72);
 }
 
-.atlas-constellation__field-node--symbol circle {
+.atlas-constellation__field-node--symbol .atlas-constellation__node-orb {
   fill: rgba(83, 216, 232, 0.09);
   stroke: rgba(143, 231, 237, 0.68);
+}
+
+.atlas-constellation__node-kernel {
+  fill: var(--text);
+  opacity: 0.72;
+}
+
+.atlas-constellation__field-node--concept .atlas-constellation__node-kernel {
+  fill: var(--gold-soft);
+}
+
+.atlas-constellation__field-node--symbol .atlas-constellation__node-kernel {
+  fill: var(--ink-cyan);
 }
 
 .atlas-constellation__field-node text {
   fill: var(--text);
   font-family: var(--font-ui);
-  font-size: 12px;
+  font-size: 13px;
+  font-weight: 700;
   paint-order: stroke;
   stroke: #050508;
   stroke-linejoin: round;
@@ -1811,8 +1941,8 @@ h3 {
 }
 
 .atlas-constellation__center circle {
-  fill: rgba(5, 5, 8, 0.74);
-  stroke: rgba(212, 175, 55, 0.76);
+  fill: rgba(5, 5, 8, 0.82);
+  stroke: rgba(212, 175, 55, 0.84);
 }
 
 .atlas-constellation__center--empty circle {
@@ -1823,8 +1953,15 @@ h3 {
 .atlas-constellation__center-order {
   fill: var(--gold-soft);
   font-family: var(--font-display);
-  font-size: 34px;
+  font-size: 42px;
   font-variant-numeric: tabular-nums;
+}
+
+.atlas-constellation__center-title {
+  fill: var(--text);
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 620;
 }
 
 .atlas-constellation__center-label {
@@ -1837,7 +1974,7 @@ h3 {
 .atlas-constellation__chapter-rail {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(12rem, 1fr);
+  grid-auto-columns: minmax(10.4rem, 1fr);
   gap: 0.55rem;
   overflow-x: auto;
   overscroll-behavior-x: contain;
@@ -1853,8 +1990,8 @@ h3 {
 .atlas-constellation__empty {
   min-height: 5.2rem;
   border: 1px solid rgba(255, 255, 255, 0.11);
-  border-radius: var(--radius);
-  background: rgba(255, 255, 255, 0.035);
+  border-radius: 0;
+  background: rgba(255, 255, 255, 0.025);
   color: var(--text);
   display: grid;
   gap: 0.1rem;
@@ -1951,6 +2088,7 @@ h3 {
   display: grid;
   align-content: start;
   gap: 0.9rem;
+  padding: 1rem;
 }
 
 .atlas-detail .chapter-sigil {
@@ -1959,8 +2097,111 @@ h3 {
 
 .atlas-detail h2 {
   margin-block: -0.35rem 0;
-  font-size: clamp(1.7rem, 3vw, 2.6rem);
+  font-size: clamp(1.55rem, 2.2vw, 2.35rem);
   text-wrap: balance;
+}
+
+.atlas-detail__meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid rgba(212, 175, 55, 0.18);
+  border-bottom: 1px solid rgba(212, 175, 55, 0.12);
+}
+
+.atlas-detail__meta span {
+  display: grid;
+  gap: 0.18rem;
+  padding: 0.55rem 0.35rem;
+}
+
+.atlas-detail__meta span + span {
+  border-left: 1px solid rgba(212, 175, 55, 0.1);
+  padding-left: 0.62rem;
+}
+
+.atlas-detail__meta strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: 1.45rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.atlas-detail__meta em {
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.6rem;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.atlas-symbol-strip {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.atlas-symbol-strip button {
+  width: 100%;
+  min-height: 3.8rem;
+  border: 1px solid rgba(83, 216, 232, 0.13);
+  border-radius: 0;
+  background: rgba(83, 216, 232, 0.025);
+  color: var(--text);
+  display: grid;
+  grid-template-columns: 2.45rem minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  column-gap: 0.58rem;
+  align-items: center;
+  padding: 0.52rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.38s var(--motion-spring),
+    background 0.38s var(--motion-spring),
+    transform 0.38s var(--motion-spring);
+}
+
+.atlas-symbol-strip button:hover,
+.atlas-symbol-strip button:focus-visible {
+  border-color: rgba(83, 216, 232, 0.36);
+  background: rgba(83, 216, 232, 0.052);
+  transform: translateY(-1px);
+}
+
+.atlas-symbol-strip span {
+  grid-row: 1 / 3;
+  width: 2.35rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.28);
+  border-radius: 50%;
+  color: var(--gold-soft);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+}
+
+.atlas-symbol-strip strong,
+.atlas-symbol-strip em {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.atlas-symbol-strip strong {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 620;
+  line-height: 1.05;
+}
+
+.atlas-symbol-strip em {
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.64rem;
+  font-style: normal;
+  line-height: 1.25;
 }
 
 .atlas-detail__empty {
@@ -2108,6 +2349,40 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch3"] .chapter-stage__reference-label {
   margin-top: 2.15rem;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro {
+  width: min(35rem, calc(100% - 2rem));
+  justify-content: flex-end;
+  padding-bottom: clamp(2.6rem, 6.4vh, 4.7rem);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro h1 {
+  max-width: 10ch;
+  font-size: clamp(2.9rem, 5.45vw, 5.25rem);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro p:not(.eyebrow) {
+  max-width: 34ch;
+  font-size: clamp(1rem, 1.28vw, 1.08rem);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__thesis-map {
+  max-width: 28rem;
+  margin-top: 1.1rem;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-map {
+  width: min(24rem, 100%);
+  margin-top: 0.65rem;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node {
+  min-height: 3.85rem;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-label {
+  margin-top: 2.05rem;
 }
 
 .chapter-stage__thesis-map {
@@ -3681,6 +3956,7 @@ h3 {
 	  .path-panel:hover,
   .chip-row button:hover,
   .concept-cloud button:hover,
+  .atlas-symbol-strip button:hover,
   .atlas-constellation__chapter:hover,
 	  .chapter-preview:hover,
 	  .chapter-stage__reference-node:hover,
@@ -3703,6 +3979,7 @@ h3 {
   .chapter-preview,
   .chip-row button,
   .concept-cloud button,
+  .atlas-symbol-strip button,
   .atlas-constellation__chapter,
 	  .chapter-card,
 		  .home-narrative__legend-item a,
@@ -3728,8 +4005,8 @@ h3 {
   }
 
   .atlas-hero__copy h1 {
-    max-width: 11ch;
-    font-size: clamp(4rem, 10vw, 6.4rem);
+    max-width: 9.5ch;
+    font-size: clamp(3rem, 8vw, 5rem);
   }
 
   .atlas-hero__copy .lede {
@@ -3741,7 +4018,7 @@ h3 {
   }
 
   .atlas-map {
-    min-height: 40rem;
+    min-height: 44rem;
   }
 }
 
@@ -3911,7 +4188,9 @@ h3 {
 
   .atlas-hero {
     display: grid;
-    padding-top: 11.5rem;
+    gap: 1rem;
+    min-height: auto;
+    padding-top: 10.25rem;
   }
 
   .atlas-layout--hero {
@@ -3932,7 +4211,7 @@ h3 {
   }
 
   .atlas-constellation__stage {
-    min-height: clamp(17.5rem, 78vw, 25rem);
+    min-height: clamp(22rem, 82vw, 30rem);
   }
 
   .atlas-constellation__chapter-rail {
@@ -3964,11 +4243,23 @@ h3 {
 
   .atlas-hero__copy h1 {
     max-width: 11ch;
-    font-size: clamp(2.85rem, 13.5vw, 4.2rem);
+    font-size: clamp(2.55rem, 12.5vw, 3.6rem);
+    line-height: 0.95;
   }
 
   .atlas-hero__copy .lede {
-    display: none;
+    display: block;
+    max-width: 20rem;
+    font-size: 0.9rem;
+    line-height: 1.55;
+  }
+
+  .atlas-hero__metrics {
+    margin-top: 0.9rem;
+  }
+
+  .atlas-hero__metrics span {
+    padding-block: 0.58rem;
   }
 
   .path-grid,


### PR DESCRIPTION
## Summary
- Reframes Atlas as a luxury scholarly visual instrument with a larger concept constellation, chapter inventory metrics, visible field axes, and richer selected-chapter symbol cards.
- Tightens mobile Atlas hierarchy so the visual field arrives sooner while keeping a visible instruction line.
- Hardens app/a11y smoke scripts by resolving Vite from the repo root, increasing startup/route patience, isolating chapter canvas sweeps, and keeping real Playwright clicks for scene controls.

## Verification
- `rg -n "^(<{7}|={7}|>{7})$" .` returned no merge markers
- `npx tsc --noEmit`
- `npm run test:app`
- `npm run build`
- `node --check scripts/testing/app-shell-smoke.mjs`
- `node --check scripts/testing/app-accessibility-smoke.mjs`
- `npm run lint`
- `npm test`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `AION_SMOKE_DEBUG=true npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages && npm run test:pages:artifact`

## Notes
- The existing Vite large chunk warning for the shared Three.js chunk remains and should be handled in the performance batch.
