### PR TITLE
feat: polish chapter ten alchemical vessel

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -379,6 +379,45 @@ async function checkChapterNineDynamicAccessibility(page, failures) {
   if (!shadowDescription?.includes('Shadow: Light casts its fish-shadow')) failures.push(`/journey/chapter/ch9: shadow scene description mismatch: ${shadowDescription}`);
 }
 
+async function checkChapterTenDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/journey/chapter/ch10`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+  const instrument = page.getByRole('img', { name: /Alchemical vessel model/ });
+  const instrumentVisible = await instrument.isVisible();
+  const initialInstrumentLabel = await instrument.getAttribute('aria-label');
+  const initialDescription = await page.locator('#scene-host-description-ch10').textContent();
+
+  if (!instrumentVisible) failures.push('/journey/chapter/ch10: alchemical vessel instrument is missing an accessible image role');
+  if (!initialInstrumentLabel?.includes('Current emphasis: Alchemy') || !initialInstrumentLabel?.includes('fish-symbol enters')) failures.push(`/journey/chapter/ch10: initial instrument label mismatch: ${initialInstrumentLabel}`);
+  if (!initialDescription?.includes('Alchemy: The fish enters the opus')) failures.push(`/journey/chapter/ch10: initial scene description mismatch: ${initialDescription}`);
+
+  const prima = page.getByRole('button', { name: /02\s+Prima Materia/ });
+  await prima.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const primaPressed = await prima.getAttribute('aria-pressed');
+  const primaLabel = await instrument.getAttribute('aria-label');
+  const primaDescription = await page.locator('#scene-host-description-ch10').textContent();
+  if (primaPressed !== 'true') failures.push(`/journey/chapter/ch10: prima materia button did not become pressed: ${primaPressed}`);
+  if (!primaLabel?.includes('Current emphasis: Prima Materia') || !primaLabel?.includes('The raw state is not a mistake')) failures.push(`/journey/chapter/ch10: prima materia instrument label mismatch: ${primaLabel}`);
+  if (!primaDescription?.includes('Prima Materia: Begin with the mixed thing')) failures.push(`/journey/chapter/ch10: prima materia scene description mismatch: ${primaDescription}`);
+
+  const opus = page.getByRole('button', { name: /03\s+Opus/ });
+  await opus.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const opusPressed = await opus.getAttribute('aria-pressed');
+  const opusLabel = await instrument.getAttribute('aria-label');
+  const opusDescription = await page.locator('#scene-host-description-ch10').textContent();
+  if (opusPressed !== 'true') failures.push(`/journey/chapter/ch10: opus button did not become pressed: ${opusPressed}`);
+  if (!opusLabel?.includes('Current emphasis: Opus') || !opusLabel?.includes('Alchemy gives psychology a theater')) failures.push(`/journey/chapter/ch10: opus instrument label mismatch: ${opusLabel}`);
+  if (!opusDescription?.includes('Opus: Matter teaches psyche')) failures.push(`/journey/chapter/ch10: opus scene description mismatch: ${opusDescription}`);
+}
+
 async function runAccessibilitySmoke() {
   const server = startPreviewServer();
   const failures = [];
@@ -397,10 +436,11 @@ async function runAccessibilitySmoke() {
     await checkChapterSevenDynamicAccessibility(desktop, failures);
     await checkChapterEightDynamicAccessibility(desktop, failures);
     await checkChapterNineDynamicAccessibility(desktop, failures);
+    await checkChapterTenDynamicAccessibility(desktop, failures);
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -671,6 +671,64 @@ async function smokeReducedMotion(browser, failures) {
   if (!chapterNineFallbackText?.includes('fish-serpent') || !chapterNineFallbackText?.includes('salvation and shadow')) {
     failures.push('reduced-motion chapter fallback lost Chapter 9 ambivalent fish teaching summary');
   }
+
+  await page.setViewportSize(mobileViewport);
+  await gotoAppRoute(page, '/journey/chapter/ch10');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterTenFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterTenReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterTenReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterTenReferenceCount = await chapterTenReferenceNodes.count();
+  const chapterTenPanelIds = await chapterTenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterTenPauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterTenCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterTenFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterTenFallbackBox = await page.locator('.scene-host__fallback').boundingBox();
+  const chapterTenFallbackHeadingBox = await page.locator('.scene-host__fallback h2').boundingBox();
+  const chapterTenFallbackBodyBox = await page.locator('.scene-host__fallback p:not(.eyebrow)').boundingBox();
+  const chapterTenInstrumentCount = await page.locator('.alchemical-vessel-instrument').count();
+  const chapterTenInstrumentBox = await page.locator('.alchemical-vessel-instrument').boundingBox();
+  const chapterTenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+  const chapterTenInstrumentMotion = await page.locator('.alchemical-vessel-instrument__field, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__vessel, .alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__fish, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__thread, .alchemical-vessel-instrument__particle, .alchemical-vessel-instrument__stages').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterTenAnimatedParts = chapterTenInstrumentMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterTenTransitioningParts = chapterTenInstrumentMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
+
+  if (!chapterTenFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 10 scene');
+  if (chapterTenReducedMotionAttribute !== 'true') failures.push('Chapter 10 did not record reduced-motion state');
+  if (chapterTenReferenceCount !== 3) failures.push(`reduced-motion Chapter 10 reference node count mismatch: ${chapterTenReferenceCount}`);
+  if (chapterTenPanelIds.join(',') !== 'vessel,prima,opus') failures.push(`reduced-motion Chapter 10 reference nodes out of order: ${chapterTenPanelIds.join(',')}`);
+  if (chapterTenPauseControlCount !== 0) failures.push(`reduced-motion Chapter 10 rendered pause controls: ${chapterTenPauseControlCount}`);
+  if (chapterTenCanvasCount !== 0) failures.push(`reduced-motion Chapter 10 rendered canvas: ${chapterTenCanvasCount}`);
+  if (chapterTenInstrumentCount !== 1) failures.push(`reduced-motion Chapter 10 alchemical vessel instrument count mismatch: ${chapterTenInstrumentCount}`);
+  if (chapterTenAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 10 alchemical vessel instrument still animates: ${JSON.stringify(chapterTenAnimatedParts)}`);
+  if (chapterTenTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 10 alchemical vessel instrument still transitions: ${JSON.stringify(chapterTenTransitioningParts)}`);
+  if (!chapterTenFallbackText?.includes('alchemical vessel') || !chapterTenFallbackText?.includes('fish motif')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 10 alchemical vessel teaching summary');
+  }
+  if (!chapterTenFallbackHeadingBox || chapterTenFallbackHeadingBox.width < 20 || chapterTenFallbackHeadingBox.height < 8) {
+    failures.push(`reduced-motion Chapter 10 fallback heading is not visibly rendered: ${chapterTenFallbackHeadingBox ? `${Math.round(chapterTenFallbackHeadingBox.width)}x${Math.round(chapterTenFallbackHeadingBox.height)}` : 'missing'}`);
+  }
+  if (!chapterTenFallbackBodyBox || chapterTenFallbackBodyBox.width < 40 || chapterTenFallbackBodyBox.height < 8) {
+    failures.push(`reduced-motion Chapter 10 fallback body is not visibly rendered: ${chapterTenFallbackBodyBox ? `${Math.round(chapterTenFallbackBodyBox.width)}x${Math.round(chapterTenFallbackBodyBox.height)}` : 'missing'}`);
+  }
+  if (chapterTenFallbackBox && chapterTenInstrumentBox) {
+    const instrumentBottom = chapterTenInstrumentBox.y + chapterTenInstrumentBox.height;
+    if (chapterTenFallbackBox.y < instrumentBottom + 6) {
+      failures.push(`reduced-motion Chapter 10 fallback overlaps the alchemical vessel instrument on mobile: fallback top ${Math.round(chapterTenFallbackBox.y)}, instrument bottom ${Math.round(instrumentBottom)}`);
+    }
+  }
+  if (chapterTenFallbackBox && chapterTenReferenceMapBox) {
+    const fallbackBottom = chapterTenFallbackBox.y + chapterTenFallbackBox.height;
+    if (fallbackBottom > chapterTenReferenceMapBox.y - 6) {
+      failures.push(`reduced-motion Chapter 10 fallback overlaps the reference map on mobile: fallback bottom ${Math.round(fallbackBottom)}, map top ${Math.round(chapterTenReferenceMapBox.y)}`);
+    }
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -1551,14 +1609,116 @@ async function smokeChapterSceneControls(page, failures) {
   recordCanvasPixelFailure(failures, 'chapter 9', chapterNinePixelSample);
 
   await gotoAppRoute(page, '/journey/chapter/ch10');
-  const opus = page.getByRole('button', { name: /03\s+Opus/ });
-  await activateSceneButton(opus);
-  await page.waitForTimeout(250);
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterTenReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterTenReferenceCount = await chapterTenReferenceNodes.count();
+  const chapterTenPanelIds = await chapterTenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterTenInstrument = page.locator('.alchemical-vessel-instrument');
+  const chapterTenInstrumentCount = await chapterTenInstrument.count();
+  const chapterTenInstrumentRole = await chapterTenInstrument.getAttribute('role');
+  const chapterTenInstrumentLabel = await chapterTenInstrument.getAttribute('aria-label');
+  const chapterTenInstrumentPanel = await chapterTenInstrument.getAttribute('data-active-panel');
+  const chapterTenInstrumentStageCount = await page.locator('.alchemical-vessel-instrument__stage').count();
+  const chapterTenInstrumentParticleCount = await page.locator('.alchemical-vessel-instrument__particle').count();
+  const chapterTenInstrumentLabelCount = await page.locator('.alchemical-vessel-instrument__label').count();
+  const chapterTenInitialDescription = await page.locator('#scene-host-description-ch10').textContent();
+  const chapterTenInstrumentMarksVisible = await page.locator('.alchemical-vessel-instrument__field, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__vessel, .alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__fish, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__thread, .alchemical-vessel-instrument__particle, .alchemical-vessel-instrument__stages').evaluateAll((nodes) => nodes.length >= 14 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterTenReferenceGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="vessel"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="prima"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="opus"] .chapter-stage__reference-mark').evaluateAll((nodes) => nodes.length === 3 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    const before = window.getComputedStyle(node, '::before');
+    const after = window.getComputedStyle(node, '::after');
+    return styles.display !== 'none'
+      && Number(styles.opacity) > 0
+      && box.width > 0
+      && box.height > 0
+      && before.content !== 'none'
+      && after.content !== 'none'
+      && Number.parseFloat(before.width) > 0
+      && Number.parseFloat(before.height) > 0
+      && Number.parseFloat(after.width) > 0
+      && Number.parseFloat(after.height) > 0;
+  }));
+
+  if (chapterTenReferenceCount !== 3) failures.push(`chapter 10 reference node count mismatch: ${chapterTenReferenceCount}`);
+  if (chapterTenPanelIds.join(',') !== 'vessel,prima,opus') failures.push(`chapter 10 reference nodes out of order: ${chapterTenPanelIds.join(',')}`);
+  if (chapterTenInstrumentCount !== 1) failures.push(`chapter 10 alchemical vessel instrument count mismatch: ${chapterTenInstrumentCount}`);
+  if (chapterTenInstrumentStageCount !== 4) failures.push(`chapter 10 alchemical vessel stage count mismatch: ${chapterTenInstrumentStageCount}`);
+  if (chapterTenInstrumentParticleCount !== 4) failures.push(`chapter 10 alchemical vessel particle count mismatch: ${chapterTenInstrumentParticleCount}`);
+  if (chapterTenInstrumentLabelCount !== 3) failures.push(`chapter 10 alchemical vessel label count mismatch: ${chapterTenInstrumentLabelCount}`);
+  if (chapterTenInstrumentRole !== 'img') failures.push(`chapter 10 alchemical vessel instrument role mismatch: ${chapterTenInstrumentRole}`);
+  if (!chapterTenInstrumentLabel?.includes('Alchemical vessel model') || !chapterTenInstrumentLabel?.includes('fish-symbol enters') || !chapterTenInstrumentLabel?.includes('Current emphasis: Alchemy')) {
+    failures.push(`chapter 10 alchemical vessel instrument label missing teaching text: ${chapterTenInstrumentLabel}`);
+  }
+  if (chapterTenInstrumentPanel !== 'vessel') failures.push(`chapter 10 alchemical vessel instrument did not start on vessel panel: ${chapterTenInstrumentPanel}`);
+  if (!chapterTenInitialDescription?.includes('Alchemy: The fish enters the opus')) failures.push(`chapter 10 initial scene description mismatch: ${chapterTenInitialDescription}`);
+  if (!chapterTenInstrumentMarksVisible) failures.push('chapter 10 alchemical vessel instrument marks are not visibly rendered');
+  if (!chapterTenReferenceGlyphsVisible) failures.push('chapter 10 reference glyphs are not visibly rendered');
+
+  const prima = page.locator('.chapter-stage__reference-node[data-panel-id="prima"]');
+  await prima.waitFor({ state: 'visible', timeout: 30_000 });
+  await prima.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(700);
+
+  const primaPressed = await prima.getAttribute('aria-pressed');
+  const primaPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="prima"]').count();
+  const primaDescription = await page.locator('#scene-host-description-ch10').textContent();
+  const primaInstrumentPanel = await chapterTenInstrument.getAttribute('data-active-panel');
+  const primaInstrumentLabel = await chapterTenInstrument.getAttribute('aria-label');
+  const primaVisualState = await page.locator('.alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__particle').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  if (primaPressed !== 'true') failures.push(`chapter 10 prima reference did not become active: ${primaPressed}`);
+  if (primaPanelActive !== 1) failures.push(`chapter 10 prima panel did not become active: ${primaPanelActive}`);
+  if (primaInstrumentPanel !== 'prima') failures.push(`chapter 10 alchemical vessel instrument did not follow prima panel: ${primaInstrumentPanel}`);
+  if (!primaInstrumentLabel?.includes('Current emphasis: Prima Materia') || !primaInstrumentLabel?.includes('The raw state is not a mistake')) {
+    failures.push(`chapter 10 alchemical vessel instrument label did not follow prima panel: ${primaInstrumentLabel}`);
+  }
+  if (primaVisualState.length !== 6 || !primaVisualState.every((opacity) => opacity >= 0.62)) {
+    failures.push(`chapter 10 alchemical vessel instrument did not visually emphasize prima materia: ${primaVisualState.join(',')}`);
+  }
+  if (!primaDescription?.includes('Prima Materia: Begin with the mixed thing')) failures.push(`chapter 10 scene description did not follow prima panel: ${primaDescription}`);
+
+  const opus = page.locator('.chapter-stage__reference-node[data-panel-id="opus"]');
+  await opus.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(700);
 
   const opusPressed = await opus.getAttribute('aria-pressed');
+  const opusPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="opus"]').count();
+  const opusDescription = await page.locator('#scene-host-description-ch10').textContent();
+  const opusInstrumentPanel = await chapterTenInstrument.getAttribute('data-active-panel');
+  const opusInstrumentLabel = await chapterTenInstrument.getAttribute('aria-label');
+  const opusVisualState = await page.locator('.alchemical-vessel-instrument__stages, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__thread--ascent').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   const chapterTenScrollY = await page.evaluate(() => window.scrollY);
   if (opusPressed !== 'true') failures.push(`chapter 10 scene control did not become active: ${opusPressed}`);
+  if (opusPanelActive !== 1) failures.push(`chapter 10 opus panel did not become active: ${opusPanelActive}`);
+  if (opusInstrumentPanel !== 'opus') failures.push(`chapter 10 alchemical vessel instrument did not follow opus panel: ${opusInstrumentPanel}`);
+  if (!opusInstrumentLabel?.includes('Current emphasis: Opus') || !opusInstrumentLabel?.includes('Alchemy gives psychology a theater')) {
+    failures.push(`chapter 10 alchemical vessel instrument label did not follow opus panel: ${opusInstrumentLabel}`);
+  }
+  if (opusVisualState.length !== 4 || !opusVisualState.every((opacity) => opacity >= 0.65)) {
+    failures.push(`chapter 10 alchemical vessel instrument did not visually emphasize opus: ${opusVisualState.join(',')}`);
+  }
+  if (!opusDescription?.includes('Opus: Matter teaches psyche')) failures.push(`chapter 10 scene description did not follow opus panel: ${opusDescription}`);
   if (chapterTenScrollY > 10) failures.push(`chapter 10 scene control unexpectedly scrolled page: ${chapterTenScrollY}`);
+
+  const chapterTenCanvas = page.locator('.scene-host canvas').first();
+  const chapterTenCanvasCount = await chapterTenCanvas.count();
+  const chapterTenFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  if (chapterTenCanvasCount !== 1) {
+    failures.push(`chapter 10 expected one ready canvas but found ${chapterTenCanvasCount}; fallback visible: ${chapterTenFallbackVisible}`);
+  } else {
+    const chapterTenCanvasBox = await chapterTenCanvas.boundingBox();
+    const chapterTenPixelSample = await waitForCanvasPixels(chapterTenCanvas);
+    if (!chapterTenCanvasBox || chapterTenCanvasBox.width < 300 || chapterTenCanvasBox.height < 300) {
+      failures.push(`chapter 10 canvas geometry too small: ${chapterTenCanvasBox ? `${Math.round(chapterTenCanvasBox.width)}x${Math.round(chapterTenCanvasBox.height)}` : 'missing'}`);
+    }
+    recordCanvasPixelFailure(failures, 'chapter 10', chapterTenPixelSample);
+  }
 
   await gotoAppRoute(page, '/journey/chapter/ch11');
   const stone = page.getByRole('button', { name: /03\s+Stone/ });
@@ -1603,7 +1763,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -1914,6 +2074,45 @@ async function smokeMobile(page, failures) {
       if (chapterNineCanvasCount > 0) {
         const chapterNinePixelSample = await waitForCanvasPixels(chapterNineCanvas);
         recordCanvasPixelFailure(failures, `mobile chapter 9 at ${viewport.width}x${viewport.height}`, chapterNinePixelSample);
+      }
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch10');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterTenNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterTenHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterTenReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterTenReferenceCount = await chapterTenReferenceNodes.count();
+    const chapterTenPanelIds = await chapterTenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterTenScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterTenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const chapterTenInstrumentBox = await page.locator('.alchemical-vessel-instrument').boundingBox();
+    if (!chapterTenNavBox || !chapterTenHeadingBox) {
+      failures.push(`mobile chapter 10 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterTenNavBottom = chapterTenNavBox.y + chapterTenNavBox.height;
+    if (chapterTenNavBottom > chapterTenHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 10 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterTenNavBottom)}, heading top ${Math.round(chapterTenHeadingBox.y)}`);
+    }
+    if (chapterTenReferenceCount !== 3) failures.push(`mobile chapter 10 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterTenReferenceCount}`);
+    if (chapterTenPanelIds.join(',') !== 'vessel,prima,opus') failures.push(`mobile chapter 10 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterTenPanelIds.join(',')}`);
+    if (chapterTenScrollWidth > viewport.width + 2) failures.push(`mobile chapter 10 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterTenScrollWidth}`);
+    if (chapterTenReferenceMapBox && chapterTenReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 10 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterTenReferenceMapBox.width)}`);
+    }
+    if (!chapterTenInstrumentBox) failures.push(`mobile chapter 10 alchemical vessel instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterTenInstrumentBox && chapterTenInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 10 alchemical vessel instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterTenInstrumentBox.width)}`);
+    }
+
+    if (viewport.width === mobileViewport.width) {
+      const chapterTenCanvas = page.locator('.scene-host canvas').first();
+      const chapterTenCanvasCount = await chapterTenCanvas.count();
+      if (chapterTenCanvasCount > 0) {
+        const chapterTenPixelSample = await waitForCanvasPixels(chapterTenCanvas);
+        recordCanvasPixelFailure(failures, `mobile chapter 10 at ${viewport.width}x${viewport.height}`, chapterTenPixelSample);
       }
     }
   }

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -19,7 +19,7 @@ const canonicalRoutes = [
   ...Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`),
 ];
 
-const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch14'];
+const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch14'];
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -20,6 +20,7 @@ const rootLines = ['left', 'center', 'right'] as const;
 const zodiacMarkers = ['AR', 'TA', 'GE', 'CN', 'LE', 'VI', 'LI', 'SC', 'SG', 'CP', 'AQ', 'PI'] as const;
 const prophecyTicks = ['0', '1000', '1555', '2000'] as const;
 const historicalStrataLayers = ['vision', 'carrier', 'healing', 'aeon', 'depth'] as const;
+const alchemicalOpusStages = ['nigredo', 'albedo', 'citrinitas', 'rubedo'] as const;
 
 function useReducedMotionPreference() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
@@ -66,6 +67,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const prophecyFieldInstrumentLabel = `Prophecy field model: historical pressure gathers around a time axis, private fear projects into a shared symbolic image-field, and the threshold mirror shows the future looking backward into older archetypal forms. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const historicalStrataInstrumentLabel = `Historical strata model: five translucent layers accumulate around the fish motif, an early Christian carrier image gathers the symbol into a readable form, and older meanings keep speaking below later interpretation. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const ambivalentFishInstrumentLabel = `Ambivalent fish model: one fish-symbol carries blessing and threat across a split field, an ouroboric return shows opposition circling back into itself, and the shadow fish keeps the Antichrist counter-pole inside the total image. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
+  const alchemicalVesselInstrumentLabel = `Alchemical vessel model: the fish-symbol enters a sealed vessel, prima materia gathers as unsettled particles, heat presses the image through four opus stages, and a lapis point appears as transformation takes form. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
 
   useEffect(() => {
     setActivePanelId(experience.panels[0]?.id || '');
@@ -319,6 +321,36 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--paradox" aria-hidden="true">double edge</span>
               <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--return" aria-hidden="true">return</span>
               <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--shadow" aria-hidden="true">counter-pole</span>
+            </div>
+          )}
+          {chapter.id === 'ch10' && (
+            <div
+              className="alchemical-vessel-instrument"
+              data-active-panel={activePanelId}
+              role="img"
+              aria-label={alchemicalVesselInstrumentLabel}
+            >
+              <span className="alchemical-vessel-instrument__field" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__heat" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__vessel" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__bath" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__fish" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__magnet" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__lapis" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__thread alchemical-vessel-instrument__thread--descent" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__thread alchemical-vessel-instrument__thread--ascent" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__particle alchemical-vessel-instrument__particle--one" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__particle alchemical-vessel-instrument__particle--two" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__particle alchemical-vessel-instrument__particle--three" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__particle alchemical-vessel-instrument__particle--four" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__stages" aria-hidden="true">
+                {alchemicalOpusStages.map((stage) => (
+                  <span key={stage} className={`alchemical-vessel-instrument__stage alchemical-vessel-instrument__stage--${stage}`} />
+                ))}
+              </span>
+              <span className="alchemical-vessel-instrument__label alchemical-vessel-instrument__label--fish" aria-hidden="true">fish enters</span>
+              <span className="alchemical-vessel-instrument__label alchemical-vessel-instrument__label--prima" aria-hidden="true">prima materia</span>
+              <span className="alchemical-vessel-instrument__label alchemical-vessel-instrument__label--opus" aria-hidden="true">opus stages</span>
             </div>
           )}
           <div className="chapter-stage__thesis-map" aria-label="Chapter visual sequence">

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -5548,6 +5548,502 @@ h3 {
     0 0 1.65rem rgba(83, 216, 232, 0.18);
 }
 
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro h1 {
+  max-width: 13.75ch;
+  font-size: clamp(3.5rem, 5.7vw, 5.15rem);
+  line-height: 0.92;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro p:not(.eyebrow) {
+  max-width: 27rem;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__thesis-map {
+  max-width: 30rem;
+  margin-top: 0.82rem;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-map {
+  width: min(26rem, 100%);
+  margin-top: 0.66rem;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-node {
+  min-height: 3.8rem;
+  background:
+    radial-gradient(circle at 43% 32%, rgba(255, 227, 156, 0.12), transparent 2.3rem),
+    radial-gradient(circle at 63% 66%, rgba(83, 216, 232, 0.1), transparent 2.4rem),
+    linear-gradient(180deg, rgba(10, 8, 12, 0.66), rgba(4, 3, 8, 0.36));
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-label {
+  margin-top: 2.04rem;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__scrim {
+  background:
+    linear-gradient(180deg, rgba(3, 3, 7, 0.75), rgba(3, 3, 7, 0.38) 48%, rgba(3, 3, 7, 0.82)),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.96), rgba(3, 3, 7, 0.52) 58%, rgba(3, 3, 7, 0.28)),
+    radial-gradient(circle at 30% 51%, rgba(212, 175, 55, 0.16), transparent 32%),
+    radial-gradient(circle at 60% 60%, rgba(83, 216, 232, 0.12), transparent 38%),
+    radial-gradient(circle at 74% 72%, rgba(194, 55, 43, 0.1), transparent 33%);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-node[data-panel-id="vessel"] .chapter-stage__reference-mark::before {
+  top: 0.82rem;
+  width: 2.3rem;
+  height: 2.25rem;
+  border: 1px solid rgba(143, 231, 237, 0.34);
+  border-radius: 48% 48% 54% 54%;
+  background:
+    radial-gradient(circle at 50% 62%, rgba(212, 175, 55, 0.18), transparent 50%),
+    linear-gradient(180deg, rgba(143, 231, 237, 0.08), transparent);
+  box-shadow:
+    inset 0 0 1rem rgba(143, 231, 237, 0.1),
+    0 0 1.2rem rgba(83, 216, 232, 0.14);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-node[data-panel-id="vessel"] .chapter-stage__reference-mark::after {
+  top: 1.74rem;
+  width: 1.8rem;
+  height: 0.32rem;
+  border-radius: 50%;
+  background: rgba(255, 227, 156, 0.64);
+  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.28);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-node[data-panel-id="prima"] .chapter-stage__reference-mark::before {
+  top: 1rem;
+  width: 2.2rem;
+  height: 1.45rem;
+  border: 1px solid rgba(181, 130, 255, 0.25);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 28% 52%, rgba(83, 216, 232, 0.75) 0 0.12rem, transparent 0.14rem),
+    radial-gradient(circle at 58% 35%, rgba(255, 227, 156, 0.64) 0 0.1rem, transparent 0.12rem),
+    radial-gradient(circle at 69% 70%, rgba(194, 55, 43, 0.58) 0 0.1rem, transparent 0.12rem),
+    radial-gradient(ellipse at 50% 50%, rgba(181, 130, 255, 0.1), transparent 72%);
+  box-shadow: 0 0 1.2rem rgba(181, 130, 255, 0.16);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-node[data-panel-id="prima"] .chapter-stage__reference-mark::after {
+  top: 0.62rem;
+  height: 2.28rem;
+  background: linear-gradient(180deg, transparent, rgba(143, 231, 237, 0.38), transparent);
+  transform: translateX(-50%) rotate(18deg);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-node[data-panel-id="opus"] .chapter-stage__reference-mark::before {
+  top: 1.42rem;
+  width: 2.5rem;
+  height: 0.44rem;
+  border: 1px solid rgba(255, 227, 156, 0.22);
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, rgba(18, 18, 22, 0.86), rgba(232, 232, 240, 0.64), rgba(255, 215, 0, 0.72), rgba(194, 55, 43, 0.72));
+  box-shadow: 0 0 1.1rem rgba(212, 175, 55, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-node[data-panel-id="opus"] .chapter-stage__reference-mark::after {
+  top: 0.92rem;
+  width: 0.58rem;
+  height: 0.58rem;
+  border-radius: 50%;
+  background: rgba(255, 227, 156, 0.9);
+  box-shadow:
+    0 0 0 0.34rem rgba(212, 175, 55, 0.08),
+    0 0 1.15rem rgba(212, 175, 55, 0.36);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument {
+  position: relative;
+  width: min(31rem, 100%);
+  min-height: clamp(6.8rem, 10.2vh, 7.85rem);
+  overflow: hidden;
+  margin-top: 0.78rem;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 29% 58%, rgba(83, 216, 232, 0.13), transparent 4.6rem),
+    radial-gradient(circle at 52% 56%, rgba(212, 175, 55, 0.16), transparent 4.5rem),
+    radial-gradient(circle at 78% 70%, rgba(194, 55, 43, 0.12), transparent 4.6rem),
+    linear-gradient(90deg, rgba(7, 8, 13, 0.86), rgba(11, 9, 12, 0.72) 48%, rgba(19, 8, 7, 0.62));
+  box-shadow:
+    var(--shadow-inset),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.24);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::before,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::before {
+  inset: 0.58rem;
+  border: 1px solid rgba(255, 227, 156, 0.08);
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::after {
+  left: 50%;
+  bottom: 1.02rem;
+  width: 58%;
+  height: 0.06rem;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.28), transparent);
+  box-shadow: 0 0 1.2rem rgba(244, 240, 232, 0.1);
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__field,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__heat,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label {
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__field {
+  inset: 0.62rem;
+  border-radius: calc(var(--radius) - 4px);
+  background:
+    linear-gradient(90deg, rgba(83, 216, 232, 0.08), transparent 48%, rgba(194, 55, 43, 0.09)),
+    radial-gradient(circle at 50% 68%, rgba(212, 175, 55, 0.1), transparent 52%);
+  opacity: 0.68;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel {
+  left: 50%;
+  top: 50%;
+  width: 6.25rem;
+  height: 5.35rem;
+  border: 1px solid rgba(143, 231, 237, 0.34);
+  border-top-color: rgba(244, 240, 232, 0.18);
+  border-radius: 45% 45% 52% 52%;
+  background:
+    linear-gradient(90deg, transparent 46%, rgba(244, 240, 232, 0.16) 49%, transparent 52%),
+    radial-gradient(ellipse at 50% 62%, rgba(255, 227, 156, 0.12), transparent 70%);
+  box-shadow:
+    inset 0 0 1.25rem rgba(143, 231, 237, 0.1),
+    0 0 1.7rem rgba(83, 216, 232, 0.14);
+  opacity: 0.74;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath {
+  left: 50%;
+  top: 59%;
+  width: 4.8rem;
+  height: 1.18rem;
+  border-radius: 50%;
+  background:
+    radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.26), transparent 68%),
+    linear-gradient(90deg, rgba(83, 216, 232, 0.18), rgba(212, 175, 55, 0.14), rgba(194, 55, 43, 0.12));
+  box-shadow: 0 0 1.35rem rgba(83, 216, 232, 0.14);
+  opacity: 0.64;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish {
+  left: 26%;
+  top: 51%;
+  width: 3.58rem;
+  height: 1.06rem;
+  border-radius: 50%;
+  border-top: 1px solid rgba(255, 227, 156, 0.58);
+  border-bottom: 1px solid rgba(143, 231, 237, 0.34);
+  background:
+    radial-gradient(circle at 31% 50%, rgba(255, 227, 156, 0.78) 0 0.14rem, transparent 0.16rem),
+    radial-gradient(ellipse at 52% 50%, rgba(212, 175, 55, 0.18), rgba(83, 216, 232, 0.08) 64%, transparent 72%);
+  box-shadow: 0 0 1.35rem rgba(212, 175, 55, 0.2);
+  opacity: 0.86;
+  transform: translate(-50%, -50%) rotate(-7deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish::after {
+  content: '';
+  position: absolute;
+  right: -0.32rem;
+  top: 50%;
+  width: 0.66rem;
+  height: 0.66rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.46);
+  border-right: 1px solid rgba(255, 227, 156, 0.32);
+  border-radius: 0.08rem;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet {
+  left: 64%;
+  top: 43%;
+  width: 1.05rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(181, 130, 255, 0.34);
+  border-radius: 0.2rem;
+  background: rgba(181, 130, 255, 0.16);
+  box-shadow:
+    0 0 0 0.48rem rgba(181, 130, 255, 0.04),
+    0 0 1.35rem rgba(181, 130, 255, 0.18);
+  opacity: 0.62;
+  transform: translate(-50%, -50%) rotate(45deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis {
+  left: 72%;
+  top: 62%;
+  width: 1.1rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(255, 227, 156, 0.38);
+  border-radius: 35%;
+  background:
+    radial-gradient(circle at 44% 38%, rgba(255, 227, 156, 0.95), rgba(212, 175, 55, 0.34) 52%, rgba(194, 55, 43, 0.14));
+  box-shadow:
+    0 0 0 0.48rem rgba(212, 175, 55, 0.05),
+    0 0 1.35rem rgba(212, 175, 55, 0.2);
+  opacity: 0.58;
+  transform: translate(-50%, -50%) rotate(18deg) scale(0.86);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__heat {
+  left: 50%;
+  bottom: 1.26rem;
+  width: 5rem;
+  height: 1.22rem;
+  border-radius: 50%;
+  background:
+    radial-gradient(ellipse at 50% 70%, rgba(194, 55, 43, 0.38), rgba(212, 175, 55, 0.18) 46%, transparent 72%);
+  filter: blur(0.08rem);
+  opacity: 0.58;
+  transform: translateX(-50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread {
+  left: 50%;
+  top: 50%;
+  width: 9.2rem;
+  height: 3.4rem;
+  border-radius: 50%;
+  opacity: 0.38;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread--descent {
+  border-top: 1px solid rgba(83, 216, 232, 0.22);
+  transform: translate(-50%, -50%) rotate(-13deg);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread--ascent {
+  border-bottom: 1px solid rgba(255, 227, 156, 0.24);
+  transform: translate(-50%, -50%) rotate(12deg);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle {
+  width: 0.32rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: rgba(143, 231, 237, 0.78);
+  box-shadow: 0 0 0.85rem rgba(83, 216, 232, 0.28);
+  opacity: 0.58;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    background 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle--one {
+  left: 43%;
+  top: 42%;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle--two {
+  left: 48%;
+  top: 63%;
+  background: rgba(255, 227, 156, 0.72);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle--three {
+  left: 55%;
+  top: 38%;
+  background: rgba(181, 130, 255, 0.68);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle--four {
+  left: 58%;
+  top: 58%;
+  background: rgba(194, 55, 43, 0.7);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages {
+  left: 50%;
+  bottom: 1.08rem;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.18rem;
+  width: 13.2rem;
+  max-width: 64%;
+  height: 0.54rem;
+  padding: 0.08rem;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.48);
+  opacity: 0.72;
+  transform: translateX(-50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stage {
+  min-width: 0;
+  border-radius: 999px;
+  opacity: 0.66;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stage--nigredo {
+  background: rgba(18, 18, 22, 0.96);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stage--albedo {
+  background: rgba(232, 232, 240, 0.7);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stage--citrinitas {
+  background: rgba(255, 215, 0, 0.72);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stage--rubedo {
+  background: rgba(194, 55, 43, 0.78);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label--fish {
+  left: 7%;
+  top: 14%;
+  color: rgba(255, 227, 156, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label--prima {
+  left: 42%;
+  top: 14%;
+  color: rgba(143, 231, 237, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label--opus {
+  right: 5%;
+  top: 14%;
+  color: rgba(255, 173, 112, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__vessel,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__fish,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__thread--descent {
+  opacity: 1;
+  box-shadow:
+    inset 0 0 1.25rem rgba(143, 231, 237, 0.13),
+    0 0 1.75rem rgba(83, 216, 232, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__fish {
+  transform: translate(-34%, -50%) rotate(-4deg) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__bath,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__magnet,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__particle {
+  opacity: 1;
+  filter: saturate(1.18);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__magnet {
+  box-shadow:
+    0 0 0 0.64rem rgba(181, 130, 255, 0.07),
+    0 0 1.55rem rgba(181, 130, 255, 0.26);
+  transform: translate(-50%, -50%) rotate(45deg) scale(1.14);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__particle--one {
+  transform: translate(-0.4rem, -0.2rem) scale(1.18);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__particle--two {
+  transform: translate(0.22rem, 0.12rem) scale(1.2);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__particle--three {
+  transform: translate(0.38rem, -0.22rem) scale(1.18);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__particle--four {
+  transform: translate(-0.18rem, 0.28rem) scale(1.16);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__stages,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__heat,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__lapis,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__thread--ascent {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__stages {
+  transform: translateX(-50%) scaleX(1.04);
+  box-shadow: 0 0 1.2rem rgba(212, 175, 55, 0.13);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__heat {
+  transform: translateX(-50%) scaleX(1.18);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__lapis {
+  box-shadow:
+    0 0 0 0.58rem rgba(212, 175, 55, 0.08),
+    0 0 1.6rem rgba(212, 175, 55, 0.34);
+  transform: translate(-50%, -50%) rotate(18deg) scale(1.12);
+}
+
 .chapter-experience[data-chapter-id="ch3"][data-reduced-motion="true"] .scene-host__fallback {
   left: auto;
   right: clamp(1rem, 4vw, 3.5rem);
@@ -7361,6 +7857,16 @@ h3 {
 		  .ambivalent-fish-instrument__fish,
 		  .ambivalent-fish-instrument__junction,
 		  .ambivalent-fish-instrument__shadow-core,
+		  .alchemical-vessel-instrument__field,
+		  .alchemical-vessel-instrument__heat,
+		  .alchemical-vessel-instrument__vessel,
+		  .alchemical-vessel-instrument__bath,
+		  .alchemical-vessel-instrument__fish,
+		  .alchemical-vessel-instrument__magnet,
+		  .alchemical-vessel-instrument__lapis,
+		  .alchemical-vessel-instrument__thread,
+		  .alchemical-vessel-instrument__particle,
+		  .alchemical-vessel-instrument__stages,
 		  .chapters-orbit__node,
 		  .home-chapter-orbit__item a,
 		  .scene-host__pause {
@@ -7435,6 +7941,19 @@ h3 {
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish,
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__junction,
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core {
+	    transition: none;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__field,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__heat,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages {
 	    transition: none;
 	  }
 		}
@@ -8968,6 +9487,157 @@ h3 {
 	    overflow: hidden;
 	    clip: rect(0, 0, 0, 0);
 	    white-space: nowrap;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro {
+	    justify-content: flex-start;
+	    padding-top: 10.25rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .chapter-sigil {
+	    display: none;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro h1 {
+	    max-width: 9.4ch;
+	    font-size: clamp(2.05rem, 10.5vw, 2.8rem);
+	    line-height: 0.92;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro p:not(.eyebrow) {
+	    margin-top: 0.68rem;
+	    max-width: 29ch;
+	    font-size: 0.9rem;
+	    line-height: 1.47;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .scene-host__pause {
+	    justify-content: center;
+	    width: 2.35rem;
+	    min-width: 2.35rem;
+	    padding-inline: 0;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .scene-host__pause span:not(.scene-host__pause-icon) {
+	    position: absolute;
+	    width: 1px;
+	    height: 1px;
+	    overflow: hidden;
+	    clip: rect(0, 0, 0, 0);
+	    white-space: nowrap;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument {
+	    min-height: 6.65rem;
+	    margin-top: 0.66rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::before {
+	    inset: 0.5rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel {
+	    width: 4.9rem;
+	    height: 4.35rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath {
+	    width: 3.85rem;
+	    height: 1rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish {
+	    left: 24%;
+	    width: 2.95rem;
+	    height: 0.92rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet {
+	    left: 65%;
+	    width: 0.88rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis {
+	    left: 74%;
+	    width: 0.92rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread {
+	    width: 6.35rem;
+	    height: 2.9rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages {
+	    width: 10.1rem;
+	    max-width: 62%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label {
+	    font-size: 0.5rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label--fish {
+	    left: 6%;
+	    top: 12%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label--prima {
+	    left: 39%;
+	    top: 12%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label--opus {
+	    right: 4%;
+	    top: 12%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback {
+	    left: 1rem;
+	    right: 1rem;
+	    top: 32.9rem;
+	    width: auto;
+	    padding: 0.38rem 0.64rem;
+	    text-align: left;
+	    transform: none;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .alchemical-vessel-instrument {
+	    min-height: 5.55rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .chapter-stage__reference-map {
+	    margin-top: 0.75rem;
+	    transform: translateY(0.5rem);
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
+	    margin: 0;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback h2,
+	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+	    position: static;
+	    width: auto;
+	    height: auto;
+	    overflow: visible;
+	    clip: auto;
+	    white-space: normal;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback h2 {
+	    margin: 0.08rem 0 0;
+	    font-size: 0.82rem;
+	    line-height: 0.96;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+	    display: -webkit-box;
+	    margin-top: 0.18rem;
+	    font-size: 0.64rem;
+	    line-height: 1.24;
+	    -webkit-line-clamp: 2;
+	    -webkit-box-orient: vertical;
+	    overflow: hidden;
 	  }
 
 	  .home-hero {

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -222,6 +222,31 @@ describe('Aion framework data contract', () => {
       'antichrist',
     ]);
   });
+
+  test('keeps Chapter 10 alchemical fish panels tied to vessel and prima materia', () => {
+    expect(CHAPTER_SCENES.ch10.panels.map((panel) => panel.id)).toEqual([
+      'vessel',
+      'prima',
+      'opus',
+    ]);
+    expect(CHAPTER_SCENES.ch10.panels.map((panel) => panel.kicker)).toEqual([
+      'Alchemy',
+      'Prima Materia',
+      'Opus',
+    ]);
+    expect(CHAPTER_SCENES.ch10.motionGrammar).toBe('transformation');
+    expect(CHAPTER_SCENES.ch10.visualTheme).toContain('Alchemical fish vessel');
+    expect(CHAPTER_SCENES.ch10.sceneModule).toBe('../visualizations/chapters/ch10/ThreeAlchemyViz.js');
+    expect(CHAPTER_SCENES.ch10.fallbackSummary).toContain('alchemical vessel');
+    expect(CHAPTER_SCENES.ch10.fallbackSummary).toContain('fish motif');
+    expect(CHAPTER_SCENES.ch10.fallbackSummary).toContain('reddening');
+
+    expect(getConceptsForChapter('ch10').map((concept) => concept.id)).toEqual([
+      'alchemy',
+      'prima-materia',
+      'fish-symbol',
+    ]);
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- Add a Chapter 10 alchemical vessel instrument that teaches fish-symbol entry, prima materia, and opus transformation with visual states tied to the active panel.
- Tune Chapter 10 mobile layout and reduced-motion fallback so the visual teaching surface stays legible without canvas motion.
- Expand contract, shell, accessibility, mobile, reduced-motion, nonblank canvas, and Pages artifact smoke coverage for the Chapter 10 route.

## Visual thesis
Chapter 10 now reads as a compact alchemical laboratory: the fish enters a sealed vessel, unsettled particles gather as prima materia, heat carries the image through the opus, and the lapis appears as transformation becomes visible.

## Routes verified
- /journey/chapter/ch10
- Whole app shell and canonical route suite via existing smoke coverage

## Local verification
- node --check scripts/testing/app-shell-smoke.mjs
- node --check scripts/testing/app-accessibility-smoke.mjs
- node --check scripts/testing/pages-artifact-smoke.mjs
- git diff --check
- rg -n "^(<<<<<<<|=======|>>>>>>>)" .
- npm run test:e2e:app
- npm run test:a11y:app
- npm run test:visual:control-tower
- npm run lint
- npx tsc --noEmit
- npm run test:app
- npm run validate:consistency
- npm run ci:chapter-shell
- npm test
- npm run build:pages
- npm run test:pages:artifact

## Visual QA evidence
- Control tower report: test-results/control-tower/route-scores.md
- Chapter 10 score: 100%, no blockers
- Chapter 10 mobile/narrow overflow: 0px, no blockers
- Reduced-motion mobile probe: no console/network errors, no canvas, visible fallback text, no horizontal overflow