### PR TITLE
docs: add Aion skill routing playbook

### DIFF
--- a/docs/AION_SKILL_ROUTING_PLAYBOOK.md
+++ b/docs/AION_SKILL_ROUTING_PLAYBOOK.md
@@ -1,0 +1,204 @@
+# Aion Skill Routing Playbook
+
+## Purpose
+
+Use this playbook when planning or executing visual-development batches for Aion Visualization. It turns the available skill stack into a repeatable workflow without requiring every skill on every turn.
+
+The rule is simple: use many skills across the project, but use the smallest high-signal set for each batch. Every skill invocation must create evidence: a design direction, a code change, a QA finding, a screenshot, a test result, a PR, or a live-route verification.
+
+## Default Batch Stack
+
+Most visual batches should use this compact stack:
+
+| Role | Default skill or tool | Output |
+|---|---|---|
+| Product/context | `redesign-existing-projects`, `open-design`, or `product-design:research` | Target route, audience, learning job, constraints |
+| Taste direction | `design-taste-frontend`, `frontend-design`, `stitch-design-taste`, `high-end-visual-design` | Visual thesis, hierarchy, typography, material rules |
+| Story/visualization | `storytelling-web`, `data-visualization`, D3/Three/WebGL skills as needed | Concept map, scene grammar, interaction model |
+| Browser evidence | `Browser` / Playwright | Desktop/mobile screenshots, console/404 checks, route behavior |
+| Accessibility/testing | `accessibility-review`, `webapp-testing` | Keyboard, reduced motion, touch targets, smoke/a11y gates |
+| Shipping | `github:yeet` | Commit, push, PR, checks, merge/deploy evidence |
+
+Default size: 4-6 skills plus Browser. Add more only when the task has distinct specialist work.
+
+## Current Source Of Truth
+
+Anchor skill-routed work to the active React/Vite app, not older static-site docs.
+
+| Concern | Current source |
+|---|---|
+| Routes | `src/app/routes.ts`, `src/app/App.tsx` |
+| Global shell | `src/app/components/Shell.tsx` |
+| Shared visual system | `src/app/styles.css` |
+| Chapter page shell | `src/app/pages/ChapterPage.tsx`, `src/app/components/SceneHost.tsx` |
+| Chapter scene registry | `src/app/visualization/chapterScenes.ts` |
+| Chapter scene modules | `src/visualizations/chapters/ch1` through `src/visualizations/chapters/ch14` |
+| Canonical data | `src/data/aion-core/*`, `src/data/aion-graph/*`, `src/app/data/aionData.ts` |
+| App contract tests | `tests/app/aion-app-contract.test.ts` |
+| Browser smoke | `scripts/testing/app-shell-smoke.mjs` |
+| Accessibility smoke | `scripts/testing/app-accessibility-smoke.mjs` |
+
+Shared ownership warnings:
+
+- `src/app/styles.css` has high blast radius. Keep one active owner per batch.
+- `src/app/visualization/chapterScenes.ts` is a registry choke point. Avoid parallel edits unless one person owns integration.
+- Old phase docs may mention static HTML, pure monochrome, or noncanonical chapter counts. Treat those as historical unless current source files and package scripts confirm them.
+
+## Specialist Triggers
+
+Use named skills when their trigger is real:
+
+| Trigger | Skills/tools |
+|---|---|
+| Broad multi-file route redesign | `orchestration-autopilot`, `parallel-task`, `subagent-driven-development` |
+| Competing visual directions | `creative-production:moodboard-explorer`, `open-design`, `sdd:create-ideas` |
+| Source-target comparison QA | `product-design:design-qa` after a source image/mockup and rendered implementation both exist |
+| New generated visual assets | `imagegen` for raster backgrounds, texture plates, symbolic stills, and fallback images |
+| Searchable maps, timelines, graphs | `data-visualization`, `d3-viz`, scientific-figure skills |
+| Chapter narrative pacing | `storytelling-web` |
+| Existing-app polish without architecture churn | `redesign-existing-projects`, `frontend-design`, `design-taste-frontend` |
+| Current user/UX research on an external product | `product-design:research` |
+| PR publishing and merge workflow | `github:yeet` plus local git and GitHub checks |
+
+Do not invoke `product-design:design-qa` as generic critique. It requires both a source visual target and a rendered implementation.
+
+## Browser Usage Contract
+
+Use Browser for every route-impacting visual batch.
+
+Required Browser evidence:
+
+- Open the changed local route or live route.
+- Capture or inspect at desktop and mobile widths.
+- Check visible global nav, route context, primary interaction, and text overflow.
+- Check console errors and unexpected 404s when practical.
+- For chapter scenes, verify canvas presence and nonblank visual output through smoke tests.
+
+Screenshots should be temporary unless the batch intentionally adds visual baselines. Delete temporary screenshots before committing.
+
+## Creative Production And Imagegen
+
+Use Creative Production before implementation when the visual direction is unclear or multiple art territories would help.
+
+Good uses:
+
+- Moodboards for "luxury scholarly atlas", "alchemical laboratory", "gnostic emanation map", or "fish aeon wheel".
+- Scene territory exploration for chapter clusters.
+- Reference boards for typography, materiality, diagrams, and symbolic density.
+
+Use Imagegen only when a generated raster asset is the right medium. Do not use Imagegen to replace layout, navigation, data visualization, or interactive scene work that belongs in code.
+
+## Subagent Policy
+
+Spawn subagents by default for non-trivial batches, but give them independent lanes.
+
+Recommended lanes:
+
+- `explorer`: route/component/data map, read-only.
+- `architect_planner`: implementation sequence and ownership boundaries.
+- `implementation_worker`: bounded code slice in an explicit write set.
+- `reviewer`: correctness, regressions, visual/accessibility risks.
+- `test_verifier`: targeted verification and failure triage.
+- `devil_advocate`: challenge the design plan and assumptions.
+
+Use 3-6 workers for ordinary complex batches. Use 8-12 only for broad research, large migrations, or independent page-family audits. Do not spawn agents for trivial single-file fixes or simple factual checks.
+
+## Design QA Release Rubric
+
+For substantial visual batches, score each category as `0 fail`, `1 partial`, or `2 pass`. A batch should not ship with critical failures, and the total should be at least 85% unless the PR explicitly documents a narrow stabilization exception.
+
+| Category | Pass condition | Evidence |
+|---|---|---|
+| Visual-first learning | First viewport has a meaningful visual anchor and concise supporting copy | Desktop/mobile Browser screenshots |
+| Scholarly integrity | Terminology matches canonical data; source-anchor gaps are known and routed to the scholarly batch | Consistency validation and editorial notes |
+| Meaningful interaction | Controls change visual understanding, not just decoration | Interaction matrix or Playwright smoke |
+| Accessibility | Named controls, keyboard path, reduced motion, no color/motion-only meaning | `npm run test:a11y:app`, focused manual checks |
+| Motion grammar | Motion maps to opposition, integration, transformation, or cyclical return | Motion intent notes and reduced-motion check |
+| Data visualization | Graphs/maps answer a clear relationship question with legible labels | Visual spec and route screenshot |
+| Browser evidence | No console errors, unexpected 404s, text overflow, or blank expected canvas | Browser/Playwright output |
+| Performance/reliability | Route budget and WebGL lifecycle risks are checked when scenes change | Build, smoke, performance scripts as applicable |
+
+Source anchors are important, but they are a dedicated content-governance migration. Do not make `sourceRefs` required casually inside a visual polish PR unless that batch owns the editorial migration and validation updates.
+
+## Create Or Install New Skills
+
+Do not install or create new skills just because more skills exist on the web. Create or install a new skill only when all are true:
+
+1. The workflow recurs across this project.
+2. Existing skills plus this playbook are insufficient.
+3. The source is trusted or the local skill can be reviewed before use.
+
+Preferred order:
+
+1. Add or update a project doc.
+2. Add a small script/test if it creates better evidence.
+3. Create a project-local skill only when the workflow is stable.
+4. Install an external skill only after source review and exact-path verification.
+
+When evaluating external skills, prefer the standard Codex skill shape described in the official Codex skills documentation: `SKILL.md` with `name` and `description`, plus optional `scripts/`, `references/`, and `assets/`. For testing skills, prefer workflows that align with Playwright's official visual-comparison and accessibility-testing capabilities rather than bespoke screenshot scripts with stale selectors.
+
+Useful external references:
+
+- [Agent Skills - Codex](https://developers.openai.com/codex/skills)
+- [Playwright visual comparisons](https://playwright.dev/docs/test-snapshots)
+- [Playwright accessibility testing](https://playwright.dev/docs/accessibility-testing)
+
+## Per-Batch Record
+
+Every batch PR should include this short record in its body or notes:
+
+```text
+Skill stack:
+Routes changed:
+Visual thesis:
+Browser evidence:
+Checks:
+Residual debt:
+```
+
+## Verification Matrix
+
+Fast route-independent checks:
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm run validate:consistency
+npm run ci:chapter-shell
+npm run test:app
+npm run build
+```
+
+Route-impacting checks:
+
+```bash
+npm run test:e2e:app
+npm run test:a11y:app
+npm run build:pages
+npm run test:pages:artifact
+```
+
+Live-site check after merge:
+
+- Confirm GitHub PR checks are green.
+- Merge through PR.
+- Confirm `main` CI, Accessibility Gate, Deploy to GitHub Pages, and Pages deployment are green.
+- Browser-smoke the live changed route.
+
+## Next Skill-Routed Batches
+
+1. Chapter 1 reference pass.
+   - Skills: `frontend-design`, `design-taste-frontend`, `high-end-visual-design`, `storytelling-web`, Browser, `accessibility-review`, `webapp-testing`.
+   - Output: Ego page as the visual benchmark for all chapters.
+
+2. Chapter 2-4 psyche arc.
+   - Skills: `storytelling-web`, `data-visualization`, D3/Three/WebGL skills, Browser, `webapp-testing`, reviewer/test verifier subagents.
+   - Output: shadow, syzygy, and self as one coherent learning sequence.
+
+3. Timeline/Symbols/About support-route polish.
+   - Skills: `data-visualization`, `high-end-visual-design`, `redesign-existing-projects`, Browser, `accessibility-review`.
+   - Output: support pages that are visual instruments, not text pages.
+
+4. Scholarly source-anchor migration.
+   - Skills: `academic-research`, `fact-check`, `conservative-retriever`, product research only if external user evidence is needed.
+   - Output: source-reference structure filled enough to support public-facing concept and scene claims.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,9 @@
 This folder collects plans, reports and helper files for the Aion Visualization project. Brief descriptions of each document are listed below.
 
 
+- **AION_SKILL_ROUTING_PLAYBOOK.md** - Compact daily guide for using design, Browser, testing, subagent, Creative Production, Imagegen, and GitHub skills without overloading each batch.
+- **AION_CONTINUAL_VISUAL_POLISH_LOOP.md** - Repeatable loop for route-by-route visual polish, verification, and focused PR delivery.
+- **SKILL_DRIVEN_AION_REDESIGN_PLAN.md** - Deeper skill-driven redesign roadmap and phase inventory.
 - **BUG_FIXES_SUMMARY.md** - Summary of bug fixes completed in Phase 2.
 - **BUG_REPORT.md** - Initial bug report and test results.
 - **COMPLETE_UPDATE_SUMMARY.md** - Overview of all updates across phases.
@@ -46,4 +49,3 @@ This folder collects plans, reports and helper files for the Aion Visualization 
 - **index-original.html** - Original HTML page preserved for reference.
 - **setup-github-pages.md** - How to host the site using GitHub Pages.
 - **verify-phase3-integration.html** - HTML file for verifying Phase 3 integration.
-

--- a/docs/SKILL_DRIVEN_AION_REDESIGN_PLAN.md
+++ b/docs/SKILL_DRIVEN_AION_REDESIGN_PLAN.md
@@ -4,6 +4,8 @@
 
 This plan turns the installed Codex skill library into a disciplined execution system for the Aion Visualization redesign. The goal is not to use skills performatively. The goal is to use a large, relevant set of design, frontend, visualization, research, testing, performance, and review skills so the project becomes a visual-first learning atlas for Jung's *Aion*.
 
+For daily routing, use the compact companion guide: [Aion Skill Routing Playbook](./AION_SKILL_ROUTING_PLAYBOOK.md). This document remains the deeper roadmap and inventory.
+
 The plan preserves the user's stated taste direction:
 
 - Keep the best parts of the previous design language, especially the Chapter 1 Ego typography, dark field, symbolic motion, and cinematic atmosphere.
@@ -35,6 +37,8 @@ For each work batch:
 5. Record what skill stack was used and what changed.
 
 This keeps the work intense and skill-rich without turning the project into chaos.
+
+The short version: pick a default stack of product/context, taste direction, story/visualization, Browser evidence, accessibility/testing, and shipping. Add specialist skills only when their trigger is real.
 
 ## Core Skill Stack
 


### PR DESCRIPTION
## Summary
- Adds a compact Aion Skill Routing Playbook for daily batch planning.
- Links the playbook from the deeper skill-driven redesign plan and docs index.
- Codifies how to use Browser, Creative Production, Imagegen, subagents, design QA, frontend/design, testing, and GitHub shipping skills without turning every batch into a giant skill inventory.

## Skill stack used
- Browser / Playwright live-route verification
- Product/design QA guidance
- design-taste-frontend, frontend-design, high-end visual design, redesign-existing-projects
- storytelling-web and data-visualization routing
- orchestration-autopilot, parallel-task, subagent-driven-development via bounded read-only subagents
- github:yeet publish flow
- External reference check for Codex skills and Playwright visual/a11y testing docs

## Verification
- `git diff --check`
- `npm run validate:consistency`
- Browser live smoke of `https://akshaybapat6365.github.io/aion-visualization/atlas/` after PR #155 merge

## Notes
- This is docs-only. It intentionally does not alter app behavior.
- Source-anchor enforcement and legacy visual/a11y tooling cleanup are routed as future dedicated batches, not hidden inside this planning PR.
