### PR TITLE
feat: polish chapter seven prophecy field

### DIFF
--- a/docs/PHASE2_PUSH_COMMANDS.txt
+++ b/docs/PHASE2_PUSH_COMMANDS.txt
@@ -1,5 +1,5 @@
 PHASE 2 - GIT PUSH COMMANDS
-===========================
+---------------------------
 
 Please run these commands in your terminal to push all Phase 2 updates:
 
@@ -88,7 +88,7 @@ and major bugs identified in the detailed bug report."
    git push origin main
 
 FILES THAT SHOULD BE INCLUDED IN THIS COMMIT:
-============================================
+--------------------------------------------
 New files:
 - webgl-utils.js
 - accessibility-utils.js  
@@ -116,7 +116,7 @@ From Phase 1 (if not already pushed):
 - chapter2-v2.html through chapter4-v2.html (navigation fixes)
 
 VERIFICATION AFTER PUSH:
-=======================
+-----------------------
 After pushing, check these URLs:
 - https://akshaybapat6365.github.io/aion-visualization/
 - https://akshaybapat6365.github.io/aion-visualization/timeline-v2.html

--- a/docs/PUSH_INSTRUCTIONS.txt
+++ b/docs/PUSH_INSTRUCTIONS.txt
@@ -1,5 +1,5 @@
 INSTRUCTIONS TO PUSH PHASE 1 UPDATES TO GITHUB
-==============================================
+----------------------------------------------
 
 Please run these commands in your terminal:
 

--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -262,6 +262,45 @@ async function checkChapterSixDynamicAccessibility(page, failures) {
   if (!thresholdDescription?.includes('Threshold: The age turns slowly')) failures.push(`/journey/chapter/ch6: threshold scene description mismatch: ${thresholdDescription}`);
 }
 
+async function checkChapterSevenDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/journey/chapter/ch7`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+  const instrument = page.getByRole('img', { name: /Prophecy field model/ });
+  const instrumentVisible = await instrument.isVisible();
+  const initialInstrumentLabel = await instrument.getAttribute('aria-label');
+  const initialDescription = await page.locator('#scene-host-description-ch7').textContent();
+
+  if (!instrumentVisible) failures.push('/journey/chapter/ch7: prophecy field instrument is missing an accessible image role');
+  if (!initialInstrumentLabel?.includes('Current emphasis: Prophecy')) failures.push(`/journey/chapter/ch7: initial instrument label mismatch: ${initialInstrumentLabel}`);
+  if (!initialDescription?.includes('Prophecy: Meaning under pressure')) failures.push(`/journey/chapter/ch7: initial scene description mismatch: ${initialDescription}`);
+
+  const collective = page.getByRole('button', { name: /02\s+Collective/ });
+  await collective.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const collectivePressed = await collective.getAttribute('aria-pressed');
+  const collectiveLabel = await instrument.getAttribute('aria-label');
+  const collectiveDescription = await page.locator('#scene-host-description-ch7').textContent();
+  if (collectivePressed !== 'true') failures.push(`/journey/chapter/ch7: collective button did not become pressed: ${collectivePressed}`);
+  if (!collectiveLabel?.includes('Current emphasis: Collective') || !collectiveLabel?.includes('Private fear becomes shared image')) failures.push(`/journey/chapter/ch7: collective instrument label mismatch: ${collectiveLabel}`);
+  if (!collectiveDescription?.includes('Collective: Private fear becomes shared image')) failures.push(`/journey/chapter/ch7: collective scene description mismatch: ${collectiveDescription}`);
+
+  const threshold = page.getByRole('button', { name: /03\s+Threshold/ });
+  await threshold.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const thresholdPressed = await threshold.getAttribute('aria-pressed');
+  const thresholdLabel = await instrument.getAttribute('aria-label');
+  const thresholdDescription = await page.locator('#scene-host-description-ch7').textContent();
+  if (thresholdPressed !== 'true') failures.push(`/journey/chapter/ch7: threshold button did not become pressed: ${thresholdPressed}`);
+  if (!thresholdLabel?.includes('Current emphasis: Threshold') || !thresholdLabel?.includes('The future looks backward')) failures.push(`/journey/chapter/ch7: threshold instrument label mismatch: ${thresholdLabel}`);
+  if (!thresholdDescription?.includes('Threshold: The future looks backward')) failures.push(`/journey/chapter/ch7: threshold scene description mismatch: ${thresholdDescription}`);
+}
+
 async function runAccessibilitySmoke() {
   const server = startPreviewServer();
   const failures = [];
@@ -277,10 +316,11 @@ async function runAccessibilitySmoke() {
     }
     await checkAtlasDynamicAccessibility(desktop, failures);
     await checkChapterSixDynamicAccessibility(desktop, failures);
+    await checkChapterSevenDynamicAccessibility(desktop, failures);
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -554,6 +554,40 @@ async function smokeReducedMotion(browser, failures) {
   if (!chapterSixFallbackText?.includes('Opposing fish') || !chapterSixFallbackText?.includes('zodiacal time')) {
     failures.push('reduced-motion chapter fallback lost Chapter 6 fish/aeon teaching summary');
   }
+
+  await gotoAppRoute(page, '/journey/chapter/ch7');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterSevenFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterSevenReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterSevenReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterSevenReferenceCount = await chapterSevenReferenceNodes.count();
+  const chapterSevenPanelIds = await chapterSevenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterSevenPauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterSevenCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterSevenFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterSevenInstrumentCount = await page.locator('.prophecy-field-instrument').count();
+  const chapterSevenInstrumentMotion = await page.locator('.prophecy-field-instrument__field, .prophecy-field-instrument__axis, .prophecy-field-instrument__tick, .prophecy-field-instrument__pressure, .prophecy-field-instrument__date, .prophecy-field-instrument__image, .prophecy-field-instrument__arc, .prophecy-field-instrument__threshold, .prophecy-field-instrument__mirror').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterSevenAnimatedParts = chapterSevenInstrumentMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterSevenTransitioningParts = chapterSevenInstrumentMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
+
+  if (!chapterSevenFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 7 scene');
+  if (chapterSevenReducedMotionAttribute !== 'true') failures.push('Chapter 7 did not record reduced-motion state');
+  if (chapterSevenReferenceCount !== 3) failures.push(`reduced-motion Chapter 7 reference node count mismatch: ${chapterSevenReferenceCount}`);
+  if (chapterSevenPanelIds.join(',') !== 'prophecy,collective,threshold') failures.push(`reduced-motion Chapter 7 reference nodes out of order: ${chapterSevenPanelIds.join(',')}`);
+  if (chapterSevenPauseControlCount !== 0) failures.push(`reduced-motion Chapter 7 rendered pause controls: ${chapterSevenPauseControlCount}`);
+  if (chapterSevenCanvasCount !== 0) failures.push(`reduced-motion Chapter 7 rendered canvas: ${chapterSevenCanvasCount}`);
+  if (chapterSevenInstrumentCount !== 1) failures.push(`reduced-motion Chapter 7 prophecy field instrument count mismatch: ${chapterSevenInstrumentCount}`);
+  if (chapterSevenAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 7 prophecy field instrument still animates: ${JSON.stringify(chapterSevenAnimatedParts)}`);
+  if (chapterSevenTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 7 prophecy field instrument still transitions: ${JSON.stringify(chapterSevenTransitioningParts)}`);
+  if (!chapterSevenFallbackText?.includes('collective anxiety') || !chapterSevenFallbackText?.includes('symbolic dates')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 7 prophecy teaching summary');
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -1105,14 +1139,118 @@ async function smokeChapterSceneControls(page, failures) {
   recordCanvasPixelFailure(failures, 'chapter 6', chapterSixPixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch7');
-  const chapterSevenThreshold = page.getByRole('button', { name: /03\s+Threshold/ });
-  await activateSceneButton(chapterSevenThreshold);
-  await page.waitForTimeout(250);
+  await page.locator('.scene-host__mount[data-state="ready"]').waitFor({ state: 'visible', timeout: 10_000 });
+  const chapterSevenReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterSevenReferenceCount = await chapterSevenReferenceNodes.count();
+  const chapterSevenPanelIds = await chapterSevenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterSevenInstrument = page.locator('.prophecy-field-instrument');
+  const chapterSevenInstrumentCount = await chapterSevenInstrument.count();
+  const chapterSevenInstrumentRole = await chapterSevenInstrument.getAttribute('role');
+  const chapterSevenInstrumentLabel = await chapterSevenInstrument.getAttribute('aria-label');
+  const chapterSevenInstrumentPanel = await chapterSevenInstrument.getAttribute('data-active-panel');
+  const chapterSevenInstrumentFieldCount = await page.locator('.prophecy-field-instrument__field').count();
+  const chapterSevenInstrumentTickCount = await page.locator('.prophecy-field-instrument__tick').count();
+  const chapterSevenInstrumentImageCount = await page.locator('.prophecy-field-instrument__image').count();
+  const chapterSevenInstrumentArcCount = await page.locator('.prophecy-field-instrument__arc').count();
+  const chapterSevenInstrumentPressureCount = await page.locator('.prophecy-field-instrument__pressure').count();
+  const chapterSevenInstrumentDateCount = await page.locator('.prophecy-field-instrument__date').count();
+  const chapterSevenInstrumentThresholdCount = await page.locator('.prophecy-field-instrument__threshold').count();
+  const chapterSevenInstrumentMirrorCount = await page.locator('.prophecy-field-instrument__mirror').count();
+  const chapterSevenInstrumentLabelCount = await page.locator('.prophecy-field-instrument__label').count();
+  const chapterSevenInstrumentMarksVisible = await page.locator('.prophecy-field-instrument__field, .prophecy-field-instrument__axis, .prophecy-field-instrument__tick, .prophecy-field-instrument__pressure, .prophecy-field-instrument__date, .prophecy-field-instrument__image, .prophecy-field-instrument__arc, .prophecy-field-instrument__threshold, .prophecy-field-instrument__mirror').evaluateAll((nodes) => nodes.length >= 16 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterSevenReferenceGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="prophecy"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="collective"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="threshold"] .chapter-stage__reference-mark').evaluateAll((nodes) => nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
 
-  const chapterSevenPressed = await chapterSevenThreshold.getAttribute('aria-pressed');
+  if (chapterSevenReferenceCount !== 3) failures.push(`chapter 7 reference node count mismatch: ${chapterSevenReferenceCount}`);
+  if (chapterSevenPanelIds.join(',') !== 'prophecy,collective,threshold') failures.push(`chapter 7 reference nodes out of order: ${chapterSevenPanelIds.join(',')}`);
+  if (chapterSevenInstrumentCount !== 1) failures.push(`chapter 7 prophecy field instrument count mismatch: ${chapterSevenInstrumentCount}`);
+  if (chapterSevenInstrumentFieldCount !== 2) failures.push(`chapter 7 prophecy field instrument field count mismatch: ${chapterSevenInstrumentFieldCount}`);
+  if (chapterSevenInstrumentTickCount !== 4) failures.push(`chapter 7 prophecy field instrument tick count mismatch: ${chapterSevenInstrumentTickCount}`);
+  if (chapterSevenInstrumentImageCount !== 3) failures.push(`chapter 7 prophecy field instrument image count mismatch: ${chapterSevenInstrumentImageCount}`);
+  if (chapterSevenInstrumentArcCount !== 2) failures.push(`chapter 7 prophecy field instrument arc count mismatch: ${chapterSevenInstrumentArcCount}`);
+  if (chapterSevenInstrumentPressureCount !== 1) failures.push(`chapter 7 prophecy field instrument pressure count mismatch: ${chapterSevenInstrumentPressureCount}`);
+  if (chapterSevenInstrumentDateCount !== 1) failures.push(`chapter 7 prophecy field instrument date count mismatch: ${chapterSevenInstrumentDateCount}`);
+  if (chapterSevenInstrumentThresholdCount !== 1) failures.push(`chapter 7 prophecy field instrument threshold count mismatch: ${chapterSevenInstrumentThresholdCount}`);
+  if (chapterSevenInstrumentMirrorCount !== 1) failures.push(`chapter 7 prophecy field instrument mirror count mismatch: ${chapterSevenInstrumentMirrorCount}`);
+  if (chapterSevenInstrumentLabelCount !== 3) failures.push(`chapter 7 prophecy field instrument label count mismatch: ${chapterSevenInstrumentLabelCount}`);
+  if (chapterSevenInstrumentRole !== 'img') failures.push(`chapter 7 prophecy field instrument role mismatch: ${chapterSevenInstrumentRole}`);
+  if (!chapterSevenInstrumentLabel?.includes('Prophecy field') || !chapterSevenInstrumentLabel?.includes('historical pressure') || !chapterSevenInstrumentLabel?.includes('Current emphasis: Prophecy')) {
+    failures.push(`chapter 7 prophecy field instrument label missing teaching text: ${chapterSevenInstrumentLabel}`);
+  }
+  if (chapterSevenInstrumentPanel !== 'prophecy') failures.push(`chapter 7 prophecy field instrument did not start on prophecy panel: ${chapterSevenInstrumentPanel}`);
+  if (!chapterSevenInstrumentMarksVisible) failures.push('chapter 7 prophecy field instrument marks are not visibly rendered');
+  if (!chapterSevenReferenceGlyphsVisible) failures.push('chapter 7 reference glyphs are not visibly rendered');
+
+  const chapterSevenCollective = page.locator('.chapter-stage__reference-node[data-panel-id="collective"]');
+  await chapterSevenCollective.waitFor({ state: 'visible', timeout: 30_000 });
+  await chapterSevenCollective.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(250);
+  await page.waitForFunction(() => {
+    const nodes = Array.from(document.querySelectorAll('.prophecy-field-instrument__image, .prophecy-field-instrument__arc'));
+    return nodes.length === 5 && nodes.every((node) => Number(window.getComputedStyle(node).opacity) >= 0.85);
+  }, null, { timeout: 3_000 }).catch(() => {});
+
+  const chapterSevenCollectivePressed = await chapterSevenCollective.getAttribute('aria-pressed');
+  const chapterSevenCollectivePanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="collective"]').count();
+  const chapterSevenCollectiveDescription = await page.locator('#scene-host-description-ch7').textContent();
+  const chapterSevenInstrumentCollectivePanel = await chapterSevenInstrument.getAttribute('data-active-panel');
+  const chapterSevenInstrumentCollectiveLabel = await chapterSevenInstrument.getAttribute('aria-label');
+  const chapterSevenCollectiveVisualState = await page.locator('.prophecy-field-instrument__image, .prophecy-field-instrument__arc').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  if (chapterSevenCollectivePressed !== 'true') failures.push(`chapter 7 collective reference did not become active: ${chapterSevenCollectivePressed}`);
+  if (chapterSevenCollectivePanelActive !== 1) failures.push(`chapter 7 collective panel did not become active: ${chapterSevenCollectivePanelActive}`);
+  if (chapterSevenInstrumentCollectivePanel !== 'collective') failures.push(`chapter 7 prophecy field instrument did not follow collective panel: ${chapterSevenInstrumentCollectivePanel}`);
+  if (!chapterSevenInstrumentCollectiveLabel?.includes('Current emphasis: Collective') || !chapterSevenInstrumentCollectiveLabel?.includes('Private fear becomes shared image')) {
+    failures.push(`chapter 7 prophecy field instrument label did not follow collective panel: ${chapterSevenInstrumentCollectiveLabel}`);
+  }
+  if (chapterSevenCollectiveVisualState.length !== 5 || chapterSevenCollectiveVisualState.some((opacity) => opacity < 0.85)) {
+    failures.push(`chapter 7 prophecy field instrument did not visually emphasize collective image: ${chapterSevenCollectiveVisualState.join(',')}`);
+  }
+  if (!chapterSevenCollectiveDescription?.includes('Collective: Private fear becomes shared image')) failures.push(`chapter 7 scene description did not follow collective panel: ${chapterSevenCollectiveDescription}`);
+
+  const chapterSevenThreshold = page.locator('.chapter-stage__reference-node[data-panel-id="threshold"]');
+  await chapterSevenThreshold.waitFor({ state: 'visible', timeout: 30_000 });
+  await chapterSevenThreshold.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(250);
+  await page.waitForFunction(() => {
+    const nodes = Array.from(document.querySelectorAll('.prophecy-field-instrument__threshold, .prophecy-field-instrument__mirror, .prophecy-field-instrument__tick--4'));
+    return nodes.length === 3 && nodes.every((node) => Number(window.getComputedStyle(node).opacity) >= 0.95);
+  }, null, { timeout: 3_000 }).catch(() => {});
+
+  const chapterSevenThresholdPressed = await chapterSevenThreshold.getAttribute('aria-pressed');
+  const chapterSevenThresholdPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="threshold"]').count();
+  const chapterSevenThresholdDescription = await page.locator('#scene-host-description-ch7').textContent();
   const chapterSevenScrollY = await page.evaluate(() => window.scrollY);
-  if (chapterSevenPressed !== 'true') failures.push(`chapter 7 scene control did not become active: ${chapterSevenPressed}`);
+  const chapterSevenInstrumentThresholdPanel = await chapterSevenInstrument.getAttribute('data-active-panel');
+  const chapterSevenInstrumentThresholdLabel = await chapterSevenInstrument.getAttribute('aria-label');
+  const chapterSevenThresholdVisualState = await page.locator('.prophecy-field-instrument__threshold, .prophecy-field-instrument__mirror, .prophecy-field-instrument__tick--4').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  if (chapterSevenThresholdPressed !== 'true') failures.push(`chapter 7 threshold reference did not become active: ${chapterSevenThresholdPressed}`);
+  if (chapterSevenThresholdPanelActive !== 1) failures.push(`chapter 7 threshold panel did not become active: ${chapterSevenThresholdPanelActive}`);
+  if (chapterSevenInstrumentThresholdPanel !== 'threshold') failures.push(`chapter 7 prophecy field instrument did not follow threshold panel: ${chapterSevenInstrumentThresholdPanel}`);
+  if (!chapterSevenInstrumentThresholdLabel?.includes('Current emphasis: Threshold') || !chapterSevenInstrumentThresholdLabel?.includes('The future looks backward')) {
+    failures.push(`chapter 7 prophecy field instrument label did not follow threshold panel: ${chapterSevenInstrumentThresholdLabel}`);
+  }
+  if (chapterSevenThresholdVisualState.length !== 3 || chapterSevenThresholdVisualState.some((opacity) => opacity < 0.95)) {
+    failures.push(`chapter 7 prophecy field instrument did not visually emphasize threshold: ${chapterSevenThresholdVisualState.join(',')}`);
+  }
+  if (!chapterSevenThresholdDescription?.includes('Threshold: The future looks backward')) failures.push(`chapter 7 scene description did not follow threshold panel: ${chapterSevenThresholdDescription}`);
   if (chapterSevenScrollY > 10) failures.push(`chapter 7 scene control unexpectedly scrolled page: ${chapterSevenScrollY}`);
+
+  const chapterSevenCanvas = page.locator('.scene-host canvas').first();
+  const chapterSevenCanvasBox = await chapterSevenCanvas.boundingBox();
+  const chapterSevenPixelSample = await countCanvasPixels(chapterSevenCanvas);
+  if (!chapterSevenCanvasBox || chapterSevenCanvasBox.width < 300 || chapterSevenCanvasBox.height < 300) {
+    failures.push(`chapter 7 canvas geometry too small: ${chapterSevenCanvasBox ? `${Math.round(chapterSevenCanvasBox.width)}x${Math.round(chapterSevenCanvasBox.height)}` : 'missing'}`);
+  }
+  recordCanvasPixelFailure(failures, 'chapter 7', chapterSevenPixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch8');
   const afterlife = page.getByRole('button', { name: /03\s+Afterlife/ });
@@ -1187,7 +1325,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -1377,6 +1515,47 @@ async function smokeMobile(page, failures) {
       if (chapterSixCanvasCount > 0) {
         const chapterSixPixelSample = await countCanvasPixels(chapterSixCanvas);
         recordCanvasPixelFailure(failures, `mobile chapter 6 at ${viewport.width}x${viewport.height}`, chapterSixPixelSample);
+      }
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch7');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterSevenNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterSevenHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterSevenReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterSevenReferenceCount = await chapterSevenReferenceNodes.count();
+    const chapterSevenPanelIds = await chapterSevenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterSevenOverlayHidden = await page.locator('.ch7-event-tooltip, .ch7-scene-dot').evaluateAll((nodes) => nodes.every((node) => window.getComputedStyle(node).display === 'none'));
+    const chapterSevenScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterSevenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const chapterSevenInstrumentBox = await page.locator('.prophecy-field-instrument').boundingBox();
+    if (!chapterSevenNavBox || !chapterSevenHeadingBox) {
+      failures.push(`mobile chapter 7 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterSevenNavBottom = chapterSevenNavBox.y + chapterSevenNavBox.height;
+    if (chapterSevenNavBottom > chapterSevenHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 7 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterSevenNavBottom)}, heading top ${Math.round(chapterSevenHeadingBox.y)}`);
+    }
+    if (chapterSevenReferenceCount !== 3) failures.push(`mobile chapter 7 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterSevenReferenceCount}`);
+    if (chapterSevenPanelIds.join(',') !== 'prophecy,collective,threshold') failures.push(`mobile chapter 7 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterSevenPanelIds.join(',')}`);
+    if (!chapterSevenOverlayHidden) failures.push(`mobile chapter 7 event overlay remains visible at ${viewport.width}x${viewport.height}`);
+    if (chapterSevenScrollWidth > viewport.width + 2) failures.push(`mobile chapter 7 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterSevenScrollWidth}`);
+    if (chapterSevenReferenceMapBox && chapterSevenReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 7 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterSevenReferenceMapBox.width)}`);
+    }
+    if (!chapterSevenInstrumentBox) failures.push(`mobile chapter 7 prophecy field instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterSevenInstrumentBox && chapterSevenInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 7 prophecy field instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterSevenInstrumentBox.width)}`);
+    }
+
+    if (viewport.width === mobileViewport.width) {
+      const chapterSevenCanvas = page.locator('.scene-host canvas').first();
+      const chapterSevenCanvasCount = await chapterSevenCanvas.count();
+      if (chapterSevenCanvasCount > 0) {
+        const chapterSevenPixelSample = await countCanvasPixels(chapterSevenCanvas);
+        recordCanvasPixelFailure(failures, `mobile chapter 7 at ${viewport.width}x${viewport.height}`, chapterSevenPixelSample);
       }
     }
   }

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -18,6 +18,7 @@ const quaternityDirections = ['north', 'east', 'south', 'west'] as const;
 const mandalaBands = ['outer', 'middle', 'inner'] as const;
 const rootLines = ['left', 'center', 'right'] as const;
 const zodiacMarkers = ['AR', 'TA', 'GE', 'CN', 'LE', 'VI', 'LI', 'SC', 'SG', 'CP', 'AQ', 'PI'] as const;
+const prophecyTicks = ['0', '1000', '1555', '2000'] as const;
 
 function useReducedMotionPreference() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
@@ -61,6 +62,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const activePanel = experience.panels[activePanelIndex] || experience.panels[0];
   const christSymbolInstrumentLabel = `Christ symbol model: a luminous cross carries a powerful Self image, three bright points form a one-sided field, the excluded fourth remains dark but necessary, and roots descend toward the counter-pole. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const aeonFishInstrumentLabel = `Sign of the Fishes model: two Pisces fish swim in opposite directions inside a zodiac wheel, the spring point precesses through symbolic time, and Aquarius marks the slow threshold of a changing aeon. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
+  const prophecyFieldInstrumentLabel = `Prophecy field model: historical pressure gathers around a time axis, private fear projects into a shared symbolic image-field, and the threshold mirror shows the future looking backward into older archetypal forms. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
 
   useEffect(() => {
     setActivePanelId(experience.panels[0]?.id || '');
@@ -229,6 +231,39 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="aeon-fish-instrument__label aeon-fish-instrument__label--fish" aria-hidden="true">two fish</span>
               <span className="aeon-fish-instrument__label aeon-fish-instrument__label--wheel" aria-hidden="true">aeon wheel</span>
               <span className="aeon-fish-instrument__label aeon-fish-instrument__label--threshold" aria-hidden="true">threshold</span>
+            </div>
+          )}
+          {chapter.id === 'ch7' && (
+            <div
+              className="prophecy-field-instrument"
+              data-active-panel={activePanelId}
+              role="img"
+              aria-label={prophecyFieldInstrumentLabel}
+            >
+              <span className="prophecy-field-instrument__field prophecy-field-instrument__field--past" aria-hidden="true" />
+              <span className="prophecy-field-instrument__field prophecy-field-instrument__field--future" aria-hidden="true" />
+              <span className="prophecy-field-instrument__axis" aria-hidden="true" />
+              {prophecyTicks.map((tick, index) => (
+                <span
+                  key={tick}
+                  className={`prophecy-field-instrument__tick prophecy-field-instrument__tick--${index + 1}`}
+                  aria-hidden="true"
+                >
+                  {tick}
+                </span>
+              ))}
+              <span className="prophecy-field-instrument__pressure" aria-hidden="true" />
+              <span className="prophecy-field-instrument__date" aria-hidden="true" />
+              <span className="prophecy-field-instrument__image prophecy-field-instrument__image--one" aria-hidden="true" />
+              <span className="prophecy-field-instrument__image prophecy-field-instrument__image--two" aria-hidden="true" />
+              <span className="prophecy-field-instrument__image prophecy-field-instrument__image--three" aria-hidden="true" />
+              <span className="prophecy-field-instrument__arc prophecy-field-instrument__arc--projection" aria-hidden="true" />
+              <span className="prophecy-field-instrument__arc prophecy-field-instrument__arc--return" aria-hidden="true" />
+              <span className="prophecy-field-instrument__threshold" aria-hidden="true" />
+              <span className="prophecy-field-instrument__mirror" aria-hidden="true" />
+              <span className="prophecy-field-instrument__label prophecy-field-instrument__label--pressure" aria-hidden="true">pressure</span>
+              <span className="prophecy-field-instrument__label prophecy-field-instrument__label--collective" aria-hidden="true">shared image</span>
+              <span className="prophecy-field-instrument__label prophecy-field-instrument__label--threshold" aria-hidden="true">threshold</span>
             </div>
           )}
           <div className="chapter-stage__thesis-map" aria-label="Chapter visual sequence">

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2469,6 +2469,52 @@ h3 {
   margin-top: 2.05rem;
 }
 
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__scrim {
+  background:
+    radial-gradient(circle at 59% 52%, rgba(255, 140, 0, 0.08), transparent 15rem),
+    radial-gradient(circle at 78% 44%, rgba(113, 75, 164, 0.1), transparent 18rem),
+    linear-gradient(90deg, rgba(5, 5, 9, 0.9) 0%, rgba(5, 5, 9, 0.52) 44%, rgba(5, 5, 9, 0.18) 100%);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__intro {
+  width: min(38rem, calc(100% - 2rem));
+  justify-content: flex-end;
+  margin-left: clamp(1rem, 4.6vw, 4.2rem);
+  padding-bottom: clamp(2rem, 5vh, 3.65rem);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__intro h1 {
+  max-width: 11ch;
+  font-size: clamp(2.85rem, 5.7vw, 5.1rem);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__intro p:not(.eyebrow) {
+  max-width: 35ch;
+  font-size: clamp(0.98rem, 1.22vw, 1.07rem);
+  line-height: 1.62;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__thesis-map {
+  max-width: 30rem;
+  margin-top: 1rem;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-map {
+  width: min(26rem, 100%);
+  margin-top: 0.68rem;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node {
+  min-height: 3.75rem;
+  background:
+    radial-gradient(circle at 50% 26%, rgba(255, 140, 0, 0.1), transparent 2.25rem),
+    linear-gradient(180deg, rgba(10, 6, 17, 0.58), rgba(3, 3, 8, 0.34));
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-label {
+  margin-top: 2.05rem;
+}
+
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro {
   width: min(35rem, calc(100% - 2rem));
   justify-content: flex-end;
@@ -4369,6 +4415,348 @@ h3 {
   opacity: 0.78;
 }
 
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument {
+  position: relative;
+  width: min(30.5rem, 100%);
+  min-height: clamp(6.45rem, 9.9vh, 7.45rem);
+  overflow: hidden;
+  margin-top: 0.85rem;
+  border: 1px solid rgba(244, 240, 232, 0.105);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 33% 48%, rgba(255, 140, 0, 0.18), transparent 4.8rem),
+    radial-gradient(circle at 58% 42%, rgba(113, 75, 164, 0.18), transparent 4.9rem),
+    radial-gradient(circle at 82% 47%, rgba(83, 216, 232, 0.12), transparent 4.7rem),
+    linear-gradient(90deg, rgba(9, 5, 12, 0.86), rgba(12, 7, 20, 0.56) 52%, rgba(4, 14, 19, 0.48));
+  box-shadow:
+    var(--shadow-inset),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument::before,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument::before {
+  inset: 0.64rem;
+  border: 1px solid rgba(255, 140, 0, 0.09);
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument::after {
+  left: 52%;
+  top: 50%;
+  width: 9.3rem;
+  height: 5.5rem;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 1.3rem rgba(113, 75, 164, 0.13),
+    0 0 2rem rgba(255, 140, 0, 0.08);
+  transform: translate(-50%, -50%) rotate(-8deg);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__field,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__axis,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__pressure,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__date,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__image,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__arc,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__threshold,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__mirror,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label {
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__field {
+  top: 0;
+  bottom: 0;
+  width: 50%;
+  opacity: 0.56;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__field--past {
+  left: 0;
+  background:
+    radial-gradient(circle at 45% 52%, rgba(255, 140, 0, 0.16), transparent 4.1rem),
+    linear-gradient(90deg, rgba(255, 140, 0, 0.08), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__field--future {
+  right: 0;
+  background:
+    radial-gradient(circle at 62% 50%, rgba(83, 216, 232, 0.14), transparent 4.3rem),
+    linear-gradient(270deg, rgba(83, 216, 232, 0.07), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__axis {
+  left: 8%;
+  right: 8%;
+  top: 58%;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 140, 0, 0.08), rgba(244, 240, 232, 0.5), rgba(83, 216, 232, 0.11));
+  opacity: 0.72;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick {
+  top: 63%;
+  display: grid;
+  min-width: 2.35rem;
+  place-items: center;
+  color: rgba(244, 240, 232, 0.56);
+  font-family: var(--font-ui);
+  font-size: 0.5rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  opacity: 0.68;
+  transform: translateX(-50%);
+  transition:
+    color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 1.16rem;
+  width: 1px;
+  height: 0.58rem;
+  background: rgba(244, 240, 232, 0.22);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick--1 {
+  left: 16%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick--2 {
+  left: 42%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick--3 {
+  left: 61%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick--4 {
+  left: 84%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__pressure {
+  left: 28%;
+  top: 47%;
+  width: 5.8rem;
+  height: 2.4rem;
+  border: 1px solid rgba(255, 140, 0, 0.28);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 140, 0, 0.22), rgba(255, 140, 0, 0.02) 68%, transparent 70%);
+  box-shadow: 0 0 1.4rem rgba(255, 140, 0, 0.14);
+  opacity: 0.82;
+  transform: translate(-50%, -50%) rotate(-7deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__date {
+  left: 42%;
+  top: 58%;
+  width: 0.68rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--gold-soft);
+  box-shadow:
+    0 0 0 0.38rem rgba(255, 140, 0, 0.1),
+    0 0 1.45rem rgba(255, 140, 0, 0.34);
+  opacity: 0.9;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__image {
+  width: 0.72rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: rgba(181, 130, 255, 0.72);
+  border: 1px solid rgba(244, 240, 232, 0.18);
+  box-shadow: 0 0 1rem rgba(113, 75, 164, 0.24);
+  opacity: 0.72;
+  transition:
+    background 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__image--one {
+  left: 54%;
+  top: 35%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__image--two {
+  left: 63%;
+  top: 47%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__image--three {
+  left: 56%;
+  top: 67%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__arc {
+  left: 47%;
+  top: 50%;
+  width: 7.8rem;
+  height: 3.8rem;
+  border-radius: 50%;
+  opacity: 0.48;
+  transition:
+    border-color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__arc--projection {
+  border-top: 1px solid rgba(181, 130, 255, 0.34);
+  border-left: 1px solid rgba(181, 130, 255, 0.22);
+  transform: translate(-50%, -50%) rotate(-14deg);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__arc--return {
+  border-bottom: 1px solid rgba(83, 216, 232, 0.28);
+  border-right: 1px solid rgba(83, 216, 232, 0.2);
+  transform: translate(-50%, -50%) rotate(14deg);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__threshold {
+  right: 17%;
+  top: 17%;
+  bottom: 16%;
+  width: 1px;
+  background: linear-gradient(180deg, transparent, rgba(83, 216, 232, 0.62), rgba(255, 140, 0, 0.24), transparent);
+  box-shadow: 0 0 1.5rem rgba(83, 216, 232, 0.2);
+  opacity: 0.58;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__mirror {
+  right: 7%;
+  top: 50%;
+  width: 3.25rem;
+  height: 2.2rem;
+  border: 1px solid rgba(83, 216, 232, 0.24);
+  border-radius: 50%;
+  background:
+    linear-gradient(128deg, transparent 48%, rgba(83, 216, 232, 0.26) 49%, transparent 51%),
+    radial-gradient(circle at 42% 48%, rgba(83, 216, 232, 0.14), transparent 70%);
+  opacity: 0.74;
+  transform: translateY(-50%) rotate(-12deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label--pressure {
+  left: 7%;
+  top: 15%;
+  color: rgba(255, 198, 120, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label--collective {
+  left: 49%;
+  top: 14%;
+  color: rgba(214, 188, 255, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label--threshold {
+  right: 5%;
+  top: 15%;
+  color: rgba(143, 231, 237, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="prophecy"] .prophecy-field-instrument__pressure,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="prophecy"] .prophecy-field-instrument__date {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1.13) rotate(-7deg);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="prophecy"] .prophecy-field-instrument__date {
+  transform: translate(-50%, -50%) scale(1.18);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="prophecy"] .prophecy-field-instrument__tick--2 {
+  color: var(--gold-soft);
+  opacity: 1;
+  transform: translateX(-50%) translateY(-0.08rem) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="collective"] .prophecy-field-instrument__image {
+  background: rgba(214, 188, 255, 0.88);
+  box-shadow: 0 0 1.35rem rgba(181, 130, 255, 0.36);
+  opacity: 1;
+  transform: scale(1.2);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="collective"] .prophecy-field-instrument__arc {
+  border-color: rgba(214, 188, 255, 0.46);
+  opacity: 0.92;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="collective"] .prophecy-field-instrument__pressure,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="collective"] .prophecy-field-instrument__date {
+  opacity: 0.62;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__field--future {
+  opacity: 0.9;
+  transform: scaleX(1.05);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__threshold,
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__mirror {
+  opacity: 1;
+  transform: translateY(-50%) rotate(-12deg) scale(1.1);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__threshold {
+  transform: scaleY(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__tick--4 {
+  color: var(--ink-cyan);
+  opacity: 1;
+  transform: translateX(-50%) translateY(-0.08rem) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__image {
+  opacity: 0.66;
+}
+
 .chapter-experience[data-chapter-id="ch3"][data-reduced-motion="true"] .scene-host__fallback {
   left: auto;
   right: clamp(1rem, 4vw, 3.5rem);
@@ -4776,6 +5164,72 @@ h3 {
   height: 2.5rem;
   background: linear-gradient(180deg, transparent, rgba(143, 231, 237, 0.68), rgba(255, 227, 156, 0.24), transparent);
   box-shadow: 0 0 1rem rgba(83, 216, 232, 0.24);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="prophecy"] .chapter-stage__reference-mark::before {
+  left: 50%;
+  top: 1.9rem;
+  width: 2.8rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 140, 0, 0.18), rgba(244, 240, 232, 0.62), rgba(113, 75, 164, 0.2));
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="prophecy"] .chapter-stage__reference-mark::after {
+  left: 50%;
+  top: 1.72rem;
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 50%;
+  background: rgba(255, 227, 156, 0.9);
+  box-shadow:
+    0 0 0 0.36rem rgba(255, 140, 0, 0.12),
+    0 0 1.2rem rgba(255, 140, 0, 0.34);
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="collective"] .chapter-stage__reference-mark::before {
+  left: 50%;
+  top: 0.82rem;
+  width: 2.7rem;
+  height: 2.4rem;
+  border-top: 1px solid rgba(181, 130, 255, 0.42);
+  border-left: 1px solid rgba(181, 130, 255, 0.24);
+  border-radius: 50%;
+  transform: translateX(-50%) rotate(-14deg);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="collective"] .chapter-stage__reference-mark::after {
+  left: 50%;
+  top: 1.86rem;
+  width: 2.2rem;
+  height: 0.7rem;
+  background:
+    radial-gradient(circle at 18% 50%, rgba(214, 188, 255, 0.9) 0 0.16rem, transparent 0.18rem),
+    radial-gradient(circle at 50% 32%, rgba(214, 188, 255, 0.86) 0 0.16rem, transparent 0.18rem),
+    radial-gradient(circle at 82% 58%, rgba(214, 188, 255, 0.76) 0 0.16rem, transparent 0.18rem);
+  filter: drop-shadow(0 0 0.65rem rgba(181, 130, 255, 0.24));
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="threshold"] .chapter-stage__reference-mark::before {
+  left: 43%;
+  top: 0.76rem;
+  width: 2rem;
+  height: 2.55rem;
+  border-right: 1px solid rgba(83, 216, 232, 0.52);
+  border-radius: 50%;
+  background: radial-gradient(circle at 65% 50%, rgba(83, 216, 232, 0.16), transparent 70%);
+  transform: translateX(-50%) rotate(-12deg);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="threshold"] .chapter-stage__reference-mark::after {
+  left: 62%;
+  top: 0.74rem;
+  width: 1px;
+  height: 2.55rem;
+  background: linear-gradient(180deg, transparent, rgba(143, 231, 237, 0.72), rgba(255, 140, 0, 0.28), transparent);
+  box-shadow: 0 0 1rem rgba(83, 216, 232, 0.22);
 }
 
 .scene-host__status,
@@ -6023,6 +6477,15 @@ h3 {
 	  .aeon-fish-instrument__fish,
 	  .aeon-fish-instrument__hand,
 	  .aeon-fish-instrument__threshold,
+	  .prophecy-field-instrument__field,
+	  .prophecy-field-instrument__axis,
+	  .prophecy-field-instrument__tick,
+	  .prophecy-field-instrument__pressure,
+	  .prophecy-field-instrument__date,
+	  .prophecy-field-instrument__image,
+	  .prophecy-field-instrument__arc,
+	  .prophecy-field-instrument__threshold,
+	  .prophecy-field-instrument__mirror,
 	  .chapters-orbit__node,
 	  .home-chapter-orbit__item a,
 	  .scene-host__pause {
@@ -6064,6 +6527,18 @@ h3 {
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish,
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__hand,
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__threshold {
+    transition: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__field,
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__axis,
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick,
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__pressure,
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__date,
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__image,
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__arc,
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__threshold,
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__mirror {
     transition: none;
   }
 	}
@@ -6608,6 +7083,56 @@ h3 {
     transform: translateY(-50%);
   }
 
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__scrim {
+    background:
+      linear-gradient(180deg, rgba(3, 3, 7, 0.94), rgba(3, 3, 7, 0.78) 54%, rgba(3, 3, 7, 0.88)),
+      radial-gradient(circle at 50% 44%, rgba(255, 140, 0, 0.18), rgba(3, 3, 7, 0.78) 62%),
+      radial-gradient(circle at 78% 40%, rgba(113, 75, 164, 0.18), transparent 42%);
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="prophecy"] .chapter-stage__reference-mark::before {
+    left: 1.35rem;
+    top: 50%;
+    width: 2rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="prophecy"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="collective"] .chapter-stage__reference-mark::before {
+    left: 1.35rem;
+    top: 50%;
+    width: 2.05rem;
+    height: 1.85rem;
+    transform: translate(-50%, -50%) rotate(-14deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="collective"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.8rem;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="threshold"] .chapter-stage__reference-mark::before {
+    left: 1.2rem;
+    top: 50%;
+    width: 1.58rem;
+    height: 2.08rem;
+    transform: translate(-50%, -50%) rotate(-12deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="threshold"] .chapter-stage__reference-mark::after {
+    left: 2.18rem;
+    top: 50%;
+    height: 2rem;
+    transform: translateY(-50%);
+  }
+
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__intro {
     padding-top: 2rem;
   }
@@ -7110,6 +7635,130 @@ h3 {
 
   .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback h2,
   .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__intro {
+    justify-content: flex-start;
+    padding-top: 10.2rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-sigil {
+    display: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__intro h1 {
+    max-width: 8.6ch;
+    font-size: clamp(2.14rem, 11.6vw, 2.9rem);
+    line-height: 0.92;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-stage__intro p:not(.eyebrow) {
+    margin-top: 0.72rem;
+    max-width: 29ch;
+    font-size: 0.92rem;
+    line-height: 1.48;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .scene-host__pause {
+    justify-content: center;
+    width: 2.35rem;
+    min-width: 2.35rem;
+    padding-inline: 0;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .scene-host__pause span:not(.scene-host__pause-icon) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument {
+    min-height: 6.65rem;
+    margin-top: 0.7rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument::before {
+    inset: 0.5rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument::after {
+    width: 6.5rem;
+    height: 4rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__pressure {
+    left: 27%;
+    width: 4.65rem;
+    height: 2rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__tick {
+    min-width: 1.85rem;
+    font-size: 0.47rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__image {
+    width: 0.62rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__arc {
+    width: 5.65rem;
+    height: 3rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__threshold {
+    right: 16%;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__mirror {
+    right: 5%;
+    width: 2.55rem;
+    height: 1.8rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label {
+    font-size: 0.51rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label--pressure {
+    left: 6%;
+    top: 12%;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label--collective {
+    left: 44%;
+    top: 12%;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__label--threshold {
+    right: 4%;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"][data-reduced-motion="true"] .scene-host__fallback {
+    left: 1rem;
+    right: 1rem;
+    top: 20.95rem;
+    width: auto;
+    padding: 0.56rem 0.7rem;
+    text-align: left;
+    transform: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
+    margin: 0;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"][data-reduced-motion="true"] .scene-host__fallback h2,
+  .chapter-experience[data-chapter-id="ch7"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/src/visualizations/chapters/ch7/ThreeProphecyViz.js
+++ b/src/visualizations/chapters/ch7/ThreeProphecyViz.js
@@ -8,9 +8,9 @@
  *  Scene 2 (scroll 0.15–0.45): The Aeon Spiral — vertical helix
  *  Scene 3 (scroll 0.45–1.00): The Pisces Timeline — 0–2000 AD detail
  *
- * Jung: Nostradamus "mined the collective unconscious," perceiving an
- * imminent enantiodromia of the Christian aeon. His prophecies reveal
- * the psyche's capacity to prefigure major archetypal transformations.
+ * Interpretive frame: prophecy is treated here as symbolic pressure.
+ * Collective anxiety and projection make historical time feel charged,
+ * so older archetypal images reappear as visions of the future.
  *
  * Palette: warm amber/gold with violet shadows — prophetic firelight.
  */
@@ -61,15 +61,15 @@ const ZODIAC = [
 const TIMELINE_EVENTS = [
     { year: -7, label: 'Star of Bethlehem', symbol: '☆', color: 0xf0d060, desc: 'Jupiter–Saturn conjunction in Pisces — the celestial sign inaugurating the new aeon', archetype: 'Self' },
     { year: 30, label: 'Crucifixion', symbol: '✝', color: 0xf0e8d0, desc: 'The Self projected onto a single figure — the supreme symbol of wholeness sacrificed', archetype: 'Self' },
-    { year: 100, label: 'Revelation of St. John', symbol: '🔥', color: 0xcc4444, desc: 'The Apocalypse archetype — Christianity’s own shadow erupts in prophetic fire', archetype: 'Shadow' },
-    { year: 325, label: 'Council of Nicæa', symbol: '⬡', color: 0xf0d060, desc: 'Christ declared God — evil officially excluded from the divine, deepening the split', archetype: 'Self' },
+    { year: 100, label: 'Revelation of St. John', symbol: '🔥', color: 0xcc4444, desc: 'Apocalyptic imagery gives collective fear a fiery symbolic form', archetype: 'Shadow' },
+    { year: 325, label: 'Council of Nicæa', symbol: '⬡', color: 0xf0d060, desc: 'Doctrine gathers the Christ image into a bright center while shadow pressure remains outside it', archetype: 'Self' },
     { year: 1000, label: 'Enantiodromia', symbol: '◆', color: 0xcc3366, desc: 'The aeon’s midpoint — everything begins turning into its opposite. The shadow stirs.', archetype: 'Shadow' },
     { year: 1179, label: 'Joachim of Fiore', symbol: '△', color: 0x9966cc, desc: 'Prophecy of the Third Age — beyond Father and Son, the Holy Spirit as integration', archetype: 'Unconscious' },
     { year: 1484, label: 'Malleus Maleficarum', symbol: '▼', color: 0x882233, desc: 'Shadow projected onto "witches" — collective psychosis manifests as persecution', archetype: 'Shadow' },
-    { year: 1555, label: 'Nostradamus\' Centuries', symbol: '✦', color: 0xff8c00, desc: 'Mining the collective unconscious — prophetic sensitivity to archetypal currents', archetype: 'Unconscious' },
-    { year: 1789, label: 'French Revolution', symbol: '⚡', color: 0xcc4444, desc: '"An infernal power shall rise against the Church" — Nostradamus fulfilled', archetype: 'Shadow' },
+    { year: 1555, label: 'Nostradamus\' Centuries', symbol: '✦', color: 0xff8c00, desc: 'Prophetic image-making as sensitivity to collective tension', archetype: 'Unconscious' },
+    { year: 1789, label: 'French Revolution', symbol: '⚡', color: 0xcc4444, desc: 'Later readers could fold revolutionary violence into prophetic imagery; the point is projection under historical pressure', archetype: 'Shadow' },
     { year: 1914, label: 'World War I', symbol: '◼', color: 0x553333, desc: 'Eruption of the collective shadow — the European psyche fragments into mass violence', archetype: 'Shadow' },
-    { year: 1945, label: 'Atomic Bomb', symbol: '☢', color: 0xeeeeee, desc: 'Ultimate enantiodromia — the light of reason becomes the fire of annihilation', archetype: 'Shadow' },
+    { year: 1945, label: 'Atomic Bomb', symbol: '☢', color: 0xeeeeee, desc: 'Reason and annihilation become fused in a modern image of reversal', archetype: 'Shadow' },
     { year: 2000, label: 'Aquarian Threshold', symbol: '♒', color: 0x44bbcc, desc: 'A new aeon approaches — will the psyche integrate its opposites, or split further?', archetype: 'Future' },
 ];
 
@@ -1061,8 +1061,8 @@ export default class ThreeProphecyViz extends BaseViz {
                         font-size:clamp(0.65rem,0.9vw,0.75rem);color:rgba(200,190,170,0.4);
                         line-height:1.6;
                     ">
-                        <span style="color:rgba(240,232,208,0.5)">First Fish</span> (0–1000 AD) — Christ<br>
-                        <span style="color:rgba(204,51,102,0.5)">Second Fish</span> (1000–2000 AD) — Antichrist<br>
+                        <span style="color:rgba(240,232,208,0.5)">First Fish</span> (0–1000 AD) — bright ideal<br>
+                        <span style="color:rgba(204,51,102,0.5)">Second Fish</span> (1000–2000 AD) — shadow pressure<br>
                         <span style="font-style:italic;margin-top:6px;display:inline-block">
                         They swim in opposite directions,<br>
                         mirroring the psyche's split.</span>
@@ -1082,7 +1082,7 @@ export default class ThreeProphecyViz extends BaseViz {
                 <div class="ch7-era-label">AGE OF<br>FAITH</div>
                 <div class="ch7-era-label" style="color:rgba(204,51,102,0.35)">ENANTIODROMIA<br>↕</div>
                 <div class="ch7-era-label">AGE OF<br>REASON</div>
-                <div class="ch7-era-label" style="text-align:right;color:rgba(68,187,204,0.3)">ANTICHRIST<br>ERA</div>
+                <div class="ch7-era-label" style="text-align:right;color:rgba(68,187,204,0.3)">MODERN<br>SHADOW</div>
             </div>
         `);
 
@@ -1156,7 +1156,7 @@ export default class ThreeProphecyViz extends BaseViz {
                 font-size:clamp(0.55rem,0.75vw,0.65rem);letter-spacing:0.2em;
                 color:rgba(200,160,64,0.2);text-transform:uppercase;
                 opacity:0;transition:opacity 1.5s ease;
-            ">CHRIST → ENANTIODROMIA → ANTICHRIST · THE TWO FISH SWIM IN OPPOSITE DIRECTIONS</div>
+            ">BRIGHT IDEAL -> REVERSAL -> SHADOW PRESSURE · THE TWO FISH SWIM IN OPPOSITE DIRECTIONS</div>
         `);
 
         /* Enantiodromia gradient bar (Scene 3) */
@@ -1555,7 +1555,10 @@ export default class ThreeProphecyViz extends BaseViz {
         this.renderer?.forceContextLoss();
         this.scene?.traverse(o => {
             o.geometry?.dispose();
-            if (o.material) [].concat(o.material).forEach(m => m.dispose());
+            if (o.material) [].concat(o.material).forEach((m) => {
+                m.map?.dispose();
+                m.dispose();
+            });
         });
         this.composer = null;
         this.scene = null;

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -148,6 +148,29 @@ describe('Aion framework data contract', () => {
       'opposites',
     ]);
   });
+
+  test('keeps Chapter 7 prophecy panels tied to collective projection', () => {
+    expect(CHAPTER_SCENES.ch7.panels.map((panel) => panel.id)).toEqual([
+      'prophecy',
+      'collective',
+      'threshold',
+    ]);
+    expect(CHAPTER_SCENES.ch7.panels.map((panel) => panel.kicker)).toEqual([
+      'Prophecy',
+      'Collective',
+      'Threshold',
+    ]);
+    expect(CHAPTER_SCENES.ch7.motionGrammar).toBe('transformation');
+    expect(CHAPTER_SCENES.ch7.visualTheme).toContain('Prophecy field');
+    expect(CHAPTER_SCENES.ch7.fallbackSummary).toContain('collective anxiety');
+    expect(CHAPTER_SCENES.ch7.fallbackSummary).toContain('symbolic dates');
+
+    expect(getConceptsForChapter('ch7').map((concept) => concept.id)).toEqual([
+      'prophecy',
+      'collective-unconscious',
+      'projection',
+    ]);
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- add a Chapter 7 prophecy-field instrument to the React chapter shell so the first viewport teaches historical pressure, collective projection, and threshold reversal visually
- tighten Chapter 7 mobile/reduced-motion styling and soften old Nostradamus scene copy away from fulfillment/Antichrist overclaims
- extend contract, shell smoke, accessibility smoke, mobile, reduced-motion, and Pages artifact coverage for Chapter 7
- normalize old docs divider lines so the requested conflict-marker scan has no false positives

## Verification
- rg -n "^(<<<<<<<|=======|>>>>>>>)" .
- git diff --check
- node --check scripts/testing/app-shell-smoke.mjs
- node --check scripts/testing/app-accessibility-smoke.mjs
- npm run lint
- npx tsc --noEmit
- npm run test:app
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:e2e:app
- npm run test:a11y:app
- npm test
- npm run build:pages
- npm run test:pages:artifact
- npm run build
- npm run test:visual:control-tower

## Visual QA
- Control Tower: 20 routes inspected, Chapter 7 desktop score 100%, no technical blockers
- Chapter 7 mobile and 320px narrow evidence: 0px overflow, no blockers
- Reviewed fresh screenshots: desktop, mobile, narrow