### PR TITLE
feat: polish chapter eight historical strata

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -301,6 +301,45 @@ async function checkChapterSevenDynamicAccessibility(page, failures) {
   if (!thresholdDescription?.includes('Threshold: The future looks backward')) failures.push(`/journey/chapter/ch7: threshold scene description mismatch: ${thresholdDescription}`);
 }
 
+async function checkChapterEightDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/journey/chapter/ch8`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+  const instrument = page.getByRole('img', { name: /Historical strata model/ });
+  const instrumentVisible = await instrument.isVisible();
+  const initialInstrumentLabel = await instrument.getAttribute('aria-label');
+  const initialDescription = await page.locator('#scene-host-description-ch8').textContent();
+
+  if (!instrumentVisible) failures.push('/journey/chapter/ch8: historical strata instrument is missing an accessible image role');
+  if (!initialInstrumentLabel?.includes('Current emphasis: History') || !initialInstrumentLabel?.includes('fish motif')) failures.push(`/journey/chapter/ch8: initial instrument label mismatch: ${initialInstrumentLabel}`);
+  if (!initialDescription?.includes('History: Symbols gather sediment')) failures.push(`/journey/chapter/ch8: initial scene description mismatch: ${initialDescription}`);
+
+  const earlyImage = page.getByRole('button', { name: /02\s+Early Image/ });
+  await earlyImage.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const earlyImagePressed = await earlyImage.getAttribute('aria-pressed');
+  const earlyImageLabel = await instrument.getAttribute('aria-label');
+  const earlyImageDescription = await page.locator('#scene-host-description-ch8').textContent();
+  if (earlyImagePressed !== 'true') failures.push(`/journey/chapter/ch8: early image button did not become pressed: ${earlyImagePressed}`);
+  if (!earlyImageLabel?.includes('Current emphasis: Early Image') || !earlyImageLabel?.includes('A small sign can hold a total world')) failures.push(`/journey/chapter/ch8: early image instrument label mismatch: ${earlyImageLabel}`);
+  if (!earlyImageDescription?.includes('Early Image: The fish becomes a carrier')) failures.push(`/journey/chapter/ch8: early image scene description mismatch: ${earlyImageDescription}`);
+
+  const afterlife = page.getByRole('button', { name: /03\s+Afterlife/ });
+  await afterlife.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const afterlifePressed = await afterlife.getAttribute('aria-pressed');
+  const afterlifeLabel = await instrument.getAttribute('aria-label');
+  const afterlifeDescription = await page.locator('#scene-host-description-ch8').textContent();
+  if (afterlifePressed !== 'true') failures.push(`/journey/chapter/ch8: afterlife button did not become pressed: ${afterlifePressed}`);
+  if (!afterlifeLabel?.includes('Current emphasis: Afterlife') || !afterlifeLabel?.includes('The unconscious preserves symbolic depth')) failures.push(`/journey/chapter/ch8: afterlife instrument label mismatch: ${afterlifeLabel}`);
+  if (!afterlifeDescription?.includes('Afterlife: Old images keep speaking')) failures.push(`/journey/chapter/ch8: afterlife scene description mismatch: ${afterlifeDescription}`);
+}
+
 async function runAccessibilitySmoke() {
   const server = startPreviewServer();
   const failures = [];
@@ -317,10 +356,11 @@ async function runAccessibilitySmoke() {
     await checkAtlasDynamicAccessibility(desktop, failures);
     await checkChapterSixDynamicAccessibility(desktop, failures);
     await checkChapterSevenDynamicAccessibility(desktop, failures);
+    await checkChapterEightDynamicAccessibility(desktop, failures);
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -588,6 +588,42 @@ async function smokeReducedMotion(browser, failures) {
   if (!chapterSevenFallbackText?.includes('collective anxiety') || !chapterSevenFallbackText?.includes('symbolic dates')) {
     failures.push('reduced-motion chapter fallback lost Chapter 7 prophecy teaching summary');
   }
+
+  await gotoAppRoute(page, '/journey/chapter/ch8');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterEightFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterEightReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterEightReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterEightReferenceCount = await chapterEightReferenceNodes.count();
+  const chapterEightPanelIds = await chapterEightReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterEightPauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterEightCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterEightAnnotationCount = await page.locator('.ch8-annotations').count();
+  const chapterEightFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterEightInstrumentCount = await page.locator('.historical-strata-instrument').count();
+  const chapterEightInstrumentMotion = await page.locator('.historical-strata-instrument__field, .historical-strata-instrument__axis, .historical-strata-instrument__layer, .historical-strata-instrument__sediment, .historical-strata-instrument__thread, .historical-strata-instrument__fish, .historical-strata-instrument__carrier, .historical-strata-instrument__depth').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterEightAnimatedParts = chapterEightInstrumentMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterEightTransitioningParts = chapterEightInstrumentMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
+
+  if (!chapterEightFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 8 scene');
+  if (chapterEightReducedMotionAttribute !== 'true') failures.push('Chapter 8 did not record reduced-motion state');
+  if (chapterEightReferenceCount !== 3) failures.push(`reduced-motion Chapter 8 reference node count mismatch: ${chapterEightReferenceCount}`);
+  if (chapterEightPanelIds.join(',') !== 'strata,christian,modern') failures.push(`reduced-motion Chapter 8 reference nodes out of order: ${chapterEightPanelIds.join(',')}`);
+  if (chapterEightPauseControlCount !== 0) failures.push(`reduced-motion Chapter 8 rendered pause controls: ${chapterEightPauseControlCount}`);
+  if (chapterEightCanvasCount !== 0) failures.push(`reduced-motion Chapter 8 rendered canvas: ${chapterEightCanvasCount}`);
+  if (chapterEightAnnotationCount !== 0) failures.push(`reduced-motion Chapter 8 rendered annotation overlay: ${chapterEightAnnotationCount}`);
+  if (chapterEightInstrumentCount !== 1) failures.push(`reduced-motion Chapter 8 historical strata instrument count mismatch: ${chapterEightInstrumentCount}`);
+  if (chapterEightAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 8 historical strata instrument still animates: ${JSON.stringify(chapterEightAnimatedParts)}`);
+  if (chapterEightTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 8 historical strata instrument still transitions: ${JSON.stringify(chapterEightTransitioningParts)}`);
+  if (!chapterEightFallbackText?.includes('Layered historical strata') || !chapterEightFallbackText?.includes('fish motif')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 8 historical strata teaching summary');
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -1253,14 +1289,110 @@ async function smokeChapterSceneControls(page, failures) {
   recordCanvasPixelFailure(failures, 'chapter 7', chapterSevenPixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch8');
-  const afterlife = page.getByRole('button', { name: /03\s+Afterlife/ });
-  await activateSceneButton(afterlife);
+  await page.locator('.scene-host__mount[data-state="ready"]').waitFor({ state: 'visible', timeout: 10_000 });
+  const chapterEightReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterEightReferenceCount = await chapterEightReferenceNodes.count();
+  const chapterEightPanelIds = await chapterEightReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterEightInstrument = page.locator('.historical-strata-instrument');
+  const chapterEightInstrumentCount = await chapterEightInstrument.count();
+  const chapterEightInstrumentRole = await chapterEightInstrument.getAttribute('role');
+  const chapterEightInstrumentLabel = await chapterEightInstrument.getAttribute('aria-label');
+  const chapterEightInstrumentPanel = await chapterEightInstrument.getAttribute('data-active-panel');
+  const chapterEightInstrumentFieldCount = await page.locator('.historical-strata-instrument__field').count();
+  const chapterEightInstrumentLayerCount = await page.locator('.historical-strata-instrument__layer').count();
+  const chapterEightInstrumentSedimentCount = await page.locator('.historical-strata-instrument__sediment').count();
+  const chapterEightInstrumentThreadCount = await page.locator('.historical-strata-instrument__thread').count();
+  const chapterEightInstrumentFishCount = await page.locator('.historical-strata-instrument__fish').count();
+  const chapterEightInstrumentCarrierCount = await page.locator('.historical-strata-instrument__carrier').count();
+  const chapterEightInstrumentDepthCount = await page.locator('.historical-strata-instrument__depth').count();
+  const chapterEightInstrumentLabelCount = await page.locator('.historical-strata-instrument__label').count();
+  const chapterEightInstrumentMarksVisible = await page.locator('.historical-strata-instrument__field, .historical-strata-instrument__axis, .historical-strata-instrument__layer, .historical-strata-instrument__sediment, .historical-strata-instrument__thread, .historical-strata-instrument__fish, .historical-strata-instrument__carrier, .historical-strata-instrument__depth').evaluateAll((nodes) => nodes.length >= 16 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterEightReferenceGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="strata"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="christian"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="modern"] .chapter-stage__reference-mark').evaluateAll((nodes) => nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+
+  if (chapterEightReferenceCount !== 3) failures.push(`chapter 8 reference node count mismatch: ${chapterEightReferenceCount}`);
+  if (chapterEightPanelIds.join(',') !== 'strata,christian,modern') failures.push(`chapter 8 reference nodes out of order: ${chapterEightPanelIds.join(',')}`);
+  if (chapterEightInstrumentCount !== 1) failures.push(`chapter 8 historical strata instrument count mismatch: ${chapterEightInstrumentCount}`);
+  if (chapterEightInstrumentFieldCount !== 2) failures.push(`chapter 8 historical strata instrument field count mismatch: ${chapterEightInstrumentFieldCount}`);
+  if (chapterEightInstrumentLayerCount !== 5) failures.push(`chapter 8 historical strata instrument layer count mismatch: ${chapterEightInstrumentLayerCount}`);
+  if (chapterEightInstrumentSedimentCount !== 3) failures.push(`chapter 8 historical strata instrument sediment count mismatch: ${chapterEightInstrumentSedimentCount}`);
+  if (chapterEightInstrumentThreadCount !== 2) failures.push(`chapter 8 historical strata instrument thread count mismatch: ${chapterEightInstrumentThreadCount}`);
+  if (chapterEightInstrumentFishCount !== 1) failures.push(`chapter 8 historical strata instrument fish count mismatch: ${chapterEightInstrumentFishCount}`);
+  if (chapterEightInstrumentCarrierCount !== 1) failures.push(`chapter 8 historical strata instrument carrier count mismatch: ${chapterEightInstrumentCarrierCount}`);
+  if (chapterEightInstrumentDepthCount !== 1) failures.push(`chapter 8 historical strata instrument depth count mismatch: ${chapterEightInstrumentDepthCount}`);
+  if (chapterEightInstrumentLabelCount !== 3) failures.push(`chapter 8 historical strata instrument label count mismatch: ${chapterEightInstrumentLabelCount}`);
+  if (chapterEightInstrumentRole !== 'img') failures.push(`chapter 8 historical strata instrument role mismatch: ${chapterEightInstrumentRole}`);
+  if (!chapterEightInstrumentLabel?.includes('Historical strata model') || !chapterEightInstrumentLabel?.includes('fish motif') || !chapterEightInstrumentLabel?.includes('Current emphasis: History')) {
+    failures.push(`chapter 8 historical strata instrument label missing teaching text: ${chapterEightInstrumentLabel}`);
+  }
+  if (chapterEightInstrumentPanel !== 'strata') failures.push(`chapter 8 historical strata instrument did not start on strata panel: ${chapterEightInstrumentPanel}`);
+  if (!chapterEightInstrumentMarksVisible) failures.push('chapter 8 historical strata instrument marks are not visibly rendered');
+  if (!chapterEightReferenceGlyphsVisible) failures.push('chapter 8 reference glyphs are not visibly rendered');
+
+  const earlyImage = page.locator('.chapter-stage__reference-node[data-panel-id="christian"]');
+  await earlyImage.waitFor({ state: 'visible', timeout: 30_000 });
+  await earlyImage.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(250);
+
+  const earlyImagePressed = await earlyImage.getAttribute('aria-pressed');
+  const earlyImagePanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="christian"]').count();
+  const earlyImageDescription = await page.locator('#scene-host-description-ch8').textContent();
+  const earlyImageInstrumentPanel = await chapterEightInstrument.getAttribute('data-active-panel');
+  const earlyImageInstrumentLabel = await chapterEightInstrument.getAttribute('aria-label');
+  const earlyImageVisualState = await page.locator('.historical-strata-instrument__carrier, .historical-strata-instrument__thread--descent, .historical-strata-instrument__fish').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  if (earlyImagePressed !== 'true') failures.push(`chapter 8 early image reference did not become active: ${earlyImagePressed}`);
+  if (earlyImagePanelActive !== 1) failures.push(`chapter 8 early image panel did not become active: ${earlyImagePanelActive}`);
+  if (earlyImageInstrumentPanel !== 'christian') failures.push(`chapter 8 historical strata instrument did not follow early image panel: ${earlyImageInstrumentPanel}`);
+  if (!earlyImageInstrumentLabel?.includes('Current emphasis: Early Image') || !earlyImageInstrumentLabel?.includes('A small sign can hold a total world')) {
+    failures.push(`chapter 8 historical strata instrument label did not follow early image panel: ${earlyImageInstrumentLabel}`);
+  }
+  if (earlyImageVisualState.length !== 3 || earlyImageVisualState.some((opacity) => opacity < 0.45)) {
+    failures.push(`chapter 8 historical strata instrument did not visually emphasize carrier image: ${earlyImageVisualState.join(',')}`);
+  }
+  if (!earlyImageDescription?.includes('Early Image: The fish becomes a carrier')) failures.push(`chapter 8 scene description did not follow early image panel: ${earlyImageDescription}`);
+
+  const afterlife = page.locator('.chapter-stage__reference-node[data-panel-id="modern"]');
+  await afterlife.waitFor({ state: 'visible', timeout: 30_000 });
+  await afterlife.focus();
+  await page.keyboard.press('Space');
   await page.waitForTimeout(250);
 
   const afterlifePressed = await afterlife.getAttribute('aria-pressed');
+  const afterlifePanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="modern"]').count();
+  const afterlifeDescription = await page.locator('#scene-host-description-ch8').textContent();
+  const afterlifeInstrumentPanel = await chapterEightInstrument.getAttribute('data-active-panel');
+  const afterlifeInstrumentLabel = await chapterEightInstrument.getAttribute('aria-label');
+  const afterlifeVisualState = await page.locator('.historical-strata-instrument__depth, .historical-strata-instrument__thread--return, .historical-strata-instrument__layer--4, .historical-strata-instrument__layer--5').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   const chapterEightScrollY = await page.evaluate(() => window.scrollY);
-  if (afterlifePressed !== 'true') failures.push(`chapter 8 scene control did not become active: ${afterlifePressed}`);
+  if (afterlifePressed !== 'true') failures.push(`chapter 8 afterlife reference did not become active: ${afterlifePressed}`);
+  if (afterlifePanelActive !== 1) failures.push(`chapter 8 afterlife panel did not become active: ${afterlifePanelActive}`);
+  if (afterlifeInstrumentPanel !== 'modern') failures.push(`chapter 8 historical strata instrument did not follow afterlife panel: ${afterlifeInstrumentPanel}`);
+  if (!afterlifeInstrumentLabel?.includes('Current emphasis: Afterlife') || !afterlifeInstrumentLabel?.includes('The unconscious preserves symbolic depth')) {
+    failures.push(`chapter 8 historical strata instrument label did not follow afterlife panel: ${afterlifeInstrumentLabel}`);
+  }
+  if (afterlifeVisualState.length !== 4 || afterlifeVisualState.some((opacity) => opacity < 0.45)) {
+    failures.push(`chapter 8 historical strata instrument did not visually emphasize afterlife/depth: ${afterlifeVisualState.join(',')}`);
+  }
+  if (!afterlifeDescription?.includes('Afterlife: Old images keep speaking')) failures.push(`chapter 8 scene description did not follow afterlife panel: ${afterlifeDescription}`);
   if (chapterEightScrollY > 10) failures.push(`chapter 8 scene control unexpectedly scrolled page: ${chapterEightScrollY}`);
+
+  const chapterEightCanvas = page.locator('.scene-host canvas').first();
+  const chapterEightCanvasBox = await chapterEightCanvas.boundingBox();
+  const chapterEightPixelSample = await countCanvasPixels(chapterEightCanvas);
+  const chapterEightStyleCount = await page.locator('style#ch8-anim-style').count();
+  if (!chapterEightCanvasBox || chapterEightCanvasBox.width < 300 || chapterEightCanvasBox.height < 300) {
+    failures.push(`chapter 8 canvas geometry too small: ${chapterEightCanvasBox ? `${Math.round(chapterEightCanvasBox.width)}x${Math.round(chapterEightCanvasBox.height)}` : 'missing'}`);
+  }
+  recordCanvasPixelFailure(failures, 'chapter 8', chapterEightPixelSample);
+  if (chapterEightStyleCount !== 1) failures.push(`chapter 8 injected style count mismatch: ${chapterEightStyleCount}`);
 
   await gotoAppRoute(page, '/journey/chapter/ch9');
   const shadowFish = page.getByRole('button', { name: /03\s+Shadow/ });
@@ -1325,7 +1457,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -1556,6 +1688,47 @@ async function smokeMobile(page, failures) {
       if (chapterSevenCanvasCount > 0) {
         const chapterSevenPixelSample = await countCanvasPixels(chapterSevenCanvas);
         recordCanvasPixelFailure(failures, `mobile chapter 7 at ${viewport.width}x${viewport.height}`, chapterSevenPixelSample);
+      }
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch8');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterEightNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterEightHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterEightReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterEightReferenceCount = await chapterEightReferenceNodes.count();
+    const chapterEightPanelIds = await chapterEightReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterEightOverlayHidden = await page.locator('.ch8-label, .ch8-progress').evaluateAll((nodes) => nodes.every((node) => window.getComputedStyle(node).display === 'none'));
+    const chapterEightScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterEightReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const chapterEightInstrumentBox = await page.locator('.historical-strata-instrument').boundingBox();
+    if (!chapterEightNavBox || !chapterEightHeadingBox) {
+      failures.push(`mobile chapter 8 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterEightNavBottom = chapterEightNavBox.y + chapterEightNavBox.height;
+    if (chapterEightNavBottom > chapterEightHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 8 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterEightNavBottom)}, heading top ${Math.round(chapterEightHeadingBox.y)}`);
+    }
+    if (chapterEightReferenceCount !== 3) failures.push(`mobile chapter 8 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterEightReferenceCount}`);
+    if (chapterEightPanelIds.join(',') !== 'strata,christian,modern') failures.push(`mobile chapter 8 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterEightPanelIds.join(',')}`);
+    if (!chapterEightOverlayHidden) failures.push(`mobile chapter 8 annotation overlay remains visible at ${viewport.width}x${viewport.height}`);
+    if (chapterEightScrollWidth > viewport.width + 2) failures.push(`mobile chapter 8 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterEightScrollWidth}`);
+    if (chapterEightReferenceMapBox && chapterEightReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 8 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterEightReferenceMapBox.width)}`);
+    }
+    if (!chapterEightInstrumentBox) failures.push(`mobile chapter 8 historical strata instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterEightInstrumentBox && chapterEightInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 8 historical strata instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterEightInstrumentBox.width)}`);
+    }
+
+    if (viewport.width === mobileViewport.width) {
+      const chapterEightCanvas = page.locator('.scene-host canvas').first();
+      const chapterEightCanvasCount = await chapterEightCanvas.count();
+      if (chapterEightCanvasCount > 0) {
+        const chapterEightPixelSample = await countCanvasPixels(chapterEightCanvas);
+        recordCanvasPixelFailure(failures, `mobile chapter 8 at ${viewport.width}x${viewport.height}`, chapterEightPixelSample);
       }
     }
   }

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -184,6 +184,19 @@ async function countCanvasPixels(canvas) {
   }));
 }
 
+async function waitForCanvasPixels(canvas, { minVisiblePixels = 8, timeoutMs = 6_000, intervalMs = 250 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let result = { timedOut: true, visiblePixels: 0 };
+
+  while (Date.now() < deadline) {
+    result = await countCanvasPixels(canvas);
+    if (!result.timedOut && result.visiblePixels > minVisiblePixels) return result;
+    await delay(intervalMs);
+  }
+
+  return result;
+}
+
 function recordCanvasPixelFailure(failures, label, result) {
   if (result.timedOut) {
     failures.push(`${label} canvas pixel sampling timed out`);
@@ -1378,7 +1391,10 @@ async function smokeChapterSceneControls(page, failures) {
   if (!afterlifeInstrumentLabel?.includes('Current emphasis: Afterlife') || !afterlifeInstrumentLabel?.includes('The unconscious preserves symbolic depth')) {
     failures.push(`chapter 8 historical strata instrument label did not follow afterlife panel: ${afterlifeInstrumentLabel}`);
   }
-  if (afterlifeVisualState.length !== 4 || afterlifeVisualState.some((opacity) => opacity < 0.45)) {
+  const [afterlifeDepthOpacity, afterlifeThreadOpacity, afterlifeLayerFourOpacity, afterlifeLayerFiveOpacity] = afterlifeVisualState;
+  const afterlifeDepthVisible = afterlifeDepthOpacity >= 0.45 && afterlifeThreadOpacity >= 0.45;
+  const afterlifeLayersVisible = afterlifeLayerFourOpacity >= 0.3 && afterlifeLayerFiveOpacity >= 0.3;
+  if (afterlifeVisualState.length !== 4 || !afterlifeDepthVisible || !afterlifeLayersVisible) {
     failures.push(`chapter 8 historical strata instrument did not visually emphasize afterlife/depth: ${afterlifeVisualState.join(',')}`);
   }
   if (!afterlifeDescription?.includes('Afterlife: Old images keep speaking')) failures.push(`chapter 8 scene description did not follow afterlife panel: ${afterlifeDescription}`);
@@ -1386,7 +1402,7 @@ async function smokeChapterSceneControls(page, failures) {
 
   const chapterEightCanvas = page.locator('.scene-host canvas').first();
   const chapterEightCanvasBox = await chapterEightCanvas.boundingBox();
-  const chapterEightPixelSample = await countCanvasPixels(chapterEightCanvas);
+  const chapterEightPixelSample = await waitForCanvasPixels(chapterEightCanvas);
   const chapterEightStyleCount = await page.locator('style#ch8-anim-style').count();
   if (!chapterEightCanvasBox || chapterEightCanvasBox.width < 300 || chapterEightCanvasBox.height < 300) {
     failures.push(`chapter 8 canvas geometry too small: ${chapterEightCanvasBox ? `${Math.round(chapterEightCanvasBox.width)}x${Math.round(chapterEightCanvasBox.height)}` : 'missing'}`);
@@ -1727,7 +1743,7 @@ async function smokeMobile(page, failures) {
       const chapterEightCanvas = page.locator('.scene-host canvas').first();
       const chapterEightCanvasCount = await chapterEightCanvas.count();
       if (chapterEightCanvasCount > 0) {
-        const chapterEightPixelSample = await countCanvasPixels(chapterEightCanvas);
+        const chapterEightPixelSample = await waitForCanvasPixels(chapterEightCanvas);
         recordCanvasPixelFailure(failures, `mobile chapter 8 at ${viewport.width}x${viewport.height}`, chapterEightPixelSample);
       }
     }

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -19,7 +19,7 @@ const canonicalRoutes = [
   ...Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`),
 ];
 
-const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch14'];
+const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch14'];
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -19,6 +19,7 @@ const mandalaBands = ['outer', 'middle', 'inner'] as const;
 const rootLines = ['left', 'center', 'right'] as const;
 const zodiacMarkers = ['AR', 'TA', 'GE', 'CN', 'LE', 'VI', 'LI', 'SC', 'SG', 'CP', 'AQ', 'PI'] as const;
 const prophecyTicks = ['0', '1000', '1555', '2000'] as const;
+const historicalStrataLayers = ['vision', 'carrier', 'healing', 'aeon', 'depth'] as const;
 
 function useReducedMotionPreference() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
@@ -63,6 +64,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const christSymbolInstrumentLabel = `Christ symbol model: a luminous cross carries a powerful Self image, three bright points form a one-sided field, the excluded fourth remains dark but necessary, and roots descend toward the counter-pole. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const aeonFishInstrumentLabel = `Sign of the Fishes model: two Pisces fish swim in opposite directions inside a zodiac wheel, the spring point precesses through symbolic time, and Aquarius marks the slow threshold of a changing aeon. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const prophecyFieldInstrumentLabel = `Prophecy field model: historical pressure gathers around a time axis, private fear projects into a shared symbolic image-field, and the threshold mirror shows the future looking backward into older archetypal forms. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
+  const historicalStrataInstrumentLabel = `Historical strata model: five translucent layers accumulate around the fish motif, an early Christian carrier image gathers the symbol into a readable form, and older meanings keep speaking below later interpretation. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
 
   useEffect(() => {
     setActivePanelId(experience.panels[0]?.id || '');
@@ -264,6 +266,36 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="prophecy-field-instrument__label prophecy-field-instrument__label--pressure" aria-hidden="true">pressure</span>
               <span className="prophecy-field-instrument__label prophecy-field-instrument__label--collective" aria-hidden="true">shared image</span>
               <span className="prophecy-field-instrument__label prophecy-field-instrument__label--threshold" aria-hidden="true">threshold</span>
+            </div>
+          )}
+          {chapter.id === 'ch8' && (
+            <div
+              className="historical-strata-instrument"
+              data-active-panel={activePanelId}
+              role="img"
+              aria-label={historicalStrataInstrumentLabel}
+            >
+              <span className="historical-strata-instrument__field historical-strata-instrument__field--archive" aria-hidden="true" />
+              <span className="historical-strata-instrument__field historical-strata-instrument__field--afterlife" aria-hidden="true" />
+              <span className="historical-strata-instrument__axis" aria-hidden="true" />
+              {historicalStrataLayers.map((layer, index) => (
+                <span
+                  key={layer}
+                  className={`historical-strata-instrument__layer historical-strata-instrument__layer--${index + 1}`}
+                  aria-hidden="true"
+                />
+              ))}
+              <span className="historical-strata-instrument__sediment historical-strata-instrument__sediment--one" aria-hidden="true" />
+              <span className="historical-strata-instrument__sediment historical-strata-instrument__sediment--two" aria-hidden="true" />
+              <span className="historical-strata-instrument__sediment historical-strata-instrument__sediment--three" aria-hidden="true" />
+              <span className="historical-strata-instrument__thread historical-strata-instrument__thread--descent" aria-hidden="true" />
+              <span className="historical-strata-instrument__thread historical-strata-instrument__thread--return" aria-hidden="true" />
+              <span className="historical-strata-instrument__fish" aria-hidden="true" />
+              <span className="historical-strata-instrument__carrier" aria-hidden="true" />
+              <span className="historical-strata-instrument__depth" aria-hidden="true" />
+              <span className="historical-strata-instrument__label historical-strata-instrument__label--strata" aria-hidden="true">strata</span>
+              <span className="historical-strata-instrument__label historical-strata-instrument__label--carrier" aria-hidden="true">carrier</span>
+              <span className="historical-strata-instrument__label historical-strata-instrument__label--afterlife" aria-hidden="true">afterlife</span>
             </div>
           )}
           <div className="chapter-stage__thesis-map" aria-label="Chapter visual sequence">

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2516,37 +2516,50 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro {
-  width: min(35rem, calc(100% - 2rem));
+  width: min(36rem, calc(100% - 2rem));
   justify-content: flex-end;
-  padding-bottom: clamp(2.6rem, 6.4vh, 4.7rem);
+  padding-bottom: clamp(2.2rem, 5.6vh, 4.25rem);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro h1 {
-  max-width: 10ch;
-  font-size: clamp(2.9rem, 5.45vw, 5.25rem);
+  max-width: 10.8ch;
+  font-size: clamp(2.75rem, 5.2vw, 5.05rem);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro p:not(.eyebrow) {
-  max-width: 34ch;
-  font-size: clamp(1rem, 1.28vw, 1.08rem);
+  max-width: 33ch;
+  font-size: clamp(0.96rem, 1.18vw, 1.05rem);
+  line-height: 1.58;
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__thesis-map {
-  max-width: 28rem;
-  margin-top: 1.1rem;
+  max-width: 30rem;
+  margin-top: 0.98rem;
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-map {
-  width: min(24rem, 100%);
-  margin-top: 0.65rem;
+  width: min(26rem, 100%);
+  margin-top: 0.68rem;
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node {
   min-height: 3.85rem;
+  background:
+    radial-gradient(circle at 50% 28%, rgba(83, 216, 232, 0.1), transparent 2.45rem),
+    radial-gradient(circle at 36% 58%, rgba(91, 214, 143, 0.08), transparent 2.5rem),
+    linear-gradient(180deg, rgba(4, 8, 12, 0.62), rgba(3, 3, 7, 0.34));
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-label {
   margin-top: 2.05rem;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__scrim {
+  background:
+    linear-gradient(180deg, rgba(3, 3, 7, 0.74), rgba(3, 3, 7, 0.38) 48%, rgba(3, 3, 7, 0.8)),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.94), rgba(3, 3, 7, 0.5) 60%, rgba(3, 3, 7, 0.28)),
+    radial-gradient(circle at 34% 48%, rgba(212, 175, 55, 0.12), transparent 32%),
+    radial-gradient(circle at 67% 52%, rgba(83, 216, 232, 0.12), transparent 36%);
 }
 
 .chapter-stage__thesis-map {
@@ -4757,6 +4770,351 @@ h3 {
   opacity: 0.66;
 }
 
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument {
+  position: relative;
+  width: min(31rem, 100%);
+  min-height: clamp(6.55rem, 10.2vh, 7.8rem);
+  overflow: hidden;
+  margin-top: 0.82rem;
+  border: 1px solid rgba(244, 240, 232, 0.11);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 27% 47%, rgba(212, 175, 55, 0.16), transparent 4.7rem),
+    radial-gradient(circle at 54% 42%, rgba(91, 214, 143, 0.14), transparent 4.9rem),
+    radial-gradient(circle at 81% 50%, rgba(83, 216, 232, 0.12), transparent 4.8rem),
+    linear-gradient(90deg, rgba(7, 7, 10, 0.84), rgba(7, 13, 14, 0.58) 54%, rgba(3, 13, 18, 0.5));
+  box-shadow:
+    var(--shadow-inset),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument::before,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument::before {
+  inset: 0.58rem;
+  border: 1px solid rgba(255, 227, 156, 0.08);
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument::after {
+  left: 53%;
+  top: 50%;
+  width: 8.7rem;
+  height: 4.7rem;
+  border: 1px solid rgba(143, 231, 237, 0.14);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 1.3rem rgba(83, 216, 232, 0.11),
+    0 0 1.8rem rgba(212, 175, 55, 0.07);
+  transform: translate(-50%, -50%) rotate(-10deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__field,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__axis,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__fish,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__carrier,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__depth,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label {
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__field {
+  top: 0;
+  bottom: 0;
+  width: 50%;
+  opacity: 0.56;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__field--archive {
+  left: 0;
+  background:
+    radial-gradient(circle at 43% 45%, rgba(212, 175, 55, 0.13), transparent 4rem),
+    linear-gradient(90deg, rgba(212, 175, 55, 0.07), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__field--afterlife {
+  right: 0;
+  background:
+    radial-gradient(circle at 62% 51%, rgba(83, 216, 232, 0.13), transparent 4.2rem),
+    linear-gradient(270deg, rgba(83, 216, 232, 0.07), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__axis {
+  left: 8%;
+  right: 8%;
+  top: 56%;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(212, 175, 55, 0.1), rgba(244, 240, 232, 0.48), rgba(83, 216, 232, 0.14));
+  opacity: 0.7;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer {
+  left: 12%;
+  right: 13%;
+  height: 0.42rem;
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.18), rgba(91, 214, 143, 0.16), rgba(83, 216, 232, 0.16), transparent);
+  border-top: 1px solid rgba(244, 240, 232, 0.08);
+  box-shadow: 0 0 1rem rgba(83, 216, 232, 0.05);
+  opacity: 0.58;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer--1 {
+  top: 22%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer--2 {
+  top: 32%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer--3 {
+  top: 42%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer--4 {
+  top: 52%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer--5 {
+  top: 62%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment {
+  width: 0.48rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: rgba(255, 227, 156, 0.62);
+  box-shadow: 0 0 0.8rem rgba(212, 175, 55, 0.2);
+  opacity: 0.72;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment--one {
+  left: 21%;
+  top: 35%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment--two {
+  left: 34%;
+  top: 52%;
+  background: rgba(91, 214, 143, 0.58);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment--three {
+  left: 69%;
+  top: 43%;
+  background: rgba(143, 231, 237, 0.58);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__fish {
+  left: 48%;
+  top: 48%;
+  width: 4.2rem;
+  height: 1.35rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.5);
+  border-bottom: 1px solid rgba(143, 231, 237, 0.36);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 31% 50%, rgba(255, 227, 156, 0.5) 0 0.16rem, transparent 0.18rem),
+    radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.1), transparent 66%);
+  box-shadow: 0 0 1.3rem rgba(83, 216, 232, 0.14);
+  opacity: 0.84;
+  transform: translate(-50%, -50%) rotate(-9deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__fish::after {
+  content: '';
+  position: absolute;
+  right: -0.44rem;
+  top: 50%;
+  width: 0.82rem;
+  height: 0.82rem;
+  border-top: 1px solid rgba(143, 231, 237, 0.34);
+  border-right: 1px solid rgba(255, 227, 156, 0.32);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__carrier {
+  left: 54%;
+  top: 49%;
+  width: 1px;
+  height: 4.6rem;
+  background: linear-gradient(180deg, transparent, rgba(255, 227, 156, 0.58), rgba(91, 214, 143, 0.2), transparent);
+  box-shadow: 0 0 1.2rem rgba(212, 175, 55, 0.22);
+  opacity: 0.58;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__carrier::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 35%;
+  width: 2.25rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.48), transparent);
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread {
+  left: 53%;
+  top: 50%;
+  width: 7.6rem;
+  height: 3.7rem;
+  border-radius: 50%;
+  opacity: 0.42;
+  transition:
+    border-color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread--descent {
+  border-top: 1px solid rgba(255, 227, 156, 0.25);
+  border-left: 1px solid rgba(255, 227, 156, 0.16);
+  transform: translate(-50%, -50%) rotate(-12deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread--return {
+  border-bottom: 1px solid rgba(143, 231, 237, 0.28);
+  border-right: 1px solid rgba(91, 214, 143, 0.2);
+  transform: translate(-50%, -50%) rotate(16deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__depth {
+  right: 8%;
+  top: 50%;
+  width: 3.6rem;
+  height: 2.3rem;
+  border: 1px solid rgba(143, 231, 237, 0.22);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 44% 50%, rgba(83, 216, 232, 0.16), transparent 66%),
+    linear-gradient(130deg, transparent 48%, rgba(83, 216, 232, 0.22) 49%, transparent 51%);
+  box-shadow: inset 0 0 1.15rem rgba(83, 216, 232, 0.09);
+  opacity: 0.66;
+  transform: translateY(-50%) rotate(-10deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--strata {
+  left: 7%;
+  top: 14%;
+  color: rgba(255, 227, 156, 0.92);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--carrier {
+  left: 48%;
+  top: 14%;
+  color: rgba(159, 238, 186, 0.92);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--afterlife {
+  right: 5%;
+  top: 14%;
+  color: rgba(143, 231, 237, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="strata"] .historical-strata-instrument__layer,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="strata"] .historical-strata-instrument__sediment {
+  opacity: 0.98;
+  transform: translateY(-0.08rem);
+  box-shadow: 0 0 1.25rem rgba(212, 175, 55, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="strata"] .historical-strata-instrument__fish {
+  opacity: 0.96;
+  transform: translate(-50%, -50%) rotate(-9deg) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="christian"] .historical-strata-instrument__carrier,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="christian"] .historical-strata-instrument__thread--descent {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1.1);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="christian"] .historical-strata-instrument__thread--descent {
+  transform: translate(-50%, -50%) rotate(-12deg) scale(1.1);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="christian"] .historical-strata-instrument__fish {
+  border-top-color: rgba(255, 227, 156, 0.74);
+  border-bottom-color: rgba(91, 214, 143, 0.54);
+  box-shadow: 0 0 1.65rem rgba(91, 214, 143, 0.2);
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="christian"] .historical-strata-instrument__layer--2,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="christian"] .historical-strata-instrument__layer--3 {
+  opacity: 0.98;
+  transform: translateY(-0.07rem) scaleX(1.03);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__field--afterlife {
+  opacity: 0.9;
+  transform: scaleX(1.05);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__depth,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__thread--return {
+  opacity: 1;
+  box-shadow: 0 0 1.5rem rgba(83, 216, 232, 0.18);
+  transform: translateY(-50%) rotate(-10deg) scale(1.1);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__thread--return {
+  transform: translate(-50%, -50%) rotate(16deg) scale(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__layer--4,
+.chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__layer--5 {
+  opacity: 1;
+  transform: translateY(0.06rem) scaleX(1.04);
+  box-shadow: 0 0 1.2rem rgba(83, 216, 232, 0.13);
+}
+
 .chapter-experience[data-chapter-id="ch3"][data-reduced-motion="true"] .scene-host__fallback {
   left: auto;
   right: clamp(1rem, 4vw, 3.5rem);
@@ -5229,6 +5587,75 @@ h3 {
   width: 1px;
   height: 2.55rem;
   background: linear-gradient(180deg, transparent, rgba(143, 231, 237, 0.72), rgba(255, 140, 0, 0.28), transparent);
+  box-shadow: 0 0 1rem rgba(83, 216, 232, 0.22);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="strata"] .chapter-stage__reference-mark::before {
+  left: 50%;
+  top: 1rem;
+  width: 2.55rem;
+  height: 1.95rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.44);
+  border-bottom: 1px solid rgba(143, 231, 237, 0.28);
+  background:
+    linear-gradient(180deg, transparent 0 29%, rgba(255, 227, 156, 0.24) 30% 32%, transparent 33% 49%, rgba(91, 214, 143, 0.2) 50% 52%, transparent 53% 69%, rgba(143, 231, 237, 0.18) 70% 72%, transparent 73%);
+  border-radius: 0.2rem;
+  transform: translateX(-50%) rotate(-4deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="strata"] .chapter-stage__reference-mark::after {
+  left: 50%;
+  top: 1.88rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: rgba(255, 227, 156, 0.86);
+  box-shadow:
+    -0.9rem -0.25rem 0 -0.08rem rgba(91, 214, 143, 0.72),
+    0.9rem 0.2rem 0 -0.1rem rgba(143, 231, 237, 0.72),
+    0 0 0.9rem rgba(212, 175, 55, 0.25);
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="christian"] .chapter-stage__reference-mark::before {
+  left: 50%;
+  top: 0.82rem;
+  width: 1px;
+  height: 2.55rem;
+  background: linear-gradient(180deg, transparent, rgba(255, 227, 156, 0.66), rgba(91, 214, 143, 0.24), transparent);
+  box-shadow: 0 0 0.9rem rgba(212, 175, 55, 0.22);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="christian"] .chapter-stage__reference-mark::after {
+  left: 50%;
+  top: 1.82rem;
+  width: 2.35rem;
+  height: 0.82rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.5);
+  border-bottom: 1px solid rgba(91, 214, 143, 0.36);
+  border-radius: 50%;
+  transform: translateX(-50%) rotate(-10deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="modern"] .chapter-stage__reference-mark::before {
+  left: 43%;
+  top: 0.76rem;
+  width: 2rem;
+  height: 2.55rem;
+  border-right: 1px solid rgba(83, 216, 232, 0.48);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 65% 50%, rgba(83, 216, 232, 0.16), transparent 70%),
+    linear-gradient(130deg, transparent 48%, rgba(83, 216, 232, 0.2) 49%, transparent 51%);
+  transform: translateX(-50%) rotate(-10deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="modern"] .chapter-stage__reference-mark::after {
+  left: 62%;
+  top: 0.74rem;
+  width: 1px;
+  height: 2.55rem;
+  background: linear-gradient(180deg, transparent, rgba(143, 231, 237, 0.68), rgba(255, 227, 156, 0.22), transparent);
   box-shadow: 0 0 1rem rgba(83, 216, 232, 0.22);
 }
 
@@ -6486,6 +6913,14 @@ h3 {
 	  .prophecy-field-instrument__arc,
 	  .prophecy-field-instrument__threshold,
 	  .prophecy-field-instrument__mirror,
+	  .historical-strata-instrument__field,
+	  .historical-strata-instrument__axis,
+	  .historical-strata-instrument__layer,
+	  .historical-strata-instrument__sediment,
+	  .historical-strata-instrument__thread,
+	  .historical-strata-instrument__fish,
+	  .historical-strata-instrument__carrier,
+	  .historical-strata-instrument__depth,
 	  .chapters-orbit__node,
 	  .home-chapter-orbit__item a,
 	  .scene-host__pause {
@@ -6539,6 +6974,17 @@ h3 {
   .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__arc,
   .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__threshold,
   .chapter-experience[data-chapter-id="ch7"] .prophecy-field-instrument__mirror {
+    transition: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__field,
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__axis,
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer,
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment,
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread,
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__fish,
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__carrier,
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__depth {
     transition: none;
   }
 	}
@@ -7127,6 +7573,57 @@ h3 {
   }
 
   .chapter-experience[data-chapter-id="ch7"] .chapter-stage__reference-node[data-panel-id="threshold"] .chapter-stage__reference-mark::after {
+    left: 2.18rem;
+    top: 50%;
+    height: 2rem;
+    transform: translateY(-50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__scrim {
+    background:
+      linear-gradient(180deg, rgba(3, 3, 7, 0.94), rgba(3, 3, 7, 0.78) 54%, rgba(3, 3, 7, 0.88)),
+      radial-gradient(circle at 50% 44%, rgba(83, 216, 232, 0.16), rgba(3, 3, 7, 0.78) 62%),
+      radial-gradient(circle at 28% 44%, rgba(212, 175, 55, 0.13), transparent 42%);
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="strata"] .chapter-stage__reference-mark::before {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.9rem;
+    height: 1.55rem;
+    transform: translate(-50%, -50%) rotate(-4deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="strata"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="christian"] .chapter-stage__reference-mark::before {
+    left: 1.35rem;
+    top: 50%;
+    height: 2rem;
+    transform: translateY(-50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="christian"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    width: 1.95rem;
+    height: 0.66rem;
+    transform: translate(-50%, -50%) rotate(-10deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="modern"] .chapter-stage__reference-mark::before {
+    left: 1.2rem;
+    top: 50%;
+    width: 1.58rem;
+    height: 2.08rem;
+    transform: translate(-50%, -50%) rotate(-10deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__reference-node[data-panel-id="modern"] .chapter-stage__reference-mark::after {
     left: 2.18rem;
     top: 50%;
     height: 2rem;
@@ -7759,6 +8256,130 @@ h3 {
 
   .chapter-experience[data-chapter-id="ch7"][data-reduced-motion="true"] .scene-host__fallback h2,
   .chapter-experience[data-chapter-id="ch7"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro {
+    justify-content: flex-start;
+    padding-top: 10.2rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-sigil {
+    display: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro h1 {
+    max-width: 8.9ch;
+    font-size: clamp(2.05rem, 10.8vw, 2.78rem);
+    line-height: 0.92;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro p:not(.eyebrow) {
+    margin-top: 0.7rem;
+    max-width: 28.5ch;
+    font-size: 0.9rem;
+    line-height: 1.47;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .scene-host__pause {
+    justify-content: center;
+    width: 2.35rem;
+    min-width: 2.35rem;
+    padding-inline: 0;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .scene-host__pause span:not(.scene-host__pause-icon) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument {
+    min-height: 6.55rem;
+    margin-top: 0.68rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument::before {
+    inset: 0.5rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument::after {
+    width: 6.45rem;
+    height: 3.85rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__layer {
+    left: 11%;
+    right: 12%;
+    height: 0.34rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__fish {
+    width: 3.25rem;
+    height: 1.05rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__carrier {
+    height: 3.9rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread {
+    width: 5.65rem;
+    height: 3rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__depth {
+    right: 5%;
+    width: 2.58rem;
+    height: 1.75rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment {
+    width: 0.4rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label {
+    font-size: 0.51rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--strata {
+    left: 6%;
+    top: 12%;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--carrier {
+    left: 43%;
+    top: 12%;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--afterlife {
+    right: 4%;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"][data-reduced-motion="true"] .scene-host__fallback {
+    left: 1rem;
+    right: 1rem;
+    top: 20.95rem;
+    width: auto;
+    padding: 0.56rem 0.7rem;
+    text-align: left;
+    transform: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
+    margin: 0;
+  }
+
+  .chapter-experience[data-chapter-id="ch8"][data-reduced-motion="true"] .scene-host__fallback h2,
+  .chapter-experience[data-chapter-id="ch8"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/src/visualizations/chapters/ch8/ThreeHistoricalViz.js
+++ b/src/visualizations/chapters/ch8/ThreeHistoricalViz.js
@@ -575,6 +575,7 @@ export default class ThreeHistoricalViz extends BaseViz {
         ov.setAttribute('aria-hidden', 'true');
 
         /* ── CSS: proper font declarations matching ch1–ch7 pattern ── */
+        document.getElementById('ch8-anim-style')?.remove();
         const style = document.createElement('style');
         style.id = 'ch8-anim-style';
         style.textContent = `
@@ -758,11 +759,11 @@ export default class ThreeHistoricalViz extends BaseViz {
             `<div class="ch8-hdr-sub ${accent}">${sub}</div>`,
             '', 'ch8-hdr'
         );
-        this._hdr1 = mkHeader('I', 'THE CELESTIAL VISION', 'Revelation 12 — The Woman and the Dragon', 'ch8-gold');
-        this._hdr2 = mkHeader('II', 'THE HOOK OF CONSCIOUSNESS', 'The Cross catches Leviathan from the deep', 'ch8-silver');
-        this._hdr3 = mkHeader('III', 'THE HEALING FISH', 'The Book of Tobit — Sight restored from darkness', 'ch8-emerald');
-        this._hdr4 = mkHeader('IV', 'THE GREAT TRANSITION', 'From the Age of Aries to the Age of Pisces', 'ch8-crimson');
-        this._hdr5 = mkHeader('V', 'THE PRIMORDIAL DEEP', 'The fish as Self — totality of the unconscious', 'ch8-deep');
+        this._hdr1 = mkHeader('I', 'HISTORICAL STRATA', 'Older image-forms gather around the fish', 'ch8-gold');
+        this._hdr2 = mkHeader('II', 'CARRIER IMAGE', 'The motif becomes a readable vessel', 'ch8-silver');
+        this._hdr3 = mkHeader('III', 'HEALING MOTIF', 'Transformation is held below the surface', 'ch8-emerald');
+        this._hdr4 = mkHeader('IV', 'AEONIC DRIFT', 'The symbol crosses historical thresholds', 'ch8-crimson');
+        this._hdr5 = mkHeader('V', 'DEPTH AFTERLIFE', 'Older meanings persist below later interpretation', 'ch8-deep');
 
         /* ═══ PRIMARY QUOTES ═══ */
         const mkQuote = (main, sub, inlineCSS, accent) => mkEl(
@@ -770,33 +771,33 @@ export default class ThreeHistoricalViz extends BaseViz {
             `<div class="ch8-quote-sub">${sub}</div>`,
             inlineCSS, 'ch8-quote', accent
         );
-        this._ann1 = mkQuote('A woman clothed with the sun',
-            'The divine feminine crowned with the zodiac — the moon beneath her feet',
+        this._ann1 = mkQuote('Symbols gather sediment',
+            'Historical image-forms do not vanish; they layer into the motif',
             'top:14%;left:50%;transform:translateX(-50%) translateY(20px);', 'ch8-gold');
-        this._ann2 = mkQuote('The Cross as Hook, Christ as Bait',
-            'Patristic allegory — the crucifixion snares the primordial unconscious',
+        this._ann2 = mkQuote('The fish becomes a carrier',
+            'An image can hold transformation without becoming a fixed definition',
             'top:48%;left:50%;transform:translate(-50%,-50%) translateY(20px);', 'ch8-silver');
-        this._ann3 = mkQuote('The fish that heals blindness',
-            'Tobias extracts the healing organs — libido drawn from the unconscious into consciousness',
+        this._ann3 = mkQuote('The old image keeps changing',
+            'The same motif can carry healing, danger, salvation, and shadow',
             'top:42%;left:50%;transform:translate(-50%,0) translateY(20px);', 'ch8-emerald');
-        this._ann4 = mkQuote('From the Ram to the Fish',
-            'The astrological age shift mirrors the psychological transformation of an era',
+        this._ann4 = mkQuote('A sign crosses time',
+            'Collective images drift as the historical field changes around them',
             'top:48%;left:50%;transform:translate(-50%,-50%) translateY(20px);', 'ch8-gradient-text');
-        this._ann5 = mkQuote('In the depths, the Self',
-            'The fish as totality — Christ and Leviathan unified in the collective unconscious',
+        this._ann5 = mkQuote('The afterlife of the symbol',
+            'Later meanings keep older depths alive rather than replacing them',
             'bottom:16%;left:50%;transform:translateX(-50%) translateY(20px);', 'ch8-deep');
 
         /* ═══ ELEMENT LABELS ═══ */
         const mkLabel = (text, inlineCSS, accent) => mkEl(text, inlineCSS, 'ch8-label', accent);
 
-        this._lbl_crown = mkLabel('Crown of Twelve Stars', 'top:22%;left:50%;transform:translateX(-50%);', 'ch8-gold');
-        this._lbl_dragon = mkLabel('The Seven-Headed Dragon', 'bottom:30%;left:50%;transform:translateX(-50%);', 'ch8-gold');
-        this._lbl_cross = mkLabel('The Cross', 'top:20%;right:28%;', 'ch8-silver');
-        this._lbl_leviathan = mkLabel('Leviathan', 'bottom:24%;right:28%;', 'ch8-silver');
-        this._lbl_tobit = mkLabel('Tobit\'s Fish', 'top:36%;left:26%;', 'ch8-emerald');
+        this._lbl_crown = mkLabel('Older Image', 'top:22%;left:50%;transform:translateX(-50%);', 'ch8-gold');
+        this._lbl_dragon = mkLabel('Counter-Image', 'bottom:30%;left:50%;transform:translateX(-50%);', 'ch8-gold');
+        this._lbl_cross = mkLabel('Carrier Sign', 'top:20%;right:28%;', 'ch8-silver');
+        this._lbl_leviathan = mkLabel('Depth Image', 'bottom:24%;right:28%;', 'ch8-silver');
+        this._lbl_tobit = mkLabel('Healing Motif', 'top:36%;left:26%;', 'ch8-emerald');
         this._lbl_aries = mkLabel('♈ Aries', 'top:30%;left:28%;', 'ch8-crimson');
         this._lbl_pisces = mkLabel('♓ Pisces', 'top:56%;right:28%;', 'ch8-azure');
-        this._lbl_self = mkLabel('The Self', 'bottom:26%;left:50%;transform:translateX(-50%);', 'ch8-deep');
+        this._lbl_self = mkLabel('Symbolic Depth', 'bottom:26%;left:50%;transform:translateX(-50%);', 'ch8-deep');
 
         /* ═══ PROGRESS DOTS ═══ */
         const pc = document.createElement('div');
@@ -1120,10 +1121,16 @@ export default class ThreeHistoricalViz extends BaseViz {
         if (this._onWheel) removeEventListener('wheel', this._onWheel);
         if (this._overlay) this._overlay.remove();
         if (this._progressContainer) this._progressContainer.remove();
+        if (this._ch8Style) this._ch8Style.remove();
         if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
         this.scene?.traverse(o => {
             o.geometry?.dispose();
-            if (o.material) (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => m.dispose());
+            if (o.material) (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => {
+                ['map', 'alphaMap', 'aoMap', 'bumpMap', 'displacementMap', 'emissiveMap', 'envMap', 'lightMap', 'metalnessMap', 'normalMap', 'roughnessMap'].forEach((key) => {
+                    m[key]?.dispose?.();
+                });
+                m.dispose();
+            });
         });
         this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
         super.dispose();

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -171,6 +171,31 @@ describe('Aion framework data contract', () => {
       'projection',
     ]);
   });
+
+  test('keeps Chapter 8 fish history panels tied to historical strata', () => {
+    expect(CHAPTER_SCENES.ch8.panels.map((panel) => panel.id)).toEqual([
+      'strata',
+      'christian',
+      'modern',
+    ]);
+    expect(CHAPTER_SCENES.ch8.panels.map((panel) => panel.kicker)).toEqual([
+      'History',
+      'Early Image',
+      'Afterlife',
+    ]);
+    expect(CHAPTER_SCENES.ch8.motionGrammar).toBe('transformation');
+    expect(CHAPTER_SCENES.ch8.visualTheme).toContain('Fish symbol historical strata');
+    expect(CHAPTER_SCENES.ch8.sceneModule).toBe('../visualizations/chapters/ch8/ThreeHistoricalViz.js');
+    expect(CHAPTER_SCENES.ch8.fallbackSummary).toContain('Layered historical strata');
+    expect(CHAPTER_SCENES.ch8.fallbackSummary).toContain('fish motif');
+    expect(CHAPTER_SCENES.ch8.fallbackSummary).toContain('fixed definition');
+
+    expect(getConceptsForChapter('ch8').map((concept) => concept.id)).toEqual([
+      'fish-symbol',
+      'archetype',
+      'collective-unconscious',
+    ]);
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- add a visual-first Chapter 8 historical strata instrument with dynamic accessible teaching labels
- tune Chapter 8 layout, reference glyphs, mobile/reduced-motion behavior, and Three scene cleanup
- add Chapter 8 contract, e2e, accessibility, and Pages artifact coverage

## Verification
- rg -n "^(<<<<<<<|=======|>>>>>>>)" . returned no matches
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- npm run build
- npm run test:e2e:app
- npm run test:a11y:app
- npm run build:pages
- npm run test:pages:artifact
- npm run test:visual:control-tower

## Visual Evidence
- local Ch8 screenshots captured at 1440x1000, 390x844, and 320x568
- visual control tower reported 20 routes inspected, 0 technical blockers, Ch8 at 100%, and 0px Ch8 mobile/narrow overflow