### PR TITLE
[codex] redesign About visual orientation

### DIFF
--- a/src/app/pages/AboutPage.css
+++ b/src/app/pages/AboutPage.css
@@ -1,0 +1,493 @@
+.page--about {
+  --about-cyan: rgba(83, 216, 232, 0.76);
+  --about-rose: rgba(218, 112, 139, 0.72);
+  --about-green: rgba(136, 214, 167, 0.68);
+}
+
+.about-hero {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 74% 48%, rgba(212, 175, 55, 0.09), transparent 28rem),
+    radial-gradient(circle at 18% 18%, rgba(83, 216, 232, 0.08), transparent 20rem),
+    linear-gradient(135deg, rgba(7, 18, 18, 0.72), rgba(3, 3, 7, 0.96) 42%, rgba(22, 18, 10, 0.74));
+}
+
+.about-hero::before {
+  content: '';
+  position: absolute;
+  inset: 6.8rem 2rem 2rem;
+  z-index: -1;
+  border: 1px solid rgba(244, 240, 232, 0.045);
+  border-radius: 1.4rem;
+  background:
+    linear-gradient(90deg, rgba(244, 240, 232, 0.04) 1px, transparent 1px),
+    linear-gradient(0deg, rgba(244, 240, 232, 0.03) 1px, transparent 1px);
+  background-size: 7.5rem 7.5rem;
+  mask-image: radial-gradient(circle at 58% 48%, black 0 38%, transparent 72%);
+  pointer-events: none;
+}
+
+.about-hero__copy {
+  max-width: 47rem;
+}
+
+.about-hero__copy h1 {
+  max-width: 9ch;
+  font-size: 6.4rem;
+}
+
+.about-hero__copy .lede {
+  max-width: 35rem;
+}
+
+.about-mode-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.72rem;
+  margin-top: 2rem;
+}
+
+.about-mode-controls__button {
+  min-height: 2.75rem;
+  border: 1px solid rgba(212, 175, 55, 0.2);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.58);
+  color: rgba(244, 240, 232, 0.7);
+  cursor: pointer;
+  font: 700 0.78rem/1 var(--font-ui);
+  letter-spacing: 0.08em;
+  padding: 0.74rem 1rem;
+  text-transform: uppercase;
+  transition:
+    border-color 0.35s var(--motion-spring),
+    background 0.35s var(--motion-spring),
+    color 0.35s var(--motion-spring),
+    transform 0.35s var(--motion-spring);
+}
+
+.about-mode-controls__button:hover,
+.about-mode-controls__button:focus-visible,
+.about-mode-controls__button--active {
+  border-color: rgba(212, 175, 55, 0.62);
+  background: rgba(212, 175, 55, 0.12);
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+.about-orientation {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  width: min(100%, 42rem);
+  justify-self: center;
+}
+
+.about-north-star-field {
+  width: min(100%, 40rem);
+  aspect-ratio: 1;
+  overflow: visible;
+  color: var(--text);
+  filter: drop-shadow(0 2rem 5rem rgba(0, 0, 0, 0.38));
+}
+
+.about-north-star-field__plate {
+  fill: rgba(3, 3, 7, 0.34);
+  stroke: rgba(244, 240, 232, 0.08);
+}
+
+.about-north-star-field__aura {
+  fill: url('#about-field-glow');
+  filter: url('#about-field-blur');
+  opacity: 0.74;
+}
+
+.about-north-star-field__halo,
+.about-north-star-field__orbit,
+.about-north-star-field__axis,
+.about-north-star-field__diagonal {
+  fill: none;
+  vector-effect: non-scaling-stroke;
+}
+
+.about-north-star-field__halo {
+  stroke: rgba(212, 175, 55, 0.28);
+  stroke-width: 1;
+}
+
+.about-north-star-field__halo--inner {
+  stroke: rgba(83, 216, 232, 0.26);
+}
+
+.about-north-star-field__orbit--concept {
+  stroke: rgba(83, 216, 232, 0.32);
+}
+
+.about-north-star-field__orbit--symbol {
+  stroke: rgba(218, 112, 139, 0.22);
+}
+
+.about-north-star-field__axis {
+  stroke: url('#about-field-axis');
+  stroke-width: 1;
+}
+
+.about-north-star-field__axis--vertical {
+  stroke: rgba(83, 216, 232, 0.28);
+}
+
+.about-north-star-field__diagonal {
+  stroke: rgba(244, 240, 232, 0.12);
+  stroke-dasharray: 4 14;
+}
+
+.about-north-star-field__glow {
+  fill: rgba(212, 175, 55, 0.04);
+  stroke: rgba(212, 175, 55, 0.22);
+}
+
+.about-north-star-field__node circle {
+  fill: rgba(3, 3, 7, 0.82);
+  stroke: rgba(244, 240, 232, 0.14);
+  stroke-width: 1;
+  transition:
+    fill 0.35s var(--motion-spring),
+    stroke 0.35s var(--motion-spring),
+    filter 0.35s var(--motion-spring),
+    transform 0.35s var(--motion-spring);
+  transform-box: fill-box;
+  transform-origin: center;
+}
+
+.about-north-star-field__node text {
+  fill: rgba(244, 240, 232, 0.72);
+  font: 700 0.82rem/1 var(--font-ui);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.about-orientation[data-active-mode='study'] .about-north-star-field__node--study circle,
+.about-orientation[data-active-mode='map'] .about-north-star-field__node--map circle,
+.about-orientation[data-active-mode='symbolize'] .about-north-star-field__node--symbolize circle,
+.about-orientation[data-active-mode='verify'] .about-north-star-field__node--verify circle {
+  fill: rgba(212, 175, 55, 0.14);
+  stroke: rgba(212, 175, 55, 0.78);
+  filter: drop-shadow(0 0 1.1rem rgba(212, 175, 55, 0.42));
+  transform: scale(1.16);
+}
+
+.about-orientation[data-active-mode='map'] .about-north-star-field__node--map circle {
+  fill: rgba(83, 216, 232, 0.12);
+  stroke: rgba(83, 216, 232, 0.74);
+  filter: drop-shadow(0 0 1.1rem rgba(83, 216, 232, 0.38));
+}
+
+.about-orientation[data-active-mode='symbolize'] .about-north-star-field__node--symbolize circle {
+  fill: rgba(218, 112, 139, 0.12);
+  stroke: rgba(218, 112, 139, 0.72);
+  filter: drop-shadow(0 0 1.1rem rgba(218, 112, 139, 0.34));
+}
+
+.about-orientation[data-active-mode='verify'] .about-north-star-field__node--verify circle {
+  fill: rgba(136, 214, 167, 0.12);
+  stroke: rgba(136, 214, 167, 0.72);
+  filter: drop-shadow(0 0 1.1rem rgba(136, 214, 167, 0.32));
+}
+
+.about-north-star-field__core circle {
+  fill: rgba(3, 3, 7, 0.74);
+  stroke: rgba(212, 175, 55, 0.48);
+}
+
+.about-north-star-field__core text {
+  fill: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: 1.38rem;
+}
+
+.about-north-star-field__core text + text {
+  fill: rgba(244, 240, 232, 0.58);
+  font-family: var(--font-ui);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.about-north-star-field__active-readout rect {
+  fill: rgba(3, 3, 7, 0.76);
+  stroke: rgba(212, 175, 55, 0.24);
+}
+
+.about-north-star-field__active-readout text {
+  fill: var(--gold-soft);
+  font: 700 0.75rem/1 var(--font-ui);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.about-north-star-field__active-readout text + text {
+  fill: rgba(244, 240, 232, 0.68);
+  font: 400 0.72rem/1 var(--font-ui);
+  letter-spacing: 0.03em;
+  text-transform: none;
+}
+
+.about-orientation__detail {
+  width: min(31rem, 86%);
+  margin-top: -5.4rem;
+  border: 1px solid rgba(244, 240, 232, 0.1);
+  border-radius: var(--radius);
+  background: rgba(3, 3, 7, 0.72);
+  box-shadow:
+    var(--shadow-inset),
+    0 1.6rem 5rem rgba(0, 0, 0, 0.34);
+  padding: 1.05rem 1.15rem 1.15rem;
+  backdrop-filter: blur(16px);
+}
+
+.about-orientation__detail h2 {
+  max-width: 18ch;
+  margin: 0.3rem 0 0.55rem;
+  font-family: var(--font-display);
+  font-size: 2.05rem;
+  font-weight: 420;
+  line-height: 1;
+}
+
+.about-orientation__detail p:not(.eyebrow) {
+  color: rgba(244, 240, 232, 0.68);
+  line-height: 1.55;
+}
+
+.about-orientation__stat {
+  display: flex;
+  align-items: end;
+  gap: 0.75rem;
+  margin-top: 0.85rem;
+}
+
+.about-orientation__stat strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: 3.4rem;
+  font-weight: 380;
+  line-height: 0.88;
+}
+
+.about-orientation__stat[data-tone='cyan'] strong {
+  color: var(--about-cyan);
+}
+
+.about-orientation__stat[data-tone='rose'] strong {
+  color: var(--about-rose);
+}
+
+.about-orientation__stat[data-tone='green'] strong {
+  color: var(--about-green);
+}
+
+.about-orientation__stat span {
+  max-width: 12ch;
+  color: rgba(244, 240, 232, 0.54);
+  font: 700 0.72rem/1.25 var(--font-ui);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.about-route-launch {
+  padding-top: 4rem;
+}
+
+.about-route-launch__grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.about-route-card {
+  position: relative;
+  min-height: 16rem;
+  border: 1px solid rgba(244, 240, 232, 0.1);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(135deg, rgba(244, 240, 232, 0.035), transparent 44%),
+    rgba(3, 3, 7, 0.5);
+  box-shadow: var(--shadow-inset);
+  color: var(--text);
+  overflow: hidden;
+  padding: 1.15rem;
+  text-decoration: none;
+  transition:
+    transform 0.35s var(--motion-spring),
+    border-color 0.35s var(--motion-spring),
+    box-shadow 0.35s var(--motion-spring);
+}
+
+.about-route-card::before {
+  content: '';
+  position: absolute;
+  right: -3.6rem;
+  top: -3.8rem;
+  width: 11rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.18);
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 2.2rem rgba(83, 216, 232, 0.025);
+}
+
+.about-route-card::after {
+  content: '';
+  position: absolute;
+  left: 1.15rem;
+  right: 1.15rem;
+  bottom: 1rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(212, 175, 55, 0.7), rgba(83, 216, 232, 0.4), transparent);
+  opacity: 0.55;
+}
+
+.about-route-card:hover,
+.about-route-card:focus-visible {
+  border-color: rgba(212, 175, 55, 0.42);
+  box-shadow: var(--shadow-inset), var(--shadow-ambient);
+  transform: translateY(-3px);
+}
+
+.about-route-card span {
+  display: grid;
+  width: 2.2rem;
+  aspect-ratio: 1;
+  place-items: center;
+  border: 1px solid rgba(83, 216, 232, 0.24);
+  border-radius: 50%;
+  color: var(--cyan);
+  font: 700 0.72rem/1 var(--font-ui);
+}
+
+.about-route-card h3 {
+  max-width: 9ch;
+  margin: 1.4rem 0 0.8rem;
+  font-family: var(--font-display);
+  font-size: 2.25rem;
+  font-weight: 430;
+  line-height: 0.94;
+}
+
+.about-route-card p {
+  color: rgba(244, 240, 232, 0.62);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+@media (max-width: 1080px) {
+  .about-hero__copy h1 {
+    font-size: 5.3rem;
+  }
+
+  .about-route-launch__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .about-hero {
+    min-height: auto;
+    padding-top: 9.6rem;
+  }
+
+  .about-hero::before {
+    inset: 9.2rem 1rem 1rem;
+  }
+
+  .about-hero__copy h1 {
+    font-size: 3.45rem;
+  }
+
+  .about-hero__copy .lede {
+    font-size: 1rem;
+  }
+
+  .about-mode-controls {
+    gap: 0.55rem;
+  }
+
+  .about-mode-controls__button {
+    flex: 1 1 calc(50% - 0.55rem);
+    min-width: 8.4rem;
+  }
+
+  .about-orientation {
+    order: -1;
+    margin-top: 1.2rem;
+  }
+
+  .about-north-star-field {
+    width: min(100%, 24rem);
+  }
+
+  .about-orientation__detail {
+    width: 100%;
+    margin-top: -2.6rem;
+  }
+
+  .about-orientation__detail h2 {
+    font-size: 1.75rem;
+  }
+
+  .about-orientation__stat strong {
+    font-size: 2.65rem;
+  }
+
+  .about-route-launch__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .about-route-card {
+    min-height: 13rem;
+  }
+
+  .about-route-card h3 {
+    font-size: 1.95rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .about-hero__copy h1 {
+    font-size: 3rem;
+  }
+
+  .about-hero__copy .lede {
+    font-size: 0.95rem;
+  }
+
+  .about-mode-controls__button {
+    flex-basis: 100%;
+  }
+
+  .about-north-star-field {
+    width: min(100%, 19.5rem);
+  }
+
+  .about-orientation__detail {
+    margin-top: -1.4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .about-mode-controls__button,
+  .about-route-card,
+  .about-north-star-field__node circle {
+    transition: none;
+  }
+
+  .about-mode-controls__button:hover,
+  .about-mode-controls__button:focus-visible,
+  .about-mode-controls__button--active,
+  .about-route-card:hover,
+  .about-route-card:focus-visible {
+    transform: none;
+  }
+}

--- a/src/app/pages/AboutPage.tsx
+++ b/src/app/pages/AboutPage.tsx
@@ -1,41 +1,206 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+
+import { getChapters, getConcepts, getSymbols } from '../data/aionData';
+
+import './AboutPage.css';
+
+const ORIENTATION_MODES = [
+  {
+    id: 'study',
+    label: 'Study',
+    title: 'Follow the chapter argument',
+    body: 'Begin with a guided sequence: each chapter becomes a visual instrument for one movement in Aion.',
+    route: '/chapters',
+    routeLabel: 'Chapters',
+    statLabel: 'visual chapters',
+    tone: 'gold',
+  },
+  {
+    id: 'map',
+    label: 'Map',
+    title: 'See concepts as relations',
+    body: 'Use the atlas when a term, symbol, or chapter needs to be understood through its neighbors.',
+    route: '/atlas',
+    routeLabel: 'Atlas',
+    statLabel: 'linked concepts',
+    tone: 'cyan',
+  },
+  {
+    id: 'symbolize',
+    label: 'Symbolize',
+    title: 'Read images as carriers',
+    body: 'Symbols are treated as recurring objects that carry meaning across the book without replacing the text.',
+    route: '/symbols',
+    routeLabel: 'Symbols',
+    statLabel: 'recurring symbols',
+    tone: 'rose',
+  },
+  {
+    id: 'verify',
+    label: 'Verify',
+    title: 'Keep the orientation honest',
+    body: "Context, restraint, accessibility, and route checks keep the visual layer in service of Jung's argument.",
+    route: '/timeline',
+    routeLabel: 'Timeline',
+    statLabel: 'context path',
+    tone: 'green',
+  },
+] as const;
+
+type OrientationMode = (typeof ORIENTATION_MODES)[number];
+
 export default function AboutPage() {
+  const chapters = getChapters();
+  const concepts = getConcepts();
+  const symbols = getSymbols();
+  const [activeModeId, setActiveModeId] = useState<OrientationMode['id']>('study');
+  const activeMode = ORIENTATION_MODES.find((mode) => mode.id === activeModeId) || ORIENTATION_MODES[0];
+  const statValueByMode: Record<OrientationMode['id'], string> = {
+    study: String(chapters.length).padStart(2, '0'),
+    map: String(concepts.length).padStart(2, '0'),
+    symbolize: String(symbols.length).padStart(2, '0'),
+    verify: 'AA',
+  };
+
   return (
-    <div className="page">
+    <div className="page page--about">
       <section className="page-header page-header--visual about-hero section-band">
-        <div>
+        <div className="about-hero__copy">
           <p className="eyebrow">About</p>
-          <h1>Depth psychology as visual orientation</h1>
+          <h1>Aion visual atlas</h1>
           <p className="lede">
-            Aion Visualization translates a difficult symbolic work into an interactive learning environment while keeping conceptual claims restrained and traceable.
+            A sparse, interactive map of chapters, concepts, symbols, and checks that keeps visuals in service of Jung's argument.
           </p>
+          <div className="about-mode-controls" aria-label="Learning orientation modes">
+            {ORIENTATION_MODES.map((mode) => (
+              <button
+                key={mode.id}
+                type="button"
+                className={mode.id === activeMode.id ? 'about-mode-controls__button about-mode-controls__button--active' : 'about-mode-controls__button'}
+                onClick={() => setActiveModeId(mode.id)}
+                aria-controls="about-orientation-detail about-orientation-field"
+                aria-pressed={mode.id === activeMode.id}
+              >
+                {mode.label}
+              </button>
+            ))}
+          </div>
         </div>
-        <div className="about-compass" aria-label="Aion learning compass">
-          <span className="about-compass__ring about-compass__ring--outer" />
-          <span className="about-compass__ring about-compass__ring--inner" />
-          <span className="about-compass__axis about-compass__axis--vertical" />
-          <span className="about-compass__axis about-compass__axis--horizontal" />
-          <span className="about-compass__node about-compass__node--one">Study</span>
-          <span className="about-compass__node about-compass__node--two">See</span>
-          <span className="about-compass__node about-compass__node--three">Move</span>
-          <span className="about-compass__node about-compass__node--four">Check</span>
-          <strong>Self</strong>
+
+        <div className="about-orientation" data-active-mode={activeMode.id}>
+          <svg
+            id="about-orientation-field"
+            className="about-north-star-field"
+            viewBox="0 0 640 640"
+            role="img"
+            aria-labelledby="about-field-title about-field-desc"
+          >
+            <title id="about-field-title">Aion learning orientation field</title>
+            <desc id="about-field-desc">
+              Four routes orbit the Self: study the chapters, map concepts, read symbols, and verify context.
+            </desc>
+            <defs>
+              <radialGradient id="about-field-glow" cx="50%" cy="50%" r="55%">
+                <stop offset="0%" stopColor="rgba(212, 175, 55, 0.58)" />
+                <stop offset="36%" stopColor="rgba(83, 216, 232, 0.14)" />
+                <stop offset="100%" stopColor="rgba(3, 3, 7, 0)" />
+              </radialGradient>
+              <linearGradient id="about-field-axis" x1="0%" x2="100%" y1="50%" y2="50%">
+                <stop offset="0%" stopColor="rgba(244, 240, 232, 0)" />
+                <stop offset="50%" stopColor="rgba(244, 240, 232, 0.46)" />
+                <stop offset="100%" stopColor="rgba(244, 240, 232, 0)" />
+              </linearGradient>
+              <filter id="about-field-blur">
+                <feGaussianBlur stdDeviation="10" />
+              </filter>
+            </defs>
+
+            <rect className="about-north-star-field__plate" x="28" y="28" width="584" height="584" rx="22" />
+            <circle className="about-north-star-field__aura" cx="320" cy="320" r="246" />
+            <circle className="about-north-star-field__halo" cx="320" cy="320" r="205" />
+            <circle className="about-north-star-field__halo about-north-star-field__halo--inner" cx="320" cy="320" r="116" />
+            <ellipse className="about-north-star-field__orbit about-north-star-field__orbit--concept" cx="320" cy="320" rx="222" ry="84" />
+            <ellipse className="about-north-star-field__orbit about-north-star-field__orbit--symbol" cx="320" cy="320" rx="132" ry="244" />
+            <path className="about-north-star-field__axis" d="M112 320h416" />
+            <path className="about-north-star-field__axis about-north-star-field__axis--vertical" d="M320 112v416" />
+            <path className="about-north-star-field__diagonal about-north-star-field__diagonal--one" d="M174 174l292 292" />
+            <path className="about-north-star-field__diagonal about-north-star-field__diagonal--two" d="M466 174L174 466" />
+            <circle className="about-north-star-field__glow" cx="320" cy="320" r="138" />
+
+            {ORIENTATION_MODES.map((mode, index) => {
+              const nodePositions = [
+                { x: 320, y: 96 },
+                { x: 544, y: 320 },
+                { x: 320, y: 544 },
+                { x: 96, y: 320 },
+              ];
+              const { x, y } = nodePositions[index];
+              return (
+                <g key={mode.id} className={`about-north-star-field__node about-north-star-field__node--${mode.id}`}>
+                  <circle cx={x} cy={y} r={32} />
+                  <text x={x} y={y + 5} textAnchor="middle">
+                    {mode.label}
+                  </text>
+                </g>
+              );
+            })}
+
+            <g className="about-north-star-field__core">
+              <circle cx="320" cy="320" r="58" />
+              <text x="320" y="312" textAnchor="middle">Aion</text>
+              <text x="320" y="338" textAnchor="middle">Self</text>
+            </g>
+            <g className="about-north-star-field__active-readout">
+              <rect x="214" y="40" width="212" height="68" rx="34" />
+              <text x="320" y="68" textAnchor="middle">{activeMode.label}</text>
+              <text x="320" y="91" textAnchor="middle">{activeMode.title}</text>
+            </g>
+          </svg>
+
+          <div id="about-orientation-detail" className="about-orientation__detail" aria-live="polite">
+            <p className="eyebrow">{activeMode.routeLabel}</p>
+            <h2>{activeMode.title}</h2>
+            <p>{activeMode.body}</p>
+            <div className="about-orientation__stat" data-tone={activeMode.tone}>
+              <strong>{statValueByMode[activeMode.id]}</strong>
+              <span>{activeMode.statLabel}</span>
+            </div>
+          </div>
         </div>
       </section>
-      <section className="about-principles section-band section-band--tight">
+
+      <section className="about-route-launch section-band section-band--tight" aria-labelledby="about-route-launch-title">
+        <div className="section-heading">
+          <p className="eyebrow">How to enter</p>
+          <h2 id="about-route-launch-title">Choose a learning vector</h2>
+        </div>
+        <div className="about-route-launch__grid">
+          {ORIENTATION_MODES.map((mode, index) => (
+            <Link key={mode.id} to={mode.route} className={`about-route-card about-route-card--${mode.id}`}>
+              <span>{String(index + 1).padStart(2, '0')}</span>
+              <h3>{mode.routeLabel}</h3>
+              <p>{mode.body}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className="about-principles section-band section-band--tight" aria-label="Product principles">
         <article>
           <span>01</span>
           <h2>Scholarly restraint</h2>
-          <p>The app treats visual invention as a way to clarify Jung's argument, not replace it.</p>
+          <p>Visual invention clarifies Jung's argument; it does not make unsupported claims.</p>
         </article>
         <article>
           <span>02</span>
           <h2>Meaningful motion</h2>
-          <p>Opposition, integration, transformation, and cyclical return become shared motion semantics.</p>
+          <p>Opposition, integration, transformation, and return become reusable interaction grammar.</p>
         </article>
         <article>
           <span>03</span>
-          <h2>Visual-first learning</h2>
-          <p>Text stays concise while diagrams, scenes, symbols, and chapter-to-chapter relationships carry the experience.</p>
+          <h2>Accessible beauty</h2>
+          <p>The same ideas must remain available through keyboard paths, contrast, and reduced motion.</p>
         </article>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- redesigns /about as an interactive Aion orientation field with Study, Map, Symbolize, and Verify modes
- adds a route-scoped About stylesheet to avoid shared CSS blast radius
- makes mobile start with the visual atlas plate while preserving named controls, route links, and reduced-motion behavior

## Verification
- npx tsc --noEmit
- npm run lint
- npm run test:app
- npm test
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run build
- npm run test:visual:control-tower
- npm run test:e2e:app
- npm run test:a11y:app
- targeted About Playwright probe for controls, 44px targets, overflow, state updates, and reduced motion
- npm run build:pages && npm run test:pages:artifact
- strict conflict marker scan: rg -n "^(<{7}(?: .*)?|={7}|>{7}(?: .*)?)$" .

## Visual Evidence
- Control Tower: /about now scores 100% with visualAnchor:2 and meaningfulInteraction:2
- Mobile/narrow Control Tower evidence: /about has 0px horizontal overflow at 390x844 and 320x568
- Screenshot artifacts: test-results/control-tower/latest/screenshots/about-desktop.png, about-mobile.png, about-narrow.png

## Notes
- No new dependencies, WebGL, data-model changes, or source-claim expansion.
- Vercel preview may remain non-authoritative for this GitHub Pages project; GitHub Actions and Pages deployment are the release gates.
