### PR TITLE
feat: polish Chapter 9 ambivalent fish surface

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -340,6 +340,45 @@ async function checkChapterEightDynamicAccessibility(page, failures) {
   if (!afterlifeDescription?.includes('Afterlife: Old images keep speaking')) failures.push(`/journey/chapter/ch8: afterlife scene description mismatch: ${afterlifeDescription}`);
 }
 
+async function checkChapterNineDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/journey/chapter/ch9`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+  const instrument = page.getByRole('img', { name: /Ambivalent fish model/ });
+  const instrumentVisible = await instrument.isVisible();
+  const initialInstrumentLabel = await instrument.getAttribute('aria-label');
+  const initialDescription = await page.locator('#scene-host-description-ch9').textContent();
+
+  if (!instrumentVisible) failures.push('/journey/chapter/ch9: ambivalent fish instrument is missing an accessible image role');
+  if (!initialInstrumentLabel?.includes('Current emphasis: Paradox') || !initialInstrumentLabel?.includes('blessing and threat')) failures.push(`/journey/chapter/ch9: initial instrument label mismatch: ${initialInstrumentLabel}`);
+  if (!initialDescription?.includes('Paradox: The fish has a double edge')) failures.push(`/journey/chapter/ch9: initial scene description mismatch: ${initialDescription}`);
+
+  const ouroboros = page.getByRole('button', { name: /02\s+Return/ });
+  await ouroboros.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const ouroborosPressed = await ouroboros.getAttribute('aria-pressed');
+  const ouroborosLabel = await instrument.getAttribute('aria-label');
+  const ouroborosDescription = await page.locator('#scene-host-description-ch9').textContent();
+  if (ouroborosPressed !== 'true') failures.push(`/journey/chapter/ch9: return button did not become pressed: ${ouroborosPressed}`);
+  if (!ouroborosLabel?.includes('Current emphasis: Return') || !ouroborosLabel?.includes('The psyche circles what it cannot solve linearly')) failures.push(`/journey/chapter/ch9: return instrument label mismatch: ${ouroborosLabel}`);
+  if (!ouroborosDescription?.includes('Return: The image eats its tail')) failures.push(`/journey/chapter/ch9: return scene description mismatch: ${ouroborosDescription}`);
+
+  const shadow = page.getByRole('button', { name: /03\s+Shadow/ });
+  await shadow.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const shadowPressed = await shadow.getAttribute('aria-pressed');
+  const shadowLabel = await instrument.getAttribute('aria-label');
+  const shadowDescription = await page.locator('#scene-host-description-ch9').textContent();
+  if (shadowPressed !== 'true') failures.push(`/journey/chapter/ch9: shadow button did not become pressed: ${shadowPressed}`);
+  if (!shadowLabel?.includes('Current emphasis: Shadow') || !shadowLabel?.includes('A total image includes its antagonist')) failures.push(`/journey/chapter/ch9: shadow instrument label mismatch: ${shadowLabel}`);
+  if (!shadowDescription?.includes('Shadow: Light casts its fish-shadow')) failures.push(`/journey/chapter/ch9: shadow scene description mismatch: ${shadowDescription}`);
+}
+
 async function runAccessibilitySmoke() {
   const server = startPreviewServer();
   const failures = [];
@@ -357,10 +396,11 @@ async function runAccessibilitySmoke() {
     await checkChapterSixDynamicAccessibility(desktop, failures);
     await checkChapterSevenDynamicAccessibility(desktop, failures);
     await checkChapterEightDynamicAccessibility(desktop, failures);
+    await checkChapterNineDynamicAccessibility(desktop, failures);
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -637,6 +637,40 @@ async function smokeReducedMotion(browser, failures) {
   if (!chapterEightFallbackText?.includes('Layered historical strata') || !chapterEightFallbackText?.includes('fish motif')) {
     failures.push('reduced-motion chapter fallback lost Chapter 8 historical strata teaching summary');
   }
+
+  await gotoAppRoute(page, '/journey/chapter/ch9');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterNineFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterNineReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterNineReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterNineReferenceCount = await chapterNineReferenceNodes.count();
+  const chapterNinePanelIds = await chapterNineReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterNinePauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterNineCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterNineFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterNineInstrumentCount = await page.locator('.ambivalent-fish-instrument').count();
+  const chapterNineInstrumentMotion = await page.locator('.ambivalent-fish-instrument__field, .ambivalent-fish-instrument__mirror, .ambivalent-fish-instrument__ring, .ambivalent-fish-instrument__thread, .ambivalent-fish-instrument__fish, .ambivalent-fish-instrument__junction, .ambivalent-fish-instrument__shadow-core').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterNineAnimatedParts = chapterNineInstrumentMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterNineTransitioningParts = chapterNineInstrumentMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
+
+  if (!chapterNineFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 9 scene');
+  if (chapterNineReducedMotionAttribute !== 'true') failures.push('Chapter 9 did not record reduced-motion state');
+  if (chapterNineReferenceCount !== 3) failures.push(`reduced-motion Chapter 9 reference node count mismatch: ${chapterNineReferenceCount}`);
+  if (chapterNinePanelIds.join(',') !== 'ambivalence,ouroboros,shadow-fish') failures.push(`reduced-motion Chapter 9 reference nodes out of order: ${chapterNinePanelIds.join(',')}`);
+  if (chapterNinePauseControlCount !== 0) failures.push(`reduced-motion Chapter 9 rendered pause controls: ${chapterNinePauseControlCount}`);
+  if (chapterNineCanvasCount !== 0) failures.push(`reduced-motion Chapter 9 rendered canvas: ${chapterNineCanvasCount}`);
+  if (chapterNineInstrumentCount !== 1) failures.push(`reduced-motion Chapter 9 ambivalent fish instrument count mismatch: ${chapterNineInstrumentCount}`);
+  if (chapterNineAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 9 ambivalent fish instrument still animates: ${JSON.stringify(chapterNineAnimatedParts)}`);
+  if (chapterNineTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 9 ambivalent fish instrument still transitions: ${JSON.stringify(chapterNineTransitioningParts)}`);
+  if (!chapterNineFallbackText?.includes('fish-serpent') || !chapterNineFallbackText?.includes('salvation and shadow')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 9 ambivalent fish teaching summary');
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -1414,14 +1448,107 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterEightStyleCount !== 1) failures.push(`chapter 8 injected style count mismatch: ${chapterEightStyleCount}`);
 
   await gotoAppRoute(page, '/journey/chapter/ch9');
-  const shadowFish = page.getByRole('button', { name: /03\s+Shadow/ });
-  await activateSceneButton(shadowFish);
-  await page.waitForTimeout(250);
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterNineReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterNineReferenceCount = await chapterNineReferenceNodes.count();
+  const chapterNinePanelIds = await chapterNineReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterNineInstrument = page.locator('.ambivalent-fish-instrument');
+  const chapterNineInstrumentCount = await chapterNineInstrument.count();
+  const chapterNineInstrumentRole = await chapterNineInstrument.getAttribute('role');
+  const chapterNineInstrumentLabel = await chapterNineInstrument.getAttribute('aria-label');
+  const chapterNineInstrumentPanel = await chapterNineInstrument.getAttribute('data-active-panel');
+  const chapterNineInstrumentFieldCount = await page.locator('.ambivalent-fish-instrument__field').count();
+  const chapterNineInstrumentMirrorCount = await page.locator('.ambivalent-fish-instrument__mirror').count();
+  const chapterNineInstrumentRingCount = await page.locator('.ambivalent-fish-instrument__ring').count();
+  const chapterNineInstrumentFishCount = await page.locator('.ambivalent-fish-instrument__fish').count();
+  const chapterNineInstrumentJunctionCount = await page.locator('.ambivalent-fish-instrument__junction').count();
+  const chapterNineInstrumentShadowCoreCount = await page.locator('.ambivalent-fish-instrument__shadow-core').count();
+  const chapterNineInstrumentLabelCount = await page.locator('.ambivalent-fish-instrument__label').count();
+  const chapterNineInitialDescription = await page.locator('#scene-host-description-ch9').textContent();
+  const chapterNineInstrumentMarksVisible = await page.locator('.ambivalent-fish-instrument__field, .ambivalent-fish-instrument__mirror, .ambivalent-fish-instrument__ring, .ambivalent-fish-instrument__thread, .ambivalent-fish-instrument__fish, .ambivalent-fish-instrument__junction, .ambivalent-fish-instrument__shadow-core').evaluateAll((nodes) => nodes.length >= 10 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterNineReferenceGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="ambivalence"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="ouroboros"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="shadow-fish"] .chapter-stage__reference-mark').evaluateAll((nodes) => nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+
+  if (chapterNineReferenceCount !== 3) failures.push(`chapter 9 reference node count mismatch: ${chapterNineReferenceCount}`);
+  if (chapterNinePanelIds.join(',') !== 'ambivalence,ouroboros,shadow-fish') failures.push(`chapter 9 reference nodes out of order: ${chapterNinePanelIds.join(',')}`);
+  if (chapterNineInstrumentCount !== 1) failures.push(`chapter 9 ambivalent fish instrument count mismatch: ${chapterNineInstrumentCount}`);
+  if (chapterNineInstrumentFieldCount !== 2) failures.push(`chapter 9 ambivalent fish instrument field count mismatch: ${chapterNineInstrumentFieldCount}`);
+  if (chapterNineInstrumentMirrorCount !== 1) failures.push(`chapter 9 ambivalent fish instrument mirror count mismatch: ${chapterNineInstrumentMirrorCount}`);
+  if (chapterNineInstrumentRingCount !== 2) failures.push(`chapter 9 ambivalent fish instrument ring count mismatch: ${chapterNineInstrumentRingCount}`);
+  if (chapterNineInstrumentFishCount !== 2) failures.push(`chapter 9 ambivalent fish instrument fish count mismatch: ${chapterNineInstrumentFishCount}`);
+  if (chapterNineInstrumentJunctionCount !== 1) failures.push(`chapter 9 ambivalent fish instrument junction count mismatch: ${chapterNineInstrumentJunctionCount}`);
+  if (chapterNineInstrumentShadowCoreCount !== 1) failures.push(`chapter 9 ambivalent fish instrument shadow core count mismatch: ${chapterNineInstrumentShadowCoreCount}`);
+  if (chapterNineInstrumentLabelCount !== 3) failures.push(`chapter 9 ambivalent fish instrument label count mismatch: ${chapterNineInstrumentLabelCount}`);
+  if (chapterNineInstrumentRole !== 'img') failures.push(`chapter 9 ambivalent fish instrument role mismatch: ${chapterNineInstrumentRole}`);
+  if (!chapterNineInstrumentLabel?.includes('Ambivalent fish model') || !chapterNineInstrumentLabel?.includes('blessing and threat') || !chapterNineInstrumentLabel?.includes('Current emphasis: Paradox')) {
+    failures.push(`chapter 9 ambivalent fish instrument label missing teaching text: ${chapterNineInstrumentLabel}`);
+  }
+  if (chapterNineInstrumentPanel !== 'ambivalence') failures.push(`chapter 9 ambivalent fish instrument did not start on ambivalence panel: ${chapterNineInstrumentPanel}`);
+  if (!chapterNineInitialDescription?.includes('Paradox: The fish has a double edge')) failures.push(`chapter 9 initial scene description mismatch: ${chapterNineInitialDescription}`);
+  if (!chapterNineInstrumentMarksVisible) failures.push('chapter 9 ambivalent fish instrument marks are not visibly rendered');
+  if (!chapterNineReferenceGlyphsVisible) failures.push('chapter 9 reference glyphs are not visibly rendered');
+
+  const ouroboros = page.locator('.chapter-stage__reference-node[data-panel-id="ouroboros"]');
+  await ouroboros.waitFor({ state: 'visible', timeout: 30_000 });
+  await ouroboros.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(700);
+
+  const ouroborosPressed = await ouroboros.getAttribute('aria-pressed');
+  const ouroborosPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="ouroboros"]').count();
+  const ouroborosDescription = await page.locator('#scene-host-description-ch9').textContent();
+  const ouroborosInstrumentPanel = await chapterNineInstrument.getAttribute('data-active-panel');
+  const ouroborosInstrumentLabel = await chapterNineInstrument.getAttribute('aria-label');
+  const ouroborosVisualState = await page.locator('.ambivalent-fish-instrument__ring--outer, .ambivalent-fish-instrument__ring--inner, .ambivalent-fish-instrument__thread, .ambivalent-fish-instrument__junction').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  if (ouroborosPressed !== 'true') failures.push(`chapter 9 ouroboros reference did not become active: ${ouroborosPressed}`);
+  if (ouroborosPanelActive !== 1) failures.push(`chapter 9 ouroboros panel did not become active: ${ouroborosPanelActive}`);
+  if (ouroborosInstrumentPanel !== 'ouroboros') failures.push(`chapter 9 ambivalent fish instrument did not follow ouroboros panel: ${ouroborosInstrumentPanel}`);
+  if (!ouroborosInstrumentLabel?.includes('Current emphasis: Return') || !ouroborosInstrumentLabel?.includes('The psyche circles what it cannot solve linearly')) {
+    failures.push(`chapter 9 ambivalent fish instrument label did not follow ouroboros panel: ${ouroborosInstrumentLabel}`);
+  }
+  if (ouroborosVisualState.length !== 4 || !ouroborosVisualState.every((opacity) => opacity >= 0.65)) {
+    failures.push(`chapter 9 ambivalent fish instrument did not visually emphasize return: ${ouroborosVisualState.join(',')}`);
+  }
+  if (!ouroborosDescription?.includes('Return: The image eats its tail')) failures.push(`chapter 9 scene description did not follow ouroboros panel: ${ouroborosDescription}`);
+
+  const shadowFish = page.locator('.chapter-stage__reference-node[data-panel-id="shadow-fish"]');
+  await shadowFish.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(700);
 
   const shadowFishPressed = await shadowFish.getAttribute('aria-pressed');
+  const shadowFishPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="shadow-fish"]').count();
+  const shadowFishDescription = await page.locator('#scene-host-description-ch9').textContent();
+  const shadowFishInstrumentPanel = await chapterNineInstrument.getAttribute('data-active-panel');
+  const shadowFishInstrumentLabel = await chapterNineInstrument.getAttribute('aria-label');
+  const shadowFishVisualState = await page.locator('.ambivalent-fish-instrument__field--shadow, .ambivalent-fish-instrument__shadow-core, .ambivalent-fish-instrument__fish--shadow, .ambivalent-fish-instrument__mirror').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   const chapterNineScrollY = await page.evaluate(() => window.scrollY);
   if (shadowFishPressed !== 'true') failures.push(`chapter 9 scene control did not become active: ${shadowFishPressed}`);
+  if (shadowFishPanelActive !== 1) failures.push(`chapter 9 shadow fish panel did not become active: ${shadowFishPanelActive}`);
+  if (shadowFishInstrumentPanel !== 'shadow-fish') failures.push(`chapter 9 ambivalent fish instrument did not follow shadow fish panel: ${shadowFishInstrumentPanel}`);
+  if (!shadowFishInstrumentLabel?.includes('Current emphasis: Shadow') || !shadowFishInstrumentLabel?.includes('A total image includes its antagonist')) {
+    failures.push(`chapter 9 ambivalent fish instrument label did not follow shadow fish panel: ${shadowFishInstrumentLabel}`);
+  }
+  if (shadowFishVisualState.length !== 4 || !shadowFishVisualState.every((opacity) => opacity >= 0.65)) {
+    failures.push(`chapter 9 ambivalent fish instrument did not visually emphasize shadow fish: ${shadowFishVisualState.join(',')}`);
+  }
+  if (!shadowFishDescription?.includes('Shadow: Light casts its fish-shadow')) failures.push(`chapter 9 scene description did not follow shadow fish panel: ${shadowFishDescription}`);
   if (chapterNineScrollY > 10) failures.push(`chapter 9 scene control unexpectedly scrolled page: ${chapterNineScrollY}`);
+
+  const chapterNineCanvas = page.locator('.scene-host canvas').first();
+  const chapterNineCanvasBox = await chapterNineCanvas.boundingBox();
+  const chapterNinePixelSample = await waitForCanvasPixels(chapterNineCanvas);
+  if (!chapterNineCanvasBox || chapterNineCanvasBox.width < 300 || chapterNineCanvasBox.height < 300) {
+    failures.push(`chapter 9 canvas geometry too small: ${chapterNineCanvasBox ? `${Math.round(chapterNineCanvasBox.width)}x${Math.round(chapterNineCanvasBox.height)}` : 'missing'}`);
+  }
+  recordCanvasPixelFailure(failures, 'chapter 9', chapterNinePixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch10');
   const opus = page.getByRole('button', { name: /03\s+Opus/ });
@@ -1476,7 +1603,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -1748,6 +1875,45 @@ async function smokeMobile(page, failures) {
       if (chapterEightCanvasCount > 0) {
         const chapterEightPixelSample = await waitForCanvasPixels(chapterEightCanvas);
         recordCanvasPixelFailure(failures, `mobile chapter 8 at ${viewport.width}x${viewport.height}`, chapterEightPixelSample);
+      }
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch9');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterNineNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterNineHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterNineReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterNineReferenceCount = await chapterNineReferenceNodes.count();
+    const chapterNinePanelIds = await chapterNineReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterNineScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterNineReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const chapterNineInstrumentBox = await page.locator('.ambivalent-fish-instrument').boundingBox();
+    if (!chapterNineNavBox || !chapterNineHeadingBox) {
+      failures.push(`mobile chapter 9 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterNineNavBottom = chapterNineNavBox.y + chapterNineNavBox.height;
+    if (chapterNineNavBottom > chapterNineHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 9 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterNineNavBottom)}, heading top ${Math.round(chapterNineHeadingBox.y)}`);
+    }
+    if (chapterNineReferenceCount !== 3) failures.push(`mobile chapter 9 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterNineReferenceCount}`);
+    if (chapterNinePanelIds.join(',') !== 'ambivalence,ouroboros,shadow-fish') failures.push(`mobile chapter 9 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterNinePanelIds.join(',')}`);
+    if (chapterNineScrollWidth > viewport.width + 2) failures.push(`mobile chapter 9 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterNineScrollWidth}`);
+    if (chapterNineReferenceMapBox && chapterNineReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 9 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterNineReferenceMapBox.width)}`);
+    }
+    if (!chapterNineInstrumentBox) failures.push(`mobile chapter 9 ambivalent fish instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterNineInstrumentBox && chapterNineInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 9 ambivalent fish instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterNineInstrumentBox.width)}`);
+    }
+
+    if (viewport.width === mobileViewport.width) {
+      const chapterNineCanvas = page.locator('.scene-host canvas').first();
+      const chapterNineCanvasCount = await chapterNineCanvas.count();
+      if (chapterNineCanvasCount > 0) {
+        const chapterNinePixelSample = await waitForCanvasPixels(chapterNineCanvas);
+        recordCanvasPixelFailure(failures, `mobile chapter 9 at ${viewport.width}x${viewport.height}`, chapterNinePixelSample);
       }
     }
   }

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -19,7 +19,7 @@ const canonicalRoutes = [
   ...Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`),
 ];
 
-const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch14'];
+const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch14'];
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -65,6 +65,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const aeonFishInstrumentLabel = `Sign of the Fishes model: two Pisces fish swim in opposite directions inside a zodiac wheel, the spring point precesses through symbolic time, and Aquarius marks the slow threshold of a changing aeon. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const prophecyFieldInstrumentLabel = `Prophecy field model: historical pressure gathers around a time axis, private fear projects into a shared symbolic image-field, and the threshold mirror shows the future looking backward into older archetypal forms. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const historicalStrataInstrumentLabel = `Historical strata model: five translucent layers accumulate around the fish motif, an early Christian carrier image gathers the symbol into a readable form, and older meanings keep speaking below later interpretation. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
+  const ambivalentFishInstrumentLabel = `Ambivalent fish model: one fish-symbol carries blessing and threat across a split field, an ouroboric return shows opposition circling back into itself, and the shadow fish keeps the Antichrist counter-pole inside the total image. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
 
   useEffect(() => {
     setActivePanelId(experience.panels[0]?.id || '');
@@ -296,6 +297,28 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="historical-strata-instrument__label historical-strata-instrument__label--strata" aria-hidden="true">strata</span>
               <span className="historical-strata-instrument__label historical-strata-instrument__label--carrier" aria-hidden="true">carrier</span>
               <span className="historical-strata-instrument__label historical-strata-instrument__label--afterlife" aria-hidden="true">afterlife</span>
+            </div>
+          )}
+          {chapter.id === 'ch9' && (
+            <div
+              className="ambivalent-fish-instrument"
+              data-active-panel={activePanelId}
+              role="img"
+              aria-label={ambivalentFishInstrumentLabel}
+            >
+              <span className="ambivalent-fish-instrument__field ambivalent-fish-instrument__field--light" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__field ambivalent-fish-instrument__field--shadow" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__mirror" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__ring ambivalent-fish-instrument__ring--outer" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__ring ambivalent-fish-instrument__ring--inner" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__thread" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__fish ambivalent-fish-instrument__fish--light" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__fish ambivalent-fish-instrument__fish--shadow" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__junction" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__shadow-core" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--paradox" aria-hidden="true">double edge</span>
+              <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--return" aria-hidden="true">return</span>
+              <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--shadow" aria-hidden="true">counter-pole</span>
             </div>
           )}
           <div className="chapter-stage__thesis-map" aria-label="Chapter visual sequence">

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -5115,6 +5115,439 @@ h3 {
   box-shadow: 0 0 1.2rem rgba(83, 216, 232, 0.13);
 }
 
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__intro h1 {
+  max-width: 13.5ch;
+  font-size: clamp(3.6rem, 6vw, 5.2rem);
+  line-height: 0.92;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__thesis-map {
+  max-width: 30rem;
+  margin-top: 0.94rem;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-map {
+  width: min(26rem, 100%);
+  margin-top: 0.68rem;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-node {
+  min-height: 3.85rem;
+  background:
+    radial-gradient(circle at 42% 34%, rgba(255, 227, 156, 0.11), transparent 2.35rem),
+    radial-gradient(circle at 62% 58%, rgba(83, 216, 232, 0.1), transparent 2.4rem),
+    linear-gradient(180deg, rgba(10, 8, 12, 0.62), rgba(3, 3, 7, 0.34));
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-label {
+  margin-top: 2.05rem;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__scrim {
+  background:
+    linear-gradient(180deg, rgba(3, 3, 7, 0.76), rgba(3, 3, 7, 0.4) 48%, rgba(3, 3, 7, 0.82)),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.95), rgba(3, 3, 7, 0.52) 60%, rgba(3, 3, 7, 0.3)),
+    radial-gradient(circle at 31% 47%, rgba(212, 175, 55, 0.14), transparent 32%),
+    radial-gradient(circle at 66% 52%, rgba(83, 216, 232, 0.13), transparent 36%);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-node[data-panel-id="ambivalence"] .chapter-stage__reference-mark::before {
+  top: 0.96rem;
+  width: 2.15rem;
+  height: 1.08rem;
+  border: 1px solid rgba(255, 227, 156, 0.3);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 34% 50%, rgba(255, 227, 156, 0.8) 0 0.14rem, transparent 0.16rem),
+    linear-gradient(90deg, rgba(255, 227, 156, 0.12), transparent 52%, rgba(83, 216, 232, 0.12));
+  box-shadow: 0 0 1.2rem rgba(212, 175, 55, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-node[data-panel-id="ambivalence"] .chapter-stage__reference-mark::after {
+  top: 0.62rem;
+  height: 2.2rem;
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.42), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-node[data-panel-id="ouroboros"] .chapter-stage__reference-mark::before {
+  top: 0.82rem;
+  width: 2.35rem;
+  height: 1.55rem;
+  border: 1px solid rgba(255, 227, 156, 0.28);
+  border-left-color: rgba(83, 216, 232, 0.34);
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.08), transparent 70%);
+  box-shadow: 0 0 1.25rem rgba(83, 216, 232, 0.16);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-node[data-panel-id="ouroboros"] .chapter-stage__reference-mark::after {
+  top: 1.28rem;
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: 50%;
+  background: rgba(255, 227, 156, 0.82);
+  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.32);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-node[data-panel-id="shadow-fish"] .chapter-stage__reference-mark::before {
+  top: 0.96rem;
+  width: 2.1rem;
+  height: 1.05rem;
+  border: 1px solid rgba(83, 216, 232, 0.3);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 66% 50%, rgba(143, 231, 237, 0.66) 0 0.13rem, transparent 0.15rem),
+    radial-gradient(ellipse at 52% 50%, rgba(83, 216, 232, 0.12), rgba(181, 130, 255, 0.08) 58%, transparent 70%);
+  box-shadow: 0 0 1.18rem rgba(83, 216, 232, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-node[data-panel-id="shadow-fish"] .chapter-stage__reference-mark::after {
+  top: 0.78rem;
+  height: 2.12rem;
+  background: linear-gradient(180deg, transparent, rgba(83, 216, 232, 0.38), transparent);
+  transform: translateX(-50%) rotate(-18deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument {
+  position: relative;
+  width: min(31rem, 100%);
+  min-height: clamp(6.75rem, 10.6vh, 8.05rem);
+  overflow: hidden;
+  margin-top: 0.82rem;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 30% 45%, rgba(212, 175, 55, 0.18), transparent 4.6rem),
+    radial-gradient(circle at 68% 52%, rgba(83, 216, 232, 0.14), transparent 4.8rem),
+    linear-gradient(90deg, rgba(17, 13, 8, 0.8), rgba(9, 9, 13, 0.66) 50%, rgba(3, 13, 18, 0.66));
+  box-shadow:
+    var(--shadow-inset),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.22);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::before,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::before {
+  inset: 0.58rem;
+  border: 1px solid rgba(255, 227, 156, 0.08);
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::after {
+  left: 50%;
+  top: 50%;
+  width: 0.08rem;
+  height: 5.25rem;
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.28), transparent);
+  box-shadow: 0 0 1.35rem rgba(244, 240, 232, 0.12);
+  transform: translate(-50%, -50%) rotate(4deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__mirror,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__thread,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__junction,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label {
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field {
+  top: 0;
+  bottom: 0;
+  width: 50%;
+  opacity: 0.56;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field--light {
+  left: 0;
+  background:
+    radial-gradient(circle at 42% 48%, rgba(255, 227, 156, 0.18), transparent 4rem),
+    linear-gradient(90deg, rgba(212, 175, 55, 0.09), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field--shadow {
+  right: 0;
+  background:
+    radial-gradient(circle at 58% 52%, rgba(83, 216, 232, 0.14), transparent 4.2rem),
+    linear-gradient(270deg, rgba(83, 216, 232, 0.08), rgba(181, 130, 255, 0.04), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__mirror {
+  left: 50%;
+  top: 50%;
+  width: 3.1rem;
+  height: 5rem;
+  border: 1px solid rgba(244, 240, 232, 0.16);
+  border-radius: 50%;
+  background:
+    linear-gradient(92deg, transparent 46%, rgba(244, 240, 232, 0.16) 49%, transparent 52%),
+    radial-gradient(ellipse at 50% 50%, rgba(244, 240, 232, 0.08), transparent 72%);
+  box-shadow:
+    inset 0 0 1.1rem rgba(244, 240, 232, 0.08),
+    0 0 1.55rem rgba(83, 216, 232, 0.12);
+  opacity: 0.7;
+  transform: translate(-50%, -50%) rotate(4deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring {
+  left: 50%;
+  top: 50%;
+  border-radius: 50%;
+  opacity: 0.42;
+  transform: translate(-50%, -50%) rotate(-14deg);
+  transition:
+    border-color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring--outer {
+  width: 9.7rem;
+  height: 4.85rem;
+  border: 1px solid rgba(255, 227, 156, 0.24);
+  border-left-color: rgba(83, 216, 232, 0.28);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring--inner {
+  width: 6.7rem;
+  height: 3.12rem;
+  border: 1px solid rgba(83, 216, 232, 0.22);
+  border-right-color: rgba(255, 227, 156, 0.26);
+  opacity: 0.34;
+  transform: translate(-50%, -50%) rotate(16deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__thread {
+  left: 50%;
+  top: 50%;
+  width: 8.25rem;
+  height: 3.6rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.22);
+  border-bottom: 1px solid rgba(83, 216, 232, 0.24);
+  border-radius: 50%;
+  opacity: 0.46;
+  transform: translate(-50%, -50%) rotate(-8deg);
+  transition:
+    border-color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish {
+  top: 50%;
+  width: 3.95rem;
+  height: 1.22rem;
+  border-radius: 50%;
+  opacity: 0.84;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 0.08rem;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--light {
+  left: 25%;
+  border-top: 1px solid rgba(255, 227, 156, 0.58);
+  border-bottom: 1px solid rgba(244, 240, 232, 0.28);
+  background:
+    radial-gradient(circle at 32% 50%, rgba(255, 227, 156, 0.72) 0 0.16rem, transparent 0.18rem),
+    radial-gradient(ellipse at 52% 50%, rgba(212, 175, 55, 0.2), transparent 68%);
+  box-shadow: 0 0 1.4rem rgba(212, 175, 55, 0.22);
+  transform: translate(-50%, -50%) rotate(-8deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--light::after {
+  right: -0.38rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.46);
+  border-right: 1px solid rgba(255, 227, 156, 0.32);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--shadow {
+  right: 24%;
+  border-top: 1px solid rgba(83, 216, 232, 0.44);
+  border-bottom: 1px solid rgba(181, 130, 255, 0.32);
+  background:
+    radial-gradient(circle at 68% 50%, rgba(143, 231, 237, 0.52) 0 0.14rem, transparent 0.16rem),
+    radial-gradient(ellipse at 48% 50%, rgba(83, 216, 232, 0.13), rgba(181, 130, 255, 0.06) 58%, transparent 70%);
+  box-shadow: 0 0 1.35rem rgba(83, 216, 232, 0.18);
+  filter: saturate(0.9);
+  transform: translate(50%, -50%) rotate(172deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--shadow::after {
+  left: -0.38rem;
+  border-left: 1px solid rgba(83, 216, 232, 0.34);
+  border-bottom: 1px solid rgba(181, 130, 255, 0.28);
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__junction {
+  left: 50%;
+  top: 50%;
+  width: 0.72rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(244, 240, 232, 0.22);
+  border-radius: 50%;
+  background: rgba(244, 240, 232, 0.16);
+  box-shadow:
+    0 0 0 0.42rem rgba(244, 240, 232, 0.05),
+    0 0 1.35rem rgba(255, 227, 156, 0.12);
+  opacity: 0.72;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core {
+  right: 10%;
+  top: 50%;
+  width: 3.35rem;
+  height: 2.25rem;
+  border: 1px solid rgba(181, 130, 255, 0.22);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(181, 130, 255, 0.16), transparent 68%),
+    linear-gradient(130deg, transparent 47%, rgba(83, 216, 232, 0.2) 49%, transparent 52%);
+  box-shadow: inset 0 0 1.1rem rgba(83, 216, 232, 0.08);
+  opacity: 0.54;
+  transform: translateY(-50%) rotate(-12deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--paradox {
+  left: 7%;
+  top: 14%;
+  color: rgba(255, 227, 156, 0.93);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--return {
+  left: 47%;
+  top: 14%;
+  color: rgba(244, 240, 232, 0.86);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--shadow {
+  right: 5%;
+  top: 14%;
+  color: rgba(143, 231, 237, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__field {
+  opacity: 0.76;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__mirror,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__thread {
+  opacity: 0.88;
+  transform: translate(-50%, -50%) rotate(4deg) scale(1.05);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__thread {
+  transform: translate(-50%, -50%) rotate(-8deg) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__fish {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__ring,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__thread,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__junction {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__ring--outer {
+  border-color: rgba(255, 227, 156, 0.42);
+  border-left-color: rgba(83, 216, 232, 0.5);
+  transform: translate(-50%, -50%) rotate(-24deg) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__ring--inner {
+  border-color: rgba(83, 216, 232, 0.4);
+  border-right-color: rgba(255, 227, 156, 0.44);
+  transform: translate(-50%, -50%) rotate(26deg) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__thread {
+  transform: translate(-50%, -50%) rotate(7deg) scale(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__fish--light {
+  transform: translate(-24%, -50%) rotate(-4deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__fish--shadow {
+  transform: translate(24%, -50%) rotate(176deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__field--shadow,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__shadow-core,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__fish--shadow {
+  opacity: 1;
+  box-shadow: 0 0 1.65rem rgba(83, 216, 232, 0.22);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__shadow-core {
+  transform: translateY(-50%) rotate(-12deg) scale(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__fish--shadow {
+  filter: saturate(1.2);
+  transform: translate(50%, -50%) rotate(172deg) scale(1.13);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__fish--light {
+  opacity: 0.52;
+  transform: translate(-50%, -50%) rotate(-8deg) scale(0.94);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__mirror {
+  opacity: 0.9;
+  box-shadow:
+    inset 0 0 1.1rem rgba(244, 240, 232, 0.09),
+    0 0 1.65rem rgba(83, 216, 232, 0.18);
+}
+
 .chapter-experience[data-chapter-id="ch3"][data-reduced-motion="true"] .scene-host__fallback {
   left: auto;
   right: clamp(1rem, 4vw, 3.5rem);
@@ -6917,15 +7350,22 @@ h3 {
 	  .historical-strata-instrument__axis,
 	  .historical-strata-instrument__layer,
 	  .historical-strata-instrument__sediment,
-	  .historical-strata-instrument__thread,
-	  .historical-strata-instrument__fish,
-	  .historical-strata-instrument__carrier,
-	  .historical-strata-instrument__depth,
-	  .chapters-orbit__node,
-	  .home-chapter-orbit__item a,
-	  .scene-host__pause {
-	    transition: none;
-	  }
+		  .historical-strata-instrument__thread,
+		  .historical-strata-instrument__fish,
+		  .historical-strata-instrument__carrier,
+		  .historical-strata-instrument__depth,
+		  .ambivalent-fish-instrument__field,
+		  .ambivalent-fish-instrument__mirror,
+		  .ambivalent-fish-instrument__ring,
+		  .ambivalent-fish-instrument__thread,
+		  .ambivalent-fish-instrument__fish,
+		  .ambivalent-fish-instrument__junction,
+		  .ambivalent-fish-instrument__shadow-core,
+		  .chapters-orbit__node,
+		  .home-chapter-orbit__item a,
+		  .scene-host__pause {
+		    transition: none;
+		  }
 
   .atlas-constellation__core-glow {
     animation: none;
@@ -6984,10 +7424,20 @@ h3 {
   .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread,
   .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__fish,
   .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__carrier,
-  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__depth {
-    transition: none;
-  }
-	}
+	  .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__depth {
+	    transition: none;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field,
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__mirror,
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring,
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__thread,
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish,
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__junction,
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core {
+	    transition: none;
+	  }
+		}
 
 @media (max-width: 1120px) {
   .atlas-hero {
@@ -8378,19 +8828,151 @@ h3 {
     margin: 0;
   }
 
-  .chapter-experience[data-chapter-id="ch8"][data-reduced-motion="true"] .scene-host__fallback h2,
-  .chapter-experience[data-chapter-id="ch8"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
-    position: absolute;
-    width: 1px;
-    height: 1px;
+	  .chapter-experience[data-chapter-id="ch8"][data-reduced-motion="true"] .scene-host__fallback h2,
+	  .chapter-experience[data-chapter-id="ch8"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+	    position: absolute;
+	    width: 1px;
+	    height: 1px;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-  }
+	    clip: rect(0, 0, 0, 0);
+	    white-space: nowrap;
+	  }
 
-  .home-hero {
-    padding-top: 12.4rem;
-  }
+	  .chapter-experience[data-chapter-id="ch9"] .chapter-stage__intro {
+	    justify-content: flex-start;
+	    padding-top: 10.25rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .chapter-sigil {
+	    display: none;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .chapter-stage__intro h1 {
+	    max-width: 9.2ch;
+	    font-size: clamp(2.05rem, 10.7vw, 2.82rem);
+	    line-height: 0.92;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .chapter-stage__intro p:not(.eyebrow) {
+	    margin-top: 0.7rem;
+	    max-width: 28.5ch;
+	    font-size: 0.9rem;
+	    line-height: 1.47;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .scene-host__pause {
+	    justify-content: center;
+	    width: 2.35rem;
+	    min-width: 2.35rem;
+	    padding-inline: 0;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .scene-host__pause span:not(.scene-host__pause-icon) {
+	    position: absolute;
+	    width: 1px;
+	    height: 1px;
+	    overflow: hidden;
+	    clip: rect(0, 0, 0, 0);
+	    white-space: nowrap;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument {
+	    min-height: 6.65rem;
+	    margin-top: 0.68rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::before {
+	    inset: 0.5rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::after {
+	    height: 4.55rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__mirror {
+	    width: 2.55rem;
+	    height: 4.3rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring--outer {
+	    width: 7.15rem;
+	    height: 4rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring--inner {
+	    width: 5.05rem;
+	    height: 2.72rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__thread {
+	    width: 6.1rem;
+	    height: 3rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish {
+	    width: 3.05rem;
+	    height: 1rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--light {
+	    left: 25%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--shadow {
+	    right: 23%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core {
+	    right: 5%;
+	    width: 2.44rem;
+	    height: 1.68rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label {
+	    font-size: 0.51rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--paradox {
+	    left: 6%;
+	    top: 12%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--return {
+	    left: 44%;
+	    top: 12%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--shadow {
+	    right: 4%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"][data-reduced-motion="true"] .scene-host__fallback {
+	    left: 1rem;
+	    right: 1rem;
+	    top: 21.05rem;
+	    width: auto;
+	    padding: 0.56rem 0.7rem;
+	    text-align: left;
+	    transform: none;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
+	    margin: 0;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"][data-reduced-motion="true"] .scene-host__fallback h2,
+	  .chapter-experience[data-chapter-id="ch9"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+	    position: absolute;
+	    width: 1px;
+	    height: 1px;
+	    overflow: hidden;
+	    clip: rect(0, 0, 0, 0);
+	    white-space: nowrap;
+	  }
+
+	  .home-hero {
+	    padding-top: 12.4rem;
+	  }
 
   .hero-actions .button {
     width: 100%;

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -196,6 +196,32 @@ describe('Aion framework data contract', () => {
       'collective-unconscious',
     ]);
   });
+
+  test('keeps Chapter 9 ambivalent fish panels tied to paradox and opposition', () => {
+    expect(CHAPTER_SCENES.ch9.panels.map((panel) => panel.id)).toEqual([
+      'ambivalence',
+      'ouroboros',
+      'shadow-fish',
+    ]);
+    expect(CHAPTER_SCENES.ch9.panels.map((panel) => panel.kicker)).toEqual([
+      'Paradox',
+      'Return',
+      'Shadow',
+    ]);
+    expect(CHAPTER_SCENES.ch9.motionGrammar).toBe('opposition');
+    expect(CHAPTER_SCENES.ch9.visualTheme).toContain('Ambivalent fish');
+    expect(CHAPTER_SCENES.ch9.visualTheme).toContain('ouroboros');
+    expect(CHAPTER_SCENES.ch9.sceneModule).toBe('../visualizations/chapters/ch9/ThreeOuroborosViz.js');
+    expect(CHAPTER_SCENES.ch9.fallbackSummary).toContain('fish-serpent');
+    expect(CHAPTER_SCENES.ch9.fallbackSummary).toContain('salvation and shadow');
+    expect(CHAPTER_SCENES.ch9.fallbackSummary).toContain('ambivalent totality');
+
+    expect(getConceptsForChapter('ch9').map((concept) => concept.id)).toEqual([
+      'fish-symbol',
+      'opposites',
+      'antichrist',
+    ]);
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- adds a Chapter 9 ambivalent fish teaching instrument tied to Paradox, Return, and Shadow panel state
- tightens Chapter 9 first-viewport layout and symbolic reference controls
- expands contract, app-shell, accessibility, mobile, and Pages artifact smoke coverage for Chapter 9

## Verification
- rg -n "^(<<<<<<<|=======|>>>>>>>)" .
- npm run lint
- npx tsc --noEmit
- npm run test:app
- npm test
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run build
- npm run test:e2e:app
- npm run test:a11y:app
- npm run build:pages
- npm run test:pages:artifact

## Visual QA
- Captured local Chapter 9 desktop, mobile, narrow mobile, Return state, and Shadow state screenshots.
- Checked no console errors or unexpected 404s during screenshot capture.