### PR TITLE
[codex] refine chapter six fish aeon

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -223,6 +223,45 @@ async function checkAtlasDynamicAccessibility(page, failures) {
   if (!emptyFieldVisible) failures.push('/atlas: empty constellation field is missing an accessible name');
 }
 
+async function checkChapterSixDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/journey/chapter/ch6`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+  const instrument = page.getByRole('img', { name: /Sign of the Fishes model/ });
+  const instrumentVisible = await instrument.isVisible();
+  const initialInstrumentLabel = await instrument.getAttribute('aria-label');
+  const initialDescription = await page.locator('#scene-host-description-ch6').textContent();
+
+  if (!instrumentVisible) failures.push('/journey/chapter/ch6: aeon fish instrument is missing an accessible image role');
+  if (!initialInstrumentLabel?.includes('Current emphasis: Pisces')) failures.push(`/journey/chapter/ch6: initial instrument label mismatch: ${initialInstrumentLabel}`);
+  if (!initialDescription?.includes('Pisces: Two fish, two directions')) failures.push(`/journey/chapter/ch6: initial scene description mismatch: ${initialDescription}`);
+
+  const aeon = page.getByRole('button', { name: /02\s+Aeon/ });
+  await aeon.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const aeonPressed = await aeon.getAttribute('aria-pressed');
+  const aeonLabel = await instrument.getAttribute('aria-label');
+  const aeonDescription = await page.locator('#scene-host-description-ch6').textContent();
+  if (aeonPressed !== 'true') failures.push(`/journey/chapter/ch6: aeon button did not become pressed: ${aeonPressed}`);
+  if (!aeonLabel?.includes('Current emphasis: Aeon') || !aeonLabel?.includes('History gains a wheel')) failures.push(`/journey/chapter/ch6: aeon instrument label mismatch: ${aeonLabel}`);
+  if (!aeonDescription?.includes('Aeon: History gains a wheel')) failures.push(`/journey/chapter/ch6: aeon scene description mismatch: ${aeonDescription}`);
+
+  const threshold = page.getByRole('button', { name: /03\s+Threshold/ });
+  await threshold.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const thresholdPressed = await threshold.getAttribute('aria-pressed');
+  const thresholdLabel = await instrument.getAttribute('aria-label');
+  const thresholdDescription = await page.locator('#scene-host-description-ch6').textContent();
+  if (thresholdPressed !== 'true') failures.push(`/journey/chapter/ch6: threshold button did not become pressed: ${thresholdPressed}`);
+  if (!thresholdLabel?.includes('Current emphasis: Threshold') || !thresholdLabel?.includes('The age turns slowly')) failures.push(`/journey/chapter/ch6: threshold instrument label mismatch: ${thresholdLabel}`);
+  if (!thresholdDescription?.includes('Threshold: The age turns slowly')) failures.push(`/journey/chapter/ch6: threshold scene description mismatch: ${thresholdDescription}`);
+}
+
 async function runAccessibilitySmoke() {
   const server = startPreviewServer();
   const failures = [];
@@ -237,6 +276,7 @@ async function runAccessibilitySmoke() {
       await checkRoute(desktop, route, failures);
     }
     await checkAtlasDynamicAccessibility(desktop, failures);
+    await checkChapterSixDynamicAccessibility(desktop, failures);
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -520,6 +520,40 @@ async function smokeReducedMotion(browser, failures) {
   if (!chapterFiveFallbackText?.includes('luminous cross') || !chapterFiveFallbackText?.includes('excluded fourth')) {
     failures.push('reduced-motion chapter fallback lost Chapter 5 Christ symbol teaching summary');
   }
+
+  await gotoAppRoute(page, '/journey/chapter/ch6');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterSixFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterSixReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterSixReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterSixReferenceCount = await chapterSixReferenceNodes.count();
+  const chapterSixPanelIds = await chapterSixReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterSixPauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterSixCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterSixFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterSixInstrumentCount = await page.locator('.aeon-fish-instrument').count();
+  const chapterSixInstrumentMotion = await page.locator('.aeon-fish-instrument__field, .aeon-fish-instrument__ring, .aeon-fish-instrument__sign, .aeon-fish-instrument__thread, .aeon-fish-instrument__fish, .aeon-fish-instrument__hand, .aeon-fish-instrument__threshold').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterSixAnimatedParts = chapterSixInstrumentMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterSixTransitioningParts = chapterSixInstrumentMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
+
+  if (!chapterSixFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 6 scene');
+  if (chapterSixReducedMotionAttribute !== 'true') failures.push('Chapter 6 did not record reduced-motion state');
+  if (chapterSixReferenceCount !== 3) failures.push(`reduced-motion Chapter 6 reference node count mismatch: ${chapterSixReferenceCount}`);
+  if (chapterSixPanelIds.join(',') !== 'fish,zodiac,transition') failures.push(`reduced-motion Chapter 6 reference nodes out of order: ${chapterSixPanelIds.join(',')}`);
+  if (chapterSixPauseControlCount !== 0) failures.push(`reduced-motion Chapter 6 rendered pause controls: ${chapterSixPauseControlCount}`);
+  if (chapterSixCanvasCount !== 0) failures.push(`reduced-motion Chapter 6 rendered canvas: ${chapterSixCanvasCount}`);
+  if (chapterSixInstrumentCount !== 1) failures.push(`reduced-motion Chapter 6 aeon fish instrument count mismatch: ${chapterSixInstrumentCount}`);
+  if (chapterSixAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 6 aeon fish instrument still animates: ${JSON.stringify(chapterSixAnimatedParts)}`);
+  if (chapterSixTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 6 aeon fish instrument still transitions: ${JSON.stringify(chapterSixTransitioningParts)}`);
+  if (!chapterSixFallbackText?.includes('Opposing fish') || !chapterSixFallbackText?.includes('zodiacal time')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 6 fish/aeon teaching summary');
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -949,14 +983,126 @@ async function smokeChapterSceneControls(page, failures) {
   recordCanvasPixelFailure(failures, 'chapter 5', chapterFivePixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch6');
-  const threshold = page.getByRole('button', { name: /03\s+Threshold/ });
-  await activateSceneButton(threshold);
+  await page.locator('.scene-host__mount[data-state="ready"]').waitFor({ state: 'visible', timeout: 10_000 });
+  const chapterSixReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterSixReferenceCount = await chapterSixReferenceNodes.count();
+  const chapterSixPanelIds = await chapterSixReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterSixInstrument = page.locator('.aeon-fish-instrument');
+  const chapterSixInstrumentCount = await chapterSixInstrument.count();
+  const chapterSixInstrumentRole = await chapterSixInstrument.getAttribute('role');
+  const chapterSixInstrumentLabel = await chapterSixInstrument.getAttribute('aria-label');
+  const chapterSixInstrumentPanel = await chapterSixInstrument.getAttribute('data-active-panel');
+  const chapterSixInstrumentFieldCount = await page.locator('.aeon-fish-instrument__field').count();
+  const chapterSixInstrumentRingCount = await page.locator('.aeon-fish-instrument__ring').count();
+  const chapterSixInstrumentSignCount = await page.locator('.aeon-fish-instrument__sign').count();
+  const chapterSixInstrumentFishCount = await page.locator('.aeon-fish-instrument__fish').count();
+  const chapterSixInstrumentThreadCount = await page.locator('.aeon-fish-instrument__thread').count();
+  const chapterSixInstrumentHandCount = await page.locator('.aeon-fish-instrument__hand').count();
+  const chapterSixInstrumentThresholdCount = await page.locator('.aeon-fish-instrument__threshold').count();
+  const chapterSixInstrumentLabelCount = await page.locator('.aeon-fish-instrument__label').count();
+  const chapterSixInstrumentMarksVisible = await page.locator('.aeon-fish-instrument__field, .aeon-fish-instrument__ring, .aeon-fish-instrument__sign, .aeon-fish-instrument__thread, .aeon-fish-instrument__fish, .aeon-fish-instrument__hand, .aeon-fish-instrument__threshold').evaluateAll((nodes) => nodes.length >= 21 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterSixReferenceGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="fish"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="zodiac"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="transition"] .chapter-stage__reference-mark').evaluateAll((nodes) => nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+
+  if (chapterSixReferenceCount !== 3) failures.push(`chapter 6 reference node count mismatch: ${chapterSixReferenceCount}`);
+  if (chapterSixPanelIds.join(',') !== 'fish,zodiac,transition') failures.push(`chapter 6 reference nodes out of order: ${chapterSixPanelIds.join(',')}`);
+  if (chapterSixInstrumentCount !== 1) failures.push(`chapter 6 aeon fish instrument count mismatch: ${chapterSixInstrumentCount}`);
+  if (chapterSixInstrumentFieldCount !== 2) failures.push(`chapter 6 aeon fish instrument field count mismatch: ${chapterSixInstrumentFieldCount}`);
+  if (chapterSixInstrumentRingCount !== 2) failures.push(`chapter 6 aeon fish instrument ring count mismatch: ${chapterSixInstrumentRingCount}`);
+  if (chapterSixInstrumentSignCount !== 12) failures.push(`chapter 6 aeon fish instrument sign count mismatch: ${chapterSixInstrumentSignCount}`);
+  if (chapterSixInstrumentFishCount !== 2) failures.push(`chapter 6 aeon fish instrument fish count mismatch: ${chapterSixInstrumentFishCount}`);
+  if (chapterSixInstrumentThreadCount !== 1) failures.push(`chapter 6 aeon fish instrument thread count mismatch: ${chapterSixInstrumentThreadCount}`);
+  if (chapterSixInstrumentHandCount !== 1) failures.push(`chapter 6 aeon fish instrument hand count mismatch: ${chapterSixInstrumentHandCount}`);
+  if (chapterSixInstrumentThresholdCount !== 1) failures.push(`chapter 6 aeon fish instrument threshold count mismatch: ${chapterSixInstrumentThresholdCount}`);
+  if (chapterSixInstrumentLabelCount !== 3) failures.push(`chapter 6 aeon fish instrument label count mismatch: ${chapterSixInstrumentLabelCount}`);
+  if (chapterSixInstrumentRole !== 'img') failures.push(`chapter 6 aeon fish instrument role mismatch: ${chapterSixInstrumentRole}`);
+  if (!chapterSixInstrumentLabel?.includes('Sign of the Fishes') || !chapterSixInstrumentLabel?.includes('two Pisces fish') || !chapterSixInstrumentLabel?.includes('zodiac wheel') || !chapterSixInstrumentLabel?.includes('Current emphasis: Pisces')) {
+    failures.push(`chapter 6 aeon fish instrument label missing teaching text: ${chapterSixInstrumentLabel}`);
+  }
+  if (chapterSixInstrumentPanel !== 'fish') failures.push(`chapter 6 aeon fish instrument did not start on fish panel: ${chapterSixInstrumentPanel}`);
+  if (!chapterSixInstrumentMarksVisible) failures.push('chapter 6 aeon fish instrument marks are not visibly rendered');
+  if (!chapterSixReferenceGlyphsVisible) failures.push('chapter 6 reference glyphs are not visibly rendered');
+
+  const zodiac = page.locator('.chapter-stage__reference-node[data-panel-id="zodiac"]');
+  await zodiac.waitFor({ state: 'visible', timeout: 30_000 });
+  await zodiac.scrollIntoViewIfNeeded({ timeout: 10_000 });
+  await zodiac.focus();
+  await page.keyboard.press('Enter');
   await page.waitForTimeout(250);
+  await page.waitForFunction(() => {
+    const signs = Array.from(document.querySelectorAll('.aeon-fish-instrument__sign'));
+    const hand = document.querySelector('.aeon-fish-instrument__hand');
+    return signs.length === 12
+      && signs.every((node) => Number(window.getComputedStyle(node).opacity) >= 0.9)
+      && hand
+      && Number(window.getComputedStyle(hand).opacity) >= 0.95;
+  }, null, { timeout: 3_000 }).catch(() => {});
+
+  const zodiacPressed = await zodiac.getAttribute('aria-pressed');
+  const zodiacPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="zodiac"]').count();
+  const chapterSixZodiacDescription = await page.locator('#scene-host-description-ch6').textContent();
+  const chapterSixInstrumentZodiacPanel = await chapterSixInstrument.getAttribute('data-active-panel');
+  const chapterSixInstrumentZodiacLabel = await chapterSixInstrument.getAttribute('aria-label');
+  const chapterSixZodiacVisualState = await page.locator('.aeon-fish-instrument__sign, .aeon-fish-instrument__hand').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  if (zodiacPressed !== 'true') failures.push(`chapter 6 zodiac reference did not become active: ${zodiacPressed}`);
+  if (zodiacPanelActive !== 1) failures.push(`chapter 6 zodiac panel did not become active: ${zodiacPanelActive}`);
+  if (chapterSixInstrumentZodiacPanel !== 'zodiac') failures.push(`chapter 6 aeon fish instrument did not follow zodiac panel: ${chapterSixInstrumentZodiacPanel}`);
+  if (!chapterSixInstrumentZodiacLabel?.includes('Current emphasis: Aeon') || !chapterSixInstrumentZodiacLabel?.includes('History gains a wheel')) {
+    failures.push(`chapter 6 aeon fish instrument label did not follow zodiac panel: ${chapterSixInstrumentZodiacLabel}`);
+  }
+  if (chapterSixZodiacVisualState.length !== 13 || chapterSixZodiacVisualState.some((opacity) => opacity < 0.9)) {
+    failures.push(`chapter 6 aeon fish instrument did not visually emphasize zodiac wheel: ${chapterSixZodiacVisualState.join(',')}`);
+  }
+  if (!chapterSixZodiacDescription?.includes('Aeon: History gains a wheel')) failures.push(`chapter 6 scene description did not follow zodiac panel: ${chapterSixZodiacDescription}`);
+
+  const threshold = page.locator('.chapter-stage__reference-node[data-panel-id="transition"]');
+  await threshold.waitFor({ state: 'visible', timeout: 30_000 });
+  await threshold.scrollIntoViewIfNeeded({ timeout: 10_000 });
+  await threshold.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(250);
+  await page.waitForFunction(() => {
+    const thresholdLine = document.querySelector('.aeon-fish-instrument__threshold');
+    const aquarius = document.querySelector('.aeon-fish-instrument__sign--11');
+    return thresholdLine
+      && aquarius
+      && Number(window.getComputedStyle(thresholdLine).opacity) >= 0.95
+      && Number(window.getComputedStyle(aquarius).opacity) >= 0.95;
+  }, null, { timeout: 3_000 }).catch(() => {});
 
   const thresholdPressed = await threshold.getAttribute('aria-pressed');
+  const thresholdPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="transition"]').count();
+  const chapterSixThresholdDescription = await page.locator('#scene-host-description-ch6').textContent();
   const chapterSixScrollY = await page.evaluate(() => window.scrollY);
+  const chapterSixInstrumentThresholdPanel = await chapterSixInstrument.getAttribute('data-active-panel');
+  const chapterSixInstrumentThresholdLabel = await chapterSixInstrument.getAttribute('aria-label');
+  const chapterSixThresholdVisualState = await page.locator('.aeon-fish-instrument__threshold, .aeon-fish-instrument__sign--11').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   if (thresholdPressed !== 'true') failures.push(`chapter 6 scene control did not become active: ${thresholdPressed}`);
+  if (thresholdPanelActive !== 1) failures.push(`chapter 6 threshold panel did not become active: ${thresholdPanelActive}`);
+  if (chapterSixInstrumentThresholdPanel !== 'transition') failures.push(`chapter 6 aeon fish instrument did not follow threshold panel: ${chapterSixInstrumentThresholdPanel}`);
+  if (!chapterSixInstrumentThresholdLabel?.includes('Current emphasis: Threshold') || !chapterSixInstrumentThresholdLabel?.includes('The age turns slowly')) {
+    failures.push(`chapter 6 aeon fish instrument label did not follow threshold panel: ${chapterSixInstrumentThresholdLabel}`);
+  }
+  if (chapterSixThresholdVisualState.length !== 2 || chapterSixThresholdVisualState.some((opacity) => opacity < 0.95)) {
+    failures.push(`chapter 6 aeon fish instrument did not visually emphasize threshold: ${chapterSixThresholdVisualState.join(',')}`);
+  }
+  if (!chapterSixThresholdDescription?.includes('Threshold: The age turns slowly')) failures.push(`chapter 6 scene description did not follow threshold panel: ${chapterSixThresholdDescription}`);
   if (chapterSixScrollY > 10) failures.push(`chapter 6 scene control unexpectedly scrolled page: ${chapterSixScrollY}`);
+
+  const chapterSixCanvas = page.locator('.scene-host canvas').first();
+  const chapterSixCanvasBox = await chapterSixCanvas.boundingBox();
+  const chapterSixPixelSample = await countCanvasPixels(chapterSixCanvas);
+  if (!chapterSixCanvasBox || chapterSixCanvasBox.width < 300 || chapterSixCanvasBox.height < 300) {
+    failures.push(`chapter 6 canvas geometry too small: ${chapterSixCanvasBox ? `${Math.round(chapterSixCanvasBox.width)}x${Math.round(chapterSixCanvasBox.height)}` : 'missing'}`);
+  }
+  recordCanvasPixelFailure(failures, 'chapter 6', chapterSixPixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch7');
   const chapterSevenThreshold = page.getByRole('button', { name: /03\s+Threshold/ });
@@ -1041,7 +1187,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -1191,6 +1337,47 @@ async function smokeMobile(page, failures) {
     if (!chapterFiveInstrumentBox) failures.push(`mobile chapter 5 Christ symbol instrument missing at ${viewport.width}x${viewport.height}`);
     if (chapterFiveInstrumentBox && chapterFiveInstrumentBox.width > viewport.width + 2) {
       failures.push(`mobile chapter 5 Christ symbol instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterFiveInstrumentBox.width)}`);
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch6');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterSixNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterSixHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterSixReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterSixReferenceCount = await chapterSixReferenceNodes.count();
+    const chapterSixPanelIds = await chapterSixReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterSixAnnotationLabelsHidden = await page.locator('.ch6-fish-label, .ch6-commissure-label, .ch6-sign-name, .ch6-spring-label, .ch6-saturn-label, .ch6-jupiter-label, .ch6-conjunction-label, .ch6-orbiter-label, .ch6-leaders-svg').evaluateAll((nodes) => nodes.every((node) => window.getComputedStyle(node).display === 'none'));
+    const chapterSixScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterSixReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const chapterSixInstrumentBox = await page.locator('.aeon-fish-instrument').boundingBox();
+    if (!chapterSixNavBox || !chapterSixHeadingBox) {
+      failures.push(`mobile chapter 6 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterSixNavBottom = chapterSixNavBox.y + chapterSixNavBox.height;
+    if (chapterSixNavBottom > chapterSixHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 6 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterSixNavBottom)}, heading top ${Math.round(chapterSixHeadingBox.y)}`);
+    }
+    if (chapterSixReferenceCount !== 3) failures.push(`mobile chapter 6 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterSixReferenceCount}`);
+    if (chapterSixPanelIds.join(',') !== 'fish,zodiac,transition') failures.push(`mobile chapter 6 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterSixPanelIds.join(',')}`);
+    if (!chapterSixAnnotationLabelsHidden) failures.push(`mobile chapter 6 annotation overlay labels remain visible at ${viewport.width}x${viewport.height}`);
+    if (chapterSixScrollWidth > viewport.width + 2) failures.push(`mobile chapter 6 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterSixScrollWidth}`);
+    if (chapterSixReferenceMapBox && chapterSixReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 6 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterSixReferenceMapBox.width)}`);
+    }
+    if (!chapterSixInstrumentBox) failures.push(`mobile chapter 6 aeon fish instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterSixInstrumentBox && chapterSixInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 6 aeon fish instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterSixInstrumentBox.width)}`);
+    }
+
+    if (viewport.width === mobileViewport.width) {
+      const chapterSixCanvas = page.locator('.scene-host canvas').first();
+      const chapterSixCanvasCount = await chapterSixCanvas.count();
+      if (chapterSixCanvasCount > 0) {
+        const chapterSixPixelSample = await countCanvasPixels(chapterSixCanvas);
+        recordCanvasPixelFailure(failures, `mobile chapter 6 at ${viewport.width}x${viewport.height}`, chapterSixPixelSample);
+      }
     }
   }
 }

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -17,6 +17,7 @@ import { CHAPTER_SCENES } from '../visualization/chapterScenes';
 const quaternityDirections = ['north', 'east', 'south', 'west'] as const;
 const mandalaBands = ['outer', 'middle', 'inner'] as const;
 const rootLines = ['left', 'center', 'right'] as const;
+const zodiacMarkers = ['AR', 'TA', 'GE', 'CN', 'LE', 'VI', 'LI', 'SC', 'SG', 'CP', 'AQ', 'PI'] as const;
 
 function useReducedMotionPreference() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
@@ -59,6 +60,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const panelProgress = experience.panels.length > 1 ? activePanelIndex / (experience.panels.length - 1) : 0;
   const activePanel = experience.panels[activePanelIndex] || experience.panels[0];
   const christSymbolInstrumentLabel = `Christ symbol model: a luminous cross carries a powerful Self image, three bright points form a one-sided field, the excluded fourth remains dark but necessary, and roots descend toward the counter-pole. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
+  const aeonFishInstrumentLabel = `Sign of the Fishes model: two Pisces fish swim in opposite directions inside a zodiac wheel, the spring point precesses through symbolic time, and Aquarius marks the slow threshold of a changing aeon. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
 
   useEffect(() => {
     setActivePanelId(experience.panels[0]?.id || '');
@@ -197,6 +199,36 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="christ-symbol-instrument__label christ-symbol-instrument__label--cross" aria-hidden="true">cross</span>
               <span className="christ-symbol-instrument__label christ-symbol-instrument__label--fourth" aria-hidden="true">fourth</span>
               <span className="christ-symbol-instrument__label christ-symbol-instrument__label--root" aria-hidden="true">root</span>
+            </div>
+          )}
+          {chapter.id === 'ch6' && (
+            <div
+              className="aeon-fish-instrument"
+              data-active-panel={activePanelId}
+              role="img"
+              aria-label={aeonFishInstrumentLabel}
+            >
+              <span className="aeon-fish-instrument__field aeon-fish-instrument__field--pisces" aria-hidden="true" />
+              <span className="aeon-fish-instrument__field aeon-fish-instrument__field--aquarius" aria-hidden="true" />
+              <span className="aeon-fish-instrument__ring aeon-fish-instrument__ring--outer" aria-hidden="true" />
+              <span className="aeon-fish-instrument__ring aeon-fish-instrument__ring--inner" aria-hidden="true" />
+              {zodiacMarkers.map((marker, index) => (
+                <span
+                  key={marker}
+                  className={`aeon-fish-instrument__sign aeon-fish-instrument__sign--${index + 1}`}
+                  aria-hidden="true"
+                >
+                  {marker}
+                </span>
+              ))}
+              <span className="aeon-fish-instrument__thread" aria-hidden="true" />
+              <span className="aeon-fish-instrument__fish aeon-fish-instrument__fish--light" aria-hidden="true" />
+              <span className="aeon-fish-instrument__fish aeon-fish-instrument__fish--shadow" aria-hidden="true" />
+              <span className="aeon-fish-instrument__hand" aria-hidden="true" />
+              <span className="aeon-fish-instrument__threshold" aria-hidden="true" />
+              <span className="aeon-fish-instrument__label aeon-fish-instrument__label--fish" aria-hidden="true">two fish</span>
+              <span className="aeon-fish-instrument__label aeon-fish-instrument__label--wheel" aria-hidden="true">aeon wheel</span>
+              <span className="aeon-fish-instrument__label aeon-fish-instrument__label--threshold" aria-hidden="true">threshold</span>
             </div>
           )}
           <div className="chapter-stage__thesis-map" aria-label="Chapter visual sequence">

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2427,6 +2427,48 @@ h3 {
   margin-top: 2.05rem;
 }
 
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__scrim {
+  background:
+    radial-gradient(circle at 63% 47%, rgba(83, 216, 232, 0.08), transparent 17rem),
+    linear-gradient(90deg, rgba(5, 5, 8, 0.88) 0%, rgba(5, 5, 8, 0.48) 43%, rgba(5, 5, 8, 0.12) 100%);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__intro {
+  width: min(38rem, calc(100% - 2rem));
+  justify-content: flex-end;
+  margin-left: clamp(1rem, 4.6vw, 4.2rem);
+  padding-bottom: clamp(2.1rem, 5.3vh, 3.8rem);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__intro h1 {
+  max-width: 9.2ch;
+  font-size: clamp(3rem, 6vw, 5.55rem);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__intro p:not(.eyebrow) {
+  max-width: 35ch;
+  font-size: clamp(0.98rem, 1.24vw, 1.08rem);
+  line-height: 1.62;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__thesis-map {
+  max-width: 29rem;
+  margin-top: 1rem;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-map {
+  width: min(25rem, 100%);
+  margin-top: 0.68rem;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node {
+  min-height: 3.75rem;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-label {
+  margin-top: 2.05rem;
+}
+
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro {
   width: min(35rem, calc(100% - 2rem));
   justify-content: flex-end;
@@ -3949,6 +3991,384 @@ h3 {
   transform: rotate(-34deg) scaleY(1.12);
 }
 
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument {
+  position: relative;
+  width: min(29.5rem, 100%);
+  min-height: clamp(6.25rem, 9.6vh, 7.2rem);
+  overflow: hidden;
+  margin-top: 0.85rem;
+  border: 1px solid rgba(244, 240, 232, 0.105);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 47% 50%, rgba(83, 216, 232, 0.13), transparent 4.6rem),
+    radial-gradient(circle at 28% 48%, rgba(212, 175, 55, 0.16), transparent 4.1rem),
+    radial-gradient(circle at 80% 45%, rgba(103, 186, 214, 0.12), transparent 4.6rem),
+    linear-gradient(90deg, rgba(8, 7, 14, 0.82), rgba(5, 8, 15, 0.52) 50%, rgba(5, 16, 22, 0.48));
+  box-shadow:
+    var(--shadow-inset),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument::before,
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument::before {
+  inset: 0.64rem;
+  border: 1px solid rgba(83, 216, 232, 0.09);
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument::after {
+  left: 50%;
+  top: 50%;
+  width: 7.6rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(255, 227, 156, 0.09);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 1.4rem rgba(83, 216, 232, 0.08),
+    0 0 1.9rem rgba(212, 175, 55, 0.08);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__field,
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring,
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign,
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__thread,
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish,
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__hand,
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__threshold,
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label {
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__field {
+  top: 0;
+  bottom: 0;
+  width: 50%;
+  opacity: 0.58;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__field--pisces {
+  left: 0;
+  background:
+    radial-gradient(circle at 38% 50%, rgba(255, 227, 156, 0.15), transparent 4.2rem),
+    linear-gradient(90deg, rgba(212, 175, 55, 0.09), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__field--aquarius {
+  right: 0;
+  background:
+    radial-gradient(circle at 65% 48%, rgba(83, 216, 232, 0.17), transparent 4.5rem),
+    linear-gradient(270deg, rgba(83, 216, 232, 0.09), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring {
+  left: 50%;
+  top: 50%;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  transition:
+    border-color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring--outer {
+  width: 7.1rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(244, 240, 232, 0.32);
+  background:
+    conic-gradient(from -28deg, rgba(212, 175, 55, 0.36), rgba(83, 216, 232, 0.24), rgba(244, 240, 232, 0.16), rgba(212, 175, 55, 0.36));
+  mask-image: radial-gradient(circle at 50% 50%, transparent 0 61%, #000 63% 66%, transparent 68%);
+  opacity: 0.9;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring--inner {
+  width: 4.35rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(83, 216, 232, 0.28);
+  opacity: 0.68;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign {
+  --sign-angle: 0deg;
+  --sign-counter: 0deg;
+  left: 50%;
+  top: 50%;
+  width: 1.05rem;
+  height: 1.05rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(244, 240, 232, 0.1);
+  border-radius: 50%;
+  background: rgba(4, 5, 10, 0.72);
+  color: rgba(244, 240, 232, 0.78);
+  font-family: var(--font-ui);
+  font-size: 0.48rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  opacity: 0.72;
+  transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.65rem) rotate(var(--sign-counter));
+  transition:
+    background 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring),
+    color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--1 {
+  --sign-angle: -90deg;
+  --sign-counter: 90deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--2 {
+  --sign-angle: -60deg;
+  --sign-counter: 60deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--3 {
+  --sign-angle: -30deg;
+  --sign-counter: 30deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--4 {
+  --sign-angle: 0deg;
+  --sign-counter: 0deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--5 {
+  --sign-angle: 30deg;
+  --sign-counter: -30deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--6 {
+  --sign-angle: 60deg;
+  --sign-counter: -60deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--7 {
+  --sign-angle: 90deg;
+  --sign-counter: -90deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--8 {
+  --sign-angle: 120deg;
+  --sign-counter: -120deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--9 {
+  --sign-angle: 150deg;
+  --sign-counter: -150deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--10 {
+  --sign-angle: 180deg;
+  --sign-counter: -180deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--11 {
+  --sign-angle: 210deg;
+  --sign-counter: -210deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign--12 {
+  --sign-angle: 240deg;
+  --sign-counter: -240deg;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__thread {
+  left: 50%;
+  top: 50%;
+  width: 43%;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 227, 156, 0.08), rgba(244, 240, 232, 0.54), rgba(83, 216, 232, 0.08));
+  opacity: 0.68;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish {
+  top: 50%;
+  width: 2.75rem;
+  height: 0.76rem;
+  border-radius: 999px 60% 60% 999px;
+  transition:
+    box-shadow 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish::before {
+  content: '';
+  position: absolute;
+  right: -0.24rem;
+  top: 50%;
+  width: 0.62rem;
+  height: 0.62rem;
+  border-top: 1px solid currentColor;
+  border-right: 1px solid currentColor;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish--light {
+  left: 35%;
+  color: rgba(255, 227, 156, 0.9);
+  background: linear-gradient(90deg, rgba(255, 227, 156, 0.18), rgba(255, 227, 156, 0.82));
+  box-shadow: 0 0 1.5rem rgba(212, 175, 55, 0.28);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish--shadow {
+  left: 65%;
+  color: rgba(143, 231, 237, 0.88);
+  background: linear-gradient(90deg, rgba(83, 216, 232, 0.78), rgba(83, 216, 232, 0.16));
+  box-shadow: 0 0 1.5rem rgba(83, 216, 232, 0.24);
+  transform: translate(-50%, -50%) rotate(180deg);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__hand {
+  left: 50%;
+  top: 50%;
+  width: 21%;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(244, 240, 232, 0.86), rgba(83, 216, 232, 0.44), transparent);
+  border-radius: 999px;
+  opacity: 0.76;
+  transform: rotate(28deg);
+  transform-origin: left center;
+  transition:
+    background 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__threshold {
+  right: 22%;
+  top: 17%;
+  bottom: 17%;
+  width: 1px;
+  background: linear-gradient(180deg, transparent, rgba(83, 216, 232, 0.66), rgba(255, 227, 156, 0.24), transparent);
+  box-shadow: 0 0 1.5rem rgba(83, 216, 232, 0.24);
+  opacity: 0.56;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label--fish {
+  left: 7%;
+  top: 15%;
+  color: rgba(255, 227, 156, 0.92);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label--wheel {
+  left: 39%;
+  bottom: 9%;
+  color: rgba(244, 240, 232, 0.84);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label--threshold {
+  right: 6%;
+  top: 15%;
+  color: rgba(143, 231, 237, 0.95);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__fish--light {
+  opacity: 1;
+  transform: translate(-50%, -50%) translateX(-0.3rem) scale(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__fish--shadow {
+  opacity: 1;
+  transform: translate(-50%, -50%) translateX(0.3rem) rotate(180deg) scale(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__thread {
+  opacity: 0.92;
+  transform: translate(-50%, -50%) scaleX(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__sign {
+  opacity: 0.46;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__sign--12 {
+  border-color: rgba(255, 227, 156, 0.58);
+  color: var(--gold-soft);
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="zodiac"] .aeon-fish-instrument__ring {
+  border-color: rgba(244, 240, 232, 0.46);
+  filter: drop-shadow(0 0 0.7rem rgba(83, 216, 232, 0.12));
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="zodiac"] .aeon-fish-instrument__sign {
+  border-color: rgba(83, 216, 232, 0.24);
+  color: rgba(244, 240, 232, 0.92);
+  opacity: 0.95;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="zodiac"] .aeon-fish-instrument__hand {
+  opacity: 1;
+  transform: rotate(44deg) scaleX(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="zodiac"] .aeon-fish-instrument__fish {
+  opacity: 0.66;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__field--aquarius {
+  opacity: 0.9;
+  transform: scaleX(1.06);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__threshold {
+  opacity: 1;
+  transform: scaleY(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__hand {
+  background: linear-gradient(90deg, rgba(244, 240, 232, 0.74), rgba(143, 231, 237, 0.92), transparent);
+  opacity: 1;
+  transform: rotate(62deg) scaleX(1.16);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__sign--11 {
+  border-color: rgba(143, 231, 237, 0.66);
+  background: rgba(7, 37, 48, 0.76);
+  color: var(--ink-cyan);
+  opacity: 1;
+  transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.65rem) rotate(var(--sign-counter)) scale(1.2);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__fish {
+  opacity: 0.78;
+}
+
 .chapter-experience[data-chapter-id="ch3"][data-reduced-motion="true"] .scene-host__fallback {
   left: auto;
   right: clamp(1rem, 4vw, 3.5rem);
@@ -4287,6 +4707,75 @@ h3 {
   background:
     linear-gradient(138deg, transparent 48%, rgba(204, 109, 134, 0.24) 49%, transparent 51%),
     linear-gradient(42deg, transparent 48%, rgba(204, 109, 134, 0.2) 49%, transparent 51%);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node {
+  background:
+    radial-gradient(circle at 50% 28%, rgba(83, 216, 232, 0.1), transparent 2.4rem),
+    linear-gradient(180deg, rgba(3, 6, 12, 0.6), rgba(3, 3, 7, 0.34));
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="fish"] .chapter-stage__reference-mark::before {
+  left: 50%;
+  top: 1.12rem;
+  width: 2.55rem;
+  height: 0.86rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.46);
+  border-bottom: 1px solid rgba(143, 231, 237, 0.38);
+  border-radius: 50%;
+  transform: translateX(-50%) rotate(-12deg);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="fish"] .chapter-stage__reference-mark::after {
+  left: 50%;
+  top: 1.22rem;
+  width: 2.55rem;
+  height: 0.86rem;
+  border-top: 1px solid rgba(143, 231, 237, 0.38);
+  border-bottom: 1px solid rgba(255, 227, 156, 0.44);
+  border-radius: 50%;
+  transform: translateX(-50%) rotate(168deg);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="zodiac"] .chapter-stage__reference-mark::before {
+  left: 50%;
+  top: 0.72rem;
+  width: 2.55rem;
+  height: 2.55rem;
+  border: 1px solid rgba(244, 240, 232, 0.32);
+  border-radius: 50%;
+  background: conic-gradient(from -20deg, rgba(212, 175, 55, 0.36), rgba(83, 216, 232, 0.24), rgba(244, 240, 232, 0.1), rgba(212, 175, 55, 0.36));
+  mask-image: radial-gradient(circle at 50% 50%, transparent 0 55%, #000 57% 61%, transparent 63%);
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="zodiac"] .chapter-stage__reference-mark::after {
+  left: 50%;
+  top: 1.96rem;
+  width: 1.5rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(244, 240, 232, 0.74), rgba(83, 216, 232, 0.35), transparent);
+  transform: rotate(36deg);
+  transform-origin: left center;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="transition"] .chapter-stage__reference-mark::before {
+  left: 39%;
+  top: 0.8rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid rgba(83, 216, 232, 0.28);
+  border-radius: 50%;
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="transition"] .chapter-stage__reference-mark::after {
+  left: 62%;
+  top: 0.72rem;
+  width: 1px;
+  height: 2.5rem;
+  background: linear-gradient(180deg, transparent, rgba(143, 231, 237, 0.68), rgba(255, 227, 156, 0.24), transparent);
+  box-shadow: 0 0 1rem rgba(83, 216, 232, 0.24);
 }
 
 .scene-host__status,
@@ -5527,6 +6016,13 @@ h3 {
 	  .christ-symbol-instrument__connector,
 	  .christ-symbol-instrument__point,
 	  .christ-symbol-instrument__root,
+	  .aeon-fish-instrument__field,
+	  .aeon-fish-instrument__ring,
+	  .aeon-fish-instrument__sign,
+	  .aeon-fish-instrument__thread,
+	  .aeon-fish-instrument__fish,
+	  .aeon-fish-instrument__hand,
+	  .aeon-fish-instrument__threshold,
 	  .chapters-orbit__node,
 	  .home-chapter-orbit__item a,
 	  .scene-host__pause {
@@ -5558,6 +6054,16 @@ h3 {
   .chapter-experience[data-chapter-id="ch5"] .christ-symbol-instrument__connector,
   .chapter-experience[data-chapter-id="ch5"] .christ-symbol-instrument__point,
   .chapter-experience[data-chapter-id="ch5"] .christ-symbol-instrument__root {
+    transition: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__field,
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring,
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign,
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__thread,
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish,
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__hand,
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__threshold {
     transition: none;
   }
 	}
@@ -6053,6 +6559,55 @@ h3 {
     top: calc(50% + 0.56rem);
   }
 
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__scrim {
+    background:
+      linear-gradient(180deg, rgba(3, 3, 7, 0.94), rgba(3, 3, 7, 0.78) 54%, rgba(3, 3, 7, 0.86)),
+      radial-gradient(circle at 52% 44%, rgba(8, 53, 66, 0.26), rgba(3, 3, 7, 0.78) 62%);
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="fish"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="fish"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.9rem;
+    height: 0.62rem;
+    transform: translate(-50%, -50%) rotate(-12deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="fish"] .chapter-stage__reference-mark::after {
+    transform: translate(-50%, -50%) rotate(168deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="zodiac"] .chapter-stage__reference-mark::before {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.9rem;
+    height: 1.9rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="zodiac"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.25rem;
+    transform: rotate(36deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="transition"] .chapter-stage__reference-mark::before {
+    left: 1.15rem;
+    top: 50%;
+    width: 1.65rem;
+    height: 1.65rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__reference-node[data-panel-id="transition"] .chapter-stage__reference-mark::after {
+    left: 2.35rem;
+    top: 50%;
+    height: 2rem;
+    transform: translateY(-50%);
+  }
+
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__intro {
     padding-top: 2rem;
   }
@@ -6450,6 +7005,111 @@ h3 {
 
   .chapter-experience[data-chapter-id="ch5"][data-reduced-motion="true"] .scene-host__fallback h2,
   .chapter-experience[data-chapter-id="ch5"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__intro {
+    justify-content: flex-start;
+    padding-top: 10.2rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-sigil {
+    display: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__intro h1 {
+    max-width: 8.6ch;
+    font-size: clamp(2.34rem, 12.5vw, 3.08rem);
+    line-height: 0.92;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .chapter-stage__intro p:not(.eyebrow) {
+    margin-top: 0.72rem;
+    max-width: 29ch;
+    font-size: 0.92rem;
+    line-height: 1.48;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .scene-host__pause {
+    justify-content: center;
+    width: 2.35rem;
+    min-width: 2.35rem;
+    padding-inline: 0;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .scene-host__pause span:not(.scene-host__pause-icon) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument {
+    min-height: 6.75rem;
+    margin-top: 0.7rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring--outer {
+    width: 6.15rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring--inner {
+    width: 3.75rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign {
+    transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.12rem) rotate(var(--sign-counter));
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__sign--11 {
+    transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.12rem) rotate(var(--sign-counter)) scale(1.16);
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish {
+    width: 2.3rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label {
+    font-size: 0.53rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label--fish {
+    left: 6%;
+    top: 12%;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label--wheel {
+    left: 37%;
+    bottom: 8%;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label--threshold {
+    right: 5%;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback {
+    left: 1rem;
+    right: 1rem;
+    top: 20.8rem;
+    width: auto;
+    padding: 0.56rem 0.7rem;
+    text-align: left;
+    transform: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
+    margin: 0;
+  }
+
+  .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback h2,
+  .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -125,6 +125,29 @@ describe('Aion framework data contract', () => {
     expect(CHAPTER_SCENES.ch5.fallbackSummary).toContain('excluded fourth');
     expect(CHAPTER_SCENES.ch5.fallbackSummary).toContain('three-plus-one');
   });
+
+  test('keeps Chapter 6 fish panels tied to aeon and zodiacal time', () => {
+    expect(CHAPTER_SCENES.ch6.panels.map((panel) => panel.id)).toEqual([
+      'fish',
+      'zodiac',
+      'transition',
+    ]);
+    expect(CHAPTER_SCENES.ch6.panels.map((panel) => panel.kicker)).toEqual([
+      'Pisces',
+      'Aeon',
+      'Threshold',
+    ]);
+    expect(CHAPTER_SCENES.ch6.motionGrammar).toBe('cyclical-return');
+    expect(CHAPTER_SCENES.ch6.visualTheme).toContain('Zodiac fish');
+    expect(CHAPTER_SCENES.ch6.fallbackSummary).toContain('Opposing fish');
+    expect(CHAPTER_SCENES.ch6.fallbackSummary).toContain('zodiacal time');
+
+    expect(getConceptsForChapter('ch6').map((concept) => concept.id)).toEqual([
+      'aeon',
+      'fish-symbol',
+      'opposites',
+    ]);
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- Adds a Chapter 6 aeon/fish/zodiac reference instrument to the shared chapter shell
- Styles the Sign of the Fishes route as a visual-first aeon threshold surface with panel-aware states
- Extends contract, shell smoke, reduced-motion, mobile, and dynamic accessibility coverage for Chapter 6

## Visual thesis
Chapter 6 now teaches the aeon as symbolic time: two Pisces fish move in opposition inside a zodiac wheel, while Aquarius marks the slow threshold of transition. Text stays sparse; the instrument and Three scene carry the concept.

## Skills / workflow
- orchestration-autopilot with explorer, architect, devil-advocate, and test-verifier lanes
- frontend-design-pro, high-end-visual-design, design-taste-frontend, redesign-existing-projects
- accessibility-review, webapp-testing, storytelling-web, canvas-design, data-visualization
- AION_SKILL_ROUTING_PLAYBOOK route ownership

## Verification
- git diff --check
- node --check scripts/testing/app-shell-smoke.mjs
- node --check scripts/testing/app-accessibility-smoke.mjs
- npm run lint:styles
- npm run test:app
- npx tsc --noEmit
- npm run lint
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run build
- npm run test:e2e:app
- npm run test:a11y:app
- npm test
- npm run build:pages
- npm run test:pages:artifact
- npm run test:visual:control-tower

## Visual QA evidence
- Control Tower scored /journey/chapter/ch6 at 100% with no blockers
- Desktop, 390px mobile, and 320px narrow screenshots were inspected
- Ch6 mobile/narrow had 0px horizontal overflow and no nav/heading overlap

## Notes
- Vite still reports the known large Three chunk warning during build.
- Direct stylelint against src/app/styles.css is not a repo gate and exposes pre-existing config mismatches; configured npm run lint:styles passes.
