### PR TITLE
feat: polish chapter eleven opus wheel

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -418,6 +418,45 @@ async function checkChapterTenDynamicAccessibility(page, failures) {
   if (!opusDescription?.includes('Opus: Matter teaches psyche')) failures.push(`/journey/chapter/ch10: opus scene description mismatch: ${opusDescription}`);
 }
 
+async function checkChapterElevenDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/journey/chapter/ch11`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+  const instrument = page.getByRole('img', { name: /Philosophical tree model/ });
+  const instrumentVisible = await instrument.isVisible();
+  const initialInstrumentLabel = await instrument.getAttribute('aria-label');
+  const initialDescription = await page.locator('#scene-host-description-ch11').textContent();
+
+  if (!instrumentVisible) failures.push('/journey/chapter/ch11: philosophical tree instrument is missing an accessible image role');
+  if (!initialInstrumentLabel?.includes('Current emphasis: Mediator') || !initialInstrumentLabel?.includes('Mercurius holds the middle')) failures.push(`/journey/chapter/ch11: initial instrument label mismatch: ${initialInstrumentLabel}`);
+  if (!initialDescription?.includes('Mediator: The slippery middle')) failures.push(`/journey/chapter/ch11: initial scene description mismatch: ${initialDescription}`);
+
+  const opus = page.getByRole('button', { name: /02\s+Opus/ });
+  await opus.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const opusPressed = await opus.getAttribute('aria-pressed');
+  const opusLabel = await instrument.getAttribute('aria-label');
+  const opusDescription = await page.locator('#scene-host-description-ch11').textContent();
+  if (opusPressed !== 'true') failures.push(`/journey/chapter/ch11: opus button did not become pressed: ${opusPressed}`);
+  if (!opusLabel?.includes('Current emphasis: Opus') || !opusLabel?.includes('Change returns to deepen itself')) failures.push(`/journey/chapter/ch11: opus instrument label mismatch: ${opusLabel}`);
+  if (!opusDescription?.includes('Opus: Transformation repeats')) failures.push(`/journey/chapter/ch11: opus scene description mismatch: ${opusDescription}`);
+
+  const stone = page.getByRole('button', { name: /03\s+Stone/ });
+  await stone.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const stonePressed = await stone.getAttribute('aria-pressed');
+  const stoneLabel = await instrument.getAttribute('aria-label');
+  const stoneDescription = await page.locator('#scene-host-description-ch11').textContent();
+  if (stonePressed !== 'true') failures.push(`/journey/chapter/ch11: stone button did not become pressed: ${stonePressed}`);
+  if (!stoneLabel?.includes('Current emphasis: Stone') || !stoneLabel?.includes('Completion keeps the opposites alive')) failures.push(`/journey/chapter/ch11: stone instrument label mismatch: ${stoneLabel}`);
+  if (!stoneDescription?.includes('Stone: The goal is a formed paradox')) failures.push(`/journey/chapter/ch11: stone scene description mismatch: ${stoneDescription}`);
+}
+
 async function runAccessibilitySmoke() {
   const server = startPreviewServer();
   const failures = [];
@@ -437,10 +476,11 @@ async function runAccessibilitySmoke() {
     await checkChapterEightDynamicAccessibility(desktop, failures);
     await checkChapterNineDynamicAccessibility(desktop, failures);
     await checkChapterTenDynamicAccessibility(desktop, failures);
+    await checkChapterElevenDynamicAccessibility(desktop, failures);
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -729,6 +729,63 @@ async function smokeReducedMotion(browser, failures) {
       failures.push(`reduced-motion Chapter 10 fallback overlaps the reference map on mobile: fallback bottom ${Math.round(fallbackBottom)}, map top ${Math.round(chapterTenReferenceMapBox.y)}`);
     }
   }
+
+  await gotoAppRoute(page, '/journey/chapter/ch11');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterElevenFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterElevenReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterElevenReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterElevenReferenceCount = await chapterElevenReferenceNodes.count();
+  const chapterElevenPanelIds = await chapterElevenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterElevenPauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterElevenCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterElevenFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterElevenFallbackBox = await page.locator('.scene-host__fallback').boundingBox();
+  const chapterElevenFallbackHeadingBox = await page.locator('.scene-host__fallback h2').boundingBox();
+  const chapterElevenFallbackBodyBox = await page.locator('.scene-host__fallback p:not(.eyebrow)').boundingBox();
+  const chapterElevenInstrumentCount = await page.locator('.alchemical-tree-instrument').count();
+  const chapterElevenInstrumentBox = await page.locator('.alchemical-tree-instrument').boundingBox();
+  const chapterElevenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+  const chapterElevenInstrumentMotion = await page.locator('.alchemical-tree-instrument__field, .alchemical-tree-instrument__root, .alchemical-tree-instrument__trunk, .alchemical-tree-instrument__branch, .alchemical-tree-instrument__thread, .alchemical-tree-instrument__mercurius, .alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__stone, .alchemical-tree-instrument__reflection').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterElevenAnimatedParts = chapterElevenInstrumentMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterElevenTransitioningParts = chapterElevenInstrumentMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
+
+  if (!chapterElevenFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 11 scene');
+  if (chapterElevenReducedMotionAttribute !== 'true') failures.push('Chapter 11 did not record reduced-motion state');
+  if (chapterElevenReferenceCount !== 3) failures.push(`reduced-motion Chapter 11 reference node count mismatch: ${chapterElevenReferenceCount}`);
+  if (chapterElevenPanelIds.join(',') !== 'mercurius,opus-wheel,lapis') failures.push(`reduced-motion Chapter 11 reference nodes out of order: ${chapterElevenPanelIds.join(',')}`);
+  if (chapterElevenPauseControlCount !== 0) failures.push(`reduced-motion Chapter 11 rendered pause controls: ${chapterElevenPauseControlCount}`);
+  if (chapterElevenCanvasCount !== 0) failures.push(`reduced-motion Chapter 11 rendered canvas: ${chapterElevenCanvasCount}`);
+  if (chapterElevenInstrumentCount !== 1) failures.push(`reduced-motion Chapter 11 alchemical tree instrument count mismatch: ${chapterElevenInstrumentCount}`);
+  if (chapterElevenAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 11 alchemical tree instrument still animates: ${JSON.stringify(chapterElevenAnimatedParts)}`);
+  if (chapterElevenTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 11 alchemical tree instrument still transitions: ${JSON.stringify(chapterElevenTransitioningParts)}`);
+  if (!chapterElevenFallbackText?.includes('Mercurius') || !chapterElevenFallbackText?.includes('opus cycle')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 11 alchemical interpretation teaching summary');
+  }
+  if (!chapterElevenFallbackHeadingBox || chapterElevenFallbackHeadingBox.width < 20 || chapterElevenFallbackHeadingBox.height < 8) {
+    failures.push(`reduced-motion Chapter 11 fallback heading is not visibly rendered: ${chapterElevenFallbackHeadingBox ? `${Math.round(chapterElevenFallbackHeadingBox.width)}x${Math.round(chapterElevenFallbackHeadingBox.height)}` : 'missing'}`);
+  }
+  if (!chapterElevenFallbackBodyBox || chapterElevenFallbackBodyBox.width < 40 || chapterElevenFallbackBodyBox.height < 8) {
+    failures.push(`reduced-motion Chapter 11 fallback body is not visibly rendered: ${chapterElevenFallbackBodyBox ? `${Math.round(chapterElevenFallbackBodyBox.width)}x${Math.round(chapterElevenFallbackBodyBox.height)}` : 'missing'}`);
+  }
+  if (chapterElevenFallbackBox && chapterElevenInstrumentBox) {
+    const instrumentBottom = chapterElevenInstrumentBox.y + chapterElevenInstrumentBox.height;
+    if (chapterElevenFallbackBox.y < instrumentBottom + 6) {
+      failures.push(`reduced-motion Chapter 11 fallback overlaps the alchemical tree instrument on mobile: fallback top ${Math.round(chapterElevenFallbackBox.y)}, instrument bottom ${Math.round(instrumentBottom)}`);
+    }
+  }
+  if (chapterElevenFallbackBox && chapterElevenReferenceMapBox) {
+    const fallbackBottom = chapterElevenFallbackBox.y + chapterElevenFallbackBox.height;
+    if (fallbackBottom > chapterElevenReferenceMapBox.y - 6) {
+      failures.push(`reduced-motion Chapter 11 fallback overlaps the reference map on mobile: fallback bottom ${Math.round(fallbackBottom)}, map top ${Math.round(chapterElevenReferenceMapBox.y)}`);
+    }
+  }
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -1721,14 +1778,118 @@ async function smokeChapterSceneControls(page, failures) {
   }
 
   await gotoAppRoute(page, '/journey/chapter/ch11');
-  const stone = page.getByRole('button', { name: /03\s+Stone/ });
-  await activateSceneButton(stone);
-  await page.waitForTimeout(250);
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterElevenReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterElevenReferenceCount = await chapterElevenReferenceNodes.count();
+  const chapterElevenPanelIds = await chapterElevenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterElevenInstrument = page.locator('.alchemical-tree-instrument');
+  const chapterElevenInstrumentCount = await chapterElevenInstrument.count();
+  const chapterElevenInstrumentRole = await chapterElevenInstrument.getAttribute('role');
+  const chapterElevenInstrumentLabel = await chapterElevenInstrument.getAttribute('aria-label');
+  const chapterElevenInstrumentPanel = await chapterElevenInstrument.getAttribute('data-active-panel');
+  const chapterElevenInstrumentStageCount = await page.locator('.alchemical-tree-instrument__stage').count();
+  const chapterElevenInstrumentRootCount = await page.locator('.alchemical-tree-instrument__root').count();
+  const chapterElevenInstrumentBranchCount = await page.locator('.alchemical-tree-instrument__branch').count();
+  const chapterElevenInstrumentLabelCount = await page.locator('.alchemical-tree-instrument__label').count();
+  const chapterElevenInitialDescription = await page.locator('#scene-host-description-ch11').textContent();
+  const chapterElevenInstrumentMarksVisible = await page.locator('.alchemical-tree-instrument__field, .alchemical-tree-instrument__root, .alchemical-tree-instrument__trunk, .alchemical-tree-instrument__branch, .alchemical-tree-instrument__thread, .alchemical-tree-instrument__mercurius, .alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__stone, .alchemical-tree-instrument__reflection').evaluateAll((nodes) => nodes.length >= 18 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterElevenReferenceGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="mercurius"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="opus-wheel"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="lapis"] .chapter-stage__reference-mark').evaluateAll((nodes) => nodes.length === 3 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    const before = window.getComputedStyle(node, '::before');
+    const after = window.getComputedStyle(node, '::after');
+    return styles.display !== 'none'
+      && Number(styles.opacity) > 0
+      && box.width > 0
+      && box.height > 0
+      && before.content !== 'none'
+      && after.content !== 'none'
+      && Number.parseFloat(before.width) > 0
+      && Number.parseFloat(before.height) > 0
+      && Number.parseFloat(after.width) > 0
+      && Number.parseFloat(after.height) > 0;
+  }));
+
+  if (chapterElevenReferenceCount !== 3) failures.push(`chapter 11 reference node count mismatch: ${chapterElevenReferenceCount}`);
+  if (chapterElevenPanelIds.join(',') !== 'mercurius,opus-wheel,lapis') failures.push(`chapter 11 reference nodes out of order: ${chapterElevenPanelIds.join(',')}`);
+  if (chapterElevenInstrumentCount !== 1) failures.push(`chapter 11 alchemical tree instrument count mismatch: ${chapterElevenInstrumentCount}`);
+  if (chapterElevenInstrumentStageCount !== 4) failures.push(`chapter 11 alchemical tree stage count mismatch: ${chapterElevenInstrumentStageCount}`);
+  if (chapterElevenInstrumentRootCount !== 3) failures.push(`chapter 11 alchemical tree root count mismatch: ${chapterElevenInstrumentRootCount}`);
+  if (chapterElevenInstrumentBranchCount !== 2) failures.push(`chapter 11 alchemical tree branch count mismatch: ${chapterElevenInstrumentBranchCount}`);
+  if (chapterElevenInstrumentLabelCount !== 3) failures.push(`chapter 11 alchemical tree label count mismatch: ${chapterElevenInstrumentLabelCount}`);
+  if (chapterElevenInstrumentRole !== 'img') failures.push(`chapter 11 alchemical tree instrument role mismatch: ${chapterElevenInstrumentRole}`);
+  if (!chapterElevenInstrumentLabel?.includes('Philosophical tree model') || !chapterElevenInstrumentLabel?.includes('Mercurius holds the middle') || !chapterElevenInstrumentLabel?.includes('Current emphasis: Mediator')) {
+    failures.push(`chapter 11 alchemical tree instrument label missing teaching text: ${chapterElevenInstrumentLabel}`);
+  }
+  if (chapterElevenInstrumentPanel !== 'mercurius') failures.push(`chapter 11 alchemical tree instrument did not start on Mercurius panel: ${chapterElevenInstrumentPanel}`);
+  if (!chapterElevenInitialDescription?.includes('Mediator: The slippery middle')) failures.push(`chapter 11 initial scene description mismatch: ${chapterElevenInitialDescription}`);
+  if (!chapterElevenInstrumentMarksVisible) failures.push('chapter 11 alchemical tree instrument marks are not visibly rendered');
+  if (!chapterElevenReferenceGlyphsVisible) failures.push('chapter 11 reference glyphs are not visibly rendered');
+
+  const opusWheel = page.locator('.chapter-stage__reference-node[data-panel-id="opus-wheel"]');
+  await opusWheel.waitFor({ state: 'visible', timeout: 30_000 });
+  await opusWheel.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(700);
+
+  const opusWheelPressed = await opusWheel.getAttribute('aria-pressed');
+  const opusWheelPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="opus-wheel"]').count();
+  const opusWheelDescription = await page.locator('#scene-host-description-ch11').textContent();
+  const opusWheelInstrumentPanel = await chapterElevenInstrument.getAttribute('data-active-panel');
+  const opusWheelInstrumentLabel = await chapterElevenInstrument.getAttribute('aria-label');
+  const opusWheelVisualState = await page.locator('.alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__thread').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  if (opusWheelPressed !== 'true') failures.push(`chapter 11 opus wheel reference did not become active: ${opusWheelPressed}`);
+  if (opusWheelPanelActive !== 1) failures.push(`chapter 11 opus wheel panel did not become active: ${opusWheelPanelActive}`);
+  if (opusWheelInstrumentPanel !== 'opus-wheel') failures.push(`chapter 11 alchemical tree instrument did not follow opus wheel panel: ${opusWheelInstrumentPanel}`);
+  if (!opusWheelInstrumentLabel?.includes('Current emphasis: Opus') || !opusWheelInstrumentLabel?.includes('Change returns to deepen itself')) {
+    failures.push(`chapter 11 alchemical tree instrument label did not follow opus panel: ${opusWheelInstrumentLabel}`);
+  }
+  if (opusWheelVisualState.length !== 7 || !opusWheelVisualState.every((opacity) => opacity >= 0.65)) {
+    failures.push(`chapter 11 alchemical tree instrument did not visually emphasize opus wheel: ${opusWheelVisualState.join(',')}`);
+  }
+  if (!opusWheelDescription?.includes('Opus: Transformation repeats')) failures.push(`chapter 11 scene description did not follow opus panel: ${opusWheelDescription}`);
+
+  const stone = page.locator('.chapter-stage__reference-node[data-panel-id="lapis"]');
+  await stone.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(700);
 
   const stonePressed = await stone.getAttribute('aria-pressed');
+  const stonePanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="lapis"]').count();
+  const stoneDescription = await page.locator('#scene-host-description-ch11').textContent();
+  const stoneInstrumentPanel = await chapterElevenInstrument.getAttribute('data-active-panel');
+  const stoneInstrumentLabel = await chapterElevenInstrument.getAttribute('aria-label');
+  const stoneVisualState = await page.locator('.alchemical-tree-instrument__stone, .alchemical-tree-instrument__reflection, .alchemical-tree-instrument__field').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   const chapterElevenScrollY = await page.evaluate(() => window.scrollY);
   if (stonePressed !== 'true') failures.push(`chapter 11 scene control did not become active: ${stonePressed}`);
+  if (stonePanelActive !== 1) failures.push(`chapter 11 stone panel did not become active: ${stonePanelActive}`);
+  if (stoneInstrumentPanel !== 'lapis') failures.push(`chapter 11 alchemical tree instrument did not follow stone panel: ${stoneInstrumentPanel}`);
+  if (!stoneInstrumentLabel?.includes('Current emphasis: Stone') || !stoneInstrumentLabel?.includes('Completion keeps the opposites alive')) {
+    failures.push(`chapter 11 alchemical tree instrument label did not follow stone panel: ${stoneInstrumentLabel}`);
+  }
+  if (stoneVisualState.length !== 4 || !stoneVisualState.every((opacity) => opacity >= 0.65)) {
+    failures.push(`chapter 11 alchemical tree instrument did not visually emphasize lapis: ${stoneVisualState.join(',')}`);
+  }
+  if (!stoneDescription?.includes('Stone: The goal is a formed paradox')) failures.push(`chapter 11 scene description did not follow stone panel: ${stoneDescription}`);
   if (chapterElevenScrollY > 10) failures.push(`chapter 11 scene control unexpectedly scrolled page: ${chapterElevenScrollY}`);
+
+  const chapterElevenCanvas = page.locator('.scene-host canvas').first();
+  const chapterElevenCanvasCount = await chapterElevenCanvas.count();
+  const chapterElevenFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  if (chapterElevenCanvasCount !== 1) {
+    failures.push(`chapter 11 expected one ready canvas but found ${chapterElevenCanvasCount}; fallback visible: ${chapterElevenFallbackVisible}`);
+  } else {
+    const chapterElevenCanvasBox = await chapterElevenCanvas.boundingBox();
+    const chapterElevenPixelSample = await waitForCanvasPixels(chapterElevenCanvas);
+    if (!chapterElevenCanvasBox || chapterElevenCanvasBox.width < 300 || chapterElevenCanvasBox.height < 300) {
+      failures.push(`chapter 11 canvas geometry too small: ${chapterElevenCanvasBox ? `${Math.round(chapterElevenCanvasBox.width)}x${Math.round(chapterElevenCanvasBox.height)}` : 'missing'}`);
+    }
+    recordCanvasPixelFailure(failures, 'chapter 11', chapterElevenPixelSample);
+  }
 
   await gotoAppRoute(page, '/journey/chapter/ch12');
   const bridge = page.getByRole('button', { name: /03\s+Bridge/ });
@@ -1763,7 +1924,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -2113,6 +2274,45 @@ async function smokeMobile(page, failures) {
       if (chapterTenCanvasCount > 0) {
         const chapterTenPixelSample = await waitForCanvasPixels(chapterTenCanvas);
         recordCanvasPixelFailure(failures, `mobile chapter 10 at ${viewport.width}x${viewport.height}`, chapterTenPixelSample);
+      }
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch11');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterElevenNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterElevenHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterElevenReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterElevenReferenceCount = await chapterElevenReferenceNodes.count();
+    const chapterElevenPanelIds = await chapterElevenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterElevenScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterElevenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const chapterElevenInstrumentBox = await page.locator('.alchemical-tree-instrument').boundingBox();
+    if (!chapterElevenNavBox || !chapterElevenHeadingBox) {
+      failures.push(`mobile chapter 11 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterElevenNavBottom = chapterElevenNavBox.y + chapterElevenNavBox.height;
+    if (chapterElevenNavBottom > chapterElevenHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 11 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterElevenNavBottom)}, heading top ${Math.round(chapterElevenHeadingBox.y)}`);
+    }
+    if (chapterElevenReferenceCount !== 3) failures.push(`mobile chapter 11 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterElevenReferenceCount}`);
+    if (chapterElevenPanelIds.join(',') !== 'mercurius,opus-wheel,lapis') failures.push(`mobile chapter 11 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterElevenPanelIds.join(',')}`);
+    if (chapterElevenScrollWidth > viewport.width + 2) failures.push(`mobile chapter 11 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterElevenScrollWidth}`);
+    if (chapterElevenReferenceMapBox && chapterElevenReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 11 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterElevenReferenceMapBox.width)}`);
+    }
+    if (!chapterElevenInstrumentBox) failures.push(`mobile chapter 11 alchemical tree instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterElevenInstrumentBox && chapterElevenInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 11 alchemical tree instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterElevenInstrumentBox.width)}`);
+    }
+
+    if (viewport.width === mobileViewport.width) {
+      const chapterElevenCanvas = page.locator('.scene-host canvas').first();
+      const chapterElevenCanvasCount = await chapterElevenCanvas.count();
+      if (chapterElevenCanvasCount > 0) {
+        const chapterElevenPixelSample = await waitForCanvasPixels(chapterElevenCanvas);
+        recordCanvasPixelFailure(failures, `mobile chapter 11 at ${viewport.width}x${viewport.height}`, chapterElevenPixelSample);
       }
     }
   }

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -19,7 +19,7 @@ const canonicalRoutes = [
   ...Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`),
 ];
 
-const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch14'];
+const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch14'];
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -21,6 +21,7 @@ const zodiacMarkers = ['AR', 'TA', 'GE', 'CN', 'LE', 'VI', 'LI', 'SC', 'SG', 'CP
 const prophecyTicks = ['0', '1000', '1555', '2000'] as const;
 const historicalStrataLayers = ['vision', 'carrier', 'healing', 'aeon', 'depth'] as const;
 const alchemicalOpusStages = ['nigredo', 'albedo', 'citrinitas', 'rubedo'] as const;
+const alchemicalTreeStages = ['black', 'white', 'gold', 'red'] as const;
 
 function useReducedMotionPreference() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean | null>(() => {
@@ -68,6 +69,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const historicalStrataInstrumentLabel = `Historical strata model: five translucent layers accumulate around the fish motif, an early Christian carrier image gathers the symbol into a readable form, and older meanings keep speaking below later interpretation. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const ambivalentFishInstrumentLabel = `Ambivalent fish model: one fish-symbol carries blessing and threat across a split field, an ouroboric return shows opposition circling back into itself, and the shadow fish keeps the Antichrist counter-pole inside the total image. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const alchemicalVesselInstrumentLabel = `Alchemical vessel model: the fish-symbol enters a sealed vessel, prima materia gathers as unsettled particles, heat presses the image through four opus stages, and a lapis point appears as transformation takes form. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
+  const alchemicalTreeInstrumentLabel = `Philosophical tree model: Mercurius holds the middle between matter and spirit, the opus wheel repeats transformation, and the lapis Coniunctio holds a formed union of opposites. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
 
   useEffect(() => {
     setActivePanelId(experience.panels[0]?.id || '');
@@ -351,6 +353,36 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="alchemical-vessel-instrument__label alchemical-vessel-instrument__label--fish" aria-hidden="true">fish enters</span>
               <span className="alchemical-vessel-instrument__label alchemical-vessel-instrument__label--prima" aria-hidden="true">prima materia</span>
               <span className="alchemical-vessel-instrument__label alchemical-vessel-instrument__label--opus" aria-hidden="true">opus stages</span>
+            </div>
+          )}
+          {chapter.id === 'ch11' && (
+            <div
+              className="alchemical-tree-instrument"
+              data-active-panel={activePanelId}
+              role="img"
+              aria-label={alchemicalTreeInstrumentLabel}
+            >
+              <span className="alchemical-tree-instrument__field alchemical-tree-instrument__field--above" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__field alchemical-tree-instrument__field--below" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__root alchemical-tree-instrument__root--one" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__root alchemical-tree-instrument__root--two" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__root alchemical-tree-instrument__root--three" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__trunk" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__branch alchemical-tree-instrument__branch--left" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__branch alchemical-tree-instrument__branch--right" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__thread alchemical-tree-instrument__thread--ascent" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__thread alchemical-tree-instrument__thread--descent" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__mercurius" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__wheel" aria-hidden="true">
+                {alchemicalTreeStages.map((stage) => (
+                  <span key={stage} className={`alchemical-tree-instrument__stage alchemical-tree-instrument__stage--${stage}`} />
+                ))}
+              </span>
+              <span className="alchemical-tree-instrument__stone" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__reflection" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__label alchemical-tree-instrument__label--mercurius" aria-hidden="true">Mercurius</span>
+              <span className="alchemical-tree-instrument__label alchemical-tree-instrument__label--opus" aria-hidden="true">opus wheel</span>
+              <span className="alchemical-tree-instrument__label alchemical-tree-instrument__label--lapis" aria-hidden="true">lapis</span>
             </div>
           )}
           <div className="chapter-stage__thesis-map" aria-label="Chapter visual sequence">

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -6044,6 +6044,499 @@ h3 {
   transform: translate(-50%, -50%) rotate(18deg) scale(1.12);
 }
 
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__intro h1 {
+  max-width: 13.2ch;
+  font-size: clamp(3.25rem, 5.55vw, 5.35rem);
+  line-height: 0.93;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__intro p:not(.eyebrow) {
+  max-width: 28rem;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__thesis-map {
+  max-width: 30rem;
+  margin-top: 0.84rem;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-map {
+  width: min(26rem, 100%);
+  margin-top: 0.66rem;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node {
+  min-height: 3.82rem;
+  background:
+    radial-gradient(circle at 42% 33%, rgba(255, 227, 156, 0.12), transparent 2.4rem),
+    radial-gradient(circle at 62% 65%, rgba(83, 216, 232, 0.11), transparent 2.5rem),
+    linear-gradient(180deg, rgba(9, 8, 13, 0.68), rgba(4, 3, 8, 0.36));
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-label {
+  margin-top: 2.04rem;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__scrim {
+  background:
+    linear-gradient(180deg, rgba(3, 3, 7, 0.75), rgba(3, 3, 7, 0.34) 48%, rgba(3, 3, 7, 0.8)),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.96), rgba(3, 3, 7, 0.52) 58%, rgba(3, 3, 7, 0.24)),
+    radial-gradient(circle at 31% 51%, rgba(212, 175, 55, 0.14), transparent 32%),
+    radial-gradient(circle at 58% 48%, rgba(83, 216, 232, 0.13), transparent 36%),
+    radial-gradient(circle at 74% 66%, rgba(181, 130, 255, 0.09), transparent 34%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node[data-panel-id="mercurius"] .chapter-stage__reference-mark::before {
+  top: 0.84rem;
+  width: 0.62rem;
+  height: 2.32rem;
+  border: 1px solid rgba(143, 231, 237, 0.34);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 50% 18%, rgba(255, 227, 156, 0.86) 0 0.13rem, transparent 0.15rem),
+    radial-gradient(circle at 50% 82%, rgba(83, 216, 232, 0.8) 0 0.13rem, transparent 0.15rem),
+    linear-gradient(180deg, rgba(255, 227, 156, 0.16), rgba(83, 216, 232, 0.16));
+  box-shadow: 0 0 1.15rem rgba(83, 216, 232, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node[data-panel-id="mercurius"] .chapter-stage__reference-mark::after {
+  top: 1.02rem;
+  width: 2.52rem;
+  height: 1.72rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.36);
+  border-bottom: 1px solid rgba(83, 216, 232, 0.32);
+  border-radius: 50%;
+  background: transparent;
+  transform: translateX(-50%) rotate(-19deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node[data-panel-id="opus-wheel"] .chapter-stage__reference-mark::before {
+  top: 0.78rem;
+  width: 2.48rem;
+  height: 2.48rem;
+  border: 1px solid rgba(255, 227, 156, 0.28);
+  border-radius: 50%;
+  background:
+    conic-gradient(from 12deg, rgba(18, 18, 22, 0.9), rgba(232, 232, 240, 0.7), rgba(255, 215, 0, 0.72), rgba(194, 55, 43, 0.74), rgba(18, 18, 22, 0.9)),
+    radial-gradient(circle at 50% 50%, rgba(3, 3, 7, 0.9) 0 42%, transparent 44%);
+  box-shadow: 0 0 1.2rem rgba(212, 175, 55, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node[data-panel-id="opus-wheel"] .chapter-stage__reference-mark::after {
+  top: 1.42rem;
+  width: 0.58rem;
+  height: 0.58rem;
+  border-radius: 50%;
+  background: rgba(255, 227, 156, 0.9);
+  box-shadow:
+    0 0 0 0.34rem rgba(3, 3, 7, 0.82),
+    0 0 1rem rgba(212, 175, 55, 0.34);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node[data-panel-id="lapis"] .chapter-stage__reference-mark::before {
+  top: 1.02rem;
+  width: 1.42rem;
+  height: 1.42rem;
+  border: 1px solid rgba(255, 227, 156, 0.4);
+  border-radius: 34%;
+  background:
+    linear-gradient(45deg, transparent 47%, rgba(244, 240, 232, 0.42) 49%, transparent 52%),
+    linear-gradient(135deg, transparent 47%, rgba(83, 216, 232, 0.3) 49%, transparent 52%),
+    radial-gradient(circle at 43% 38%, rgba(255, 227, 156, 0.92), rgba(212, 175, 55, 0.34) 58%, rgba(181, 130, 255, 0.12));
+  box-shadow:
+    0 0 0 0.44rem rgba(212, 175, 55, 0.06),
+    0 0 1.25rem rgba(212, 175, 55, 0.25);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node[data-panel-id="lapis"] .chapter-stage__reference-mark::after {
+  top: 2.18rem;
+  width: 2.35rem;
+  height: 0.58rem;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.23), transparent 72%);
+  box-shadow: 0 0 1.05rem rgba(83, 216, 232, 0.13);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument {
+  position: relative;
+  width: min(31rem, 100%);
+  min-height: clamp(7.3rem, 11vh, 8.35rem);
+  overflow: hidden;
+  margin-top: 0.78rem;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 28% 52%, rgba(83, 216, 232, 0.12), transparent 4.9rem),
+    radial-gradient(circle at 51% 48%, rgba(212, 175, 55, 0.15), transparent 4.6rem),
+    radial-gradient(circle at 75% 62%, rgba(181, 130, 255, 0.11), transparent 4.9rem),
+    linear-gradient(90deg, rgba(7, 8, 13, 0.86), rgba(11, 9, 12, 0.72) 48%, rgba(12, 7, 18, 0.62));
+  box-shadow:
+    var(--shadow-inset),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.24);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::before,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::before {
+  inset: 0.58rem;
+  border: 1px solid rgba(255, 227, 156, 0.08);
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::after {
+  left: 50%;
+  top: 50%;
+  width: 74%;
+  height: 0.06rem;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.28), transparent);
+  box-shadow: 0 0 1.2rem rgba(244, 240, 232, 0.1);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field {
+  left: 50%;
+  width: 74%;
+  height: 3.2rem;
+  border-radius: 50%;
+  opacity: 0.5;
+  transform: translateX(-50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field--above {
+  top: 0.75rem;
+  background: radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.12), transparent 70%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field--below {
+  bottom: 0.7rem;
+  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.13), transparent 70%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk {
+  left: 50%;
+  top: 16%;
+  width: 0.18rem;
+  height: 66%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 227, 156, 0.72), rgba(143, 231, 237, 0.58));
+  box-shadow: 0 0 1rem rgba(83, 216, 232, 0.16);
+  opacity: 0.72;
+  transform: translateX(-50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root {
+  left: 50%;
+  bottom: 1.12rem;
+  width: 7.8rem;
+  height: 2.05rem;
+  border-bottom: 1px solid rgba(83, 216, 232, 0.24);
+  border-radius: 50%;
+  opacity: 0.44;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root--one {
+  transform: translateX(-50%) rotate(-18deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root--two {
+  width: 5.8rem;
+  transform: translateX(-50%) rotate(16deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root--three {
+  width: 4.3rem;
+  transform: translateX(-50%) rotate(0deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch {
+  left: 50%;
+  top: 34%;
+  width: 8.4rem;
+  height: 2.85rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.26);
+  border-radius: 50%;
+  opacity: 0.44;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch--left {
+  transform: translateX(-88%) rotate(16deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch--right {
+  transform: translateX(-12%) rotate(-16deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread {
+  left: 50%;
+  top: 50%;
+  width: 12.6rem;
+  height: 4.6rem;
+  border-radius: 50%;
+  opacity: 0.38;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread--ascent {
+  border-top: 1px solid rgba(255, 227, 156, 0.24);
+  transform: translate(-50%, -50%) rotate(-12deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread--descent {
+  border-bottom: 1px solid rgba(83, 216, 232, 0.24);
+  transform: translate(-50%, -50%) rotate(12deg);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius {
+  left: 50%;
+  top: 48%;
+  width: 1.05rem;
+  height: 2.85rem;
+  border: 1px solid rgba(143, 231, 237, 0.36);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 50% 18%, rgba(255, 227, 156, 0.94) 0 0.14rem, transparent 0.16rem),
+    radial-gradient(circle at 50% 82%, rgba(83, 216, 232, 0.86) 0 0.14rem, transparent 0.16rem),
+    linear-gradient(180deg, rgba(255, 227, 156, 0.16), rgba(83, 216, 232, 0.16));
+  box-shadow:
+    inset 0 0 0.8rem rgba(143, 231, 237, 0.08),
+    0 0 1.45rem rgba(83, 216, 232, 0.16);
+  opacity: 0.72;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel {
+  right: 14%;
+  top: 51%;
+  width: 4.9rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(255, 227, 156, 0.28);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(3, 3, 7, 0.94) 0 38%, transparent 40%),
+    conic-gradient(from 22deg, rgba(18, 18, 22, 0.92), rgba(232, 232, 240, 0.7), rgba(255, 215, 0, 0.72), rgba(194, 55, 43, 0.72), rgba(18, 18, 22, 0.92));
+  box-shadow:
+    inset 0 0 1rem rgba(3, 3, 7, 0.7),
+    0 0 1.55rem rgba(212, 175, 55, 0.14);
+  opacity: 0.68;
+  transform: translateY(-50%);
+  animation: alchemical-tree-wheel 18s linear infinite;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel::before,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel::before {
+  width: 68%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.3), transparent);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel::after {
+  width: 1px;
+  height: 68%;
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.3), transparent);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage {
+  left: 50%;
+  top: 50%;
+  width: 0.48rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  opacity: 0.72;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--black {
+  background: rgba(18, 18, 22, 0.96);
+  box-shadow: 0 0 0.7rem rgba(244, 240, 232, 0.12);
+  transform: translate(-50%, -2.15rem);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--white {
+  background: rgba(232, 232, 240, 0.78);
+  transform: translate(1.72rem, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--gold {
+  background: rgba(255, 215, 0, 0.78);
+  box-shadow: 0 0 0.78rem rgba(212, 175, 55, 0.28);
+  transform: translate(-50%, 1.72rem);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--red {
+  background: rgba(194, 55, 43, 0.78);
+  transform: translate(-2.15rem, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone {
+  left: 27%;
+  top: 58%;
+  width: 1.28rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(255, 227, 156, 0.42);
+  border-radius: 34%;
+  background:
+    linear-gradient(45deg, transparent 47%, rgba(244, 240, 232, 0.42) 49%, transparent 52%),
+    linear-gradient(135deg, transparent 47%, rgba(83, 216, 232, 0.28) 49%, transparent 52%),
+    radial-gradient(circle at 43% 38%, rgba(255, 227, 156, 0.94), rgba(212, 175, 55, 0.34) 58%, rgba(181, 130, 255, 0.14));
+  box-shadow:
+    0 0 0 0.5rem rgba(212, 175, 55, 0.05),
+    0 0 1.35rem rgba(212, 175, 55, 0.2);
+  opacity: 0.62;
+  transform: translate(-50%, -50%) rotate(45deg) scale(0.9);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection {
+  left: 27%;
+  top: 71%;
+  width: 4rem;
+  height: 0.84rem;
+  border-radius: 50%;
+  background:
+    radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.22), transparent 72%),
+    linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.14), transparent);
+  box-shadow: 0 0 1.15rem rgba(83, 216, 232, 0.12);
+  opacity: 0.48;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--mercurius {
+  left: 8%;
+  top: 14%;
+  color: rgba(143, 231, 237, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--opus {
+  left: 43%;
+  top: 14%;
+  color: rgba(255, 227, 156, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--lapis {
+  right: 6%;
+  top: 14%;
+  color: rgba(255, 173, 112, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__trunk,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__branch,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__root,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__thread,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__mercurius {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__mercurius {
+  box-shadow:
+    inset 0 0 0.95rem rgba(143, 231, 237, 0.12),
+    0 0 1.8rem rgba(83, 216, 232, 0.26);
+  transform: translate(-50%, -50%) scale(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__wheel,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__stage,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__thread {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__wheel {
+  box-shadow:
+    inset 0 0 1rem rgba(3, 3, 7, 0.7),
+    0 0 1.85rem rgba(212, 175, 55, 0.24);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__stone,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__reflection,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__field {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__stone {
+  box-shadow:
+    0 0 0 0.62rem rgba(212, 175, 55, 0.08),
+    0 0 1.75rem rgba(212, 175, 55, 0.36);
+  transform: translate(-50%, -50%) rotate(45deg) scale(1.18);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__reflection {
+  transform: translate(-50%, -50%) scaleX(1.18);
+}
+
+@keyframes alchemical-tree-wheel {
+  from {
+    transform: translateY(-50%) rotate(0deg);
+  }
+
+  to {
+    transform: translateY(-50%) rotate(360deg);
+  }
+}
+
 .chapter-experience[data-chapter-id="ch3"][data-reduced-motion="true"] .scene-host__fallback {
   left: auto;
   right: clamp(1rem, 4vw, 3.5rem);
@@ -7864,14 +8357,24 @@ h3 {
 		  .alchemical-vessel-instrument__fish,
 		  .alchemical-vessel-instrument__magnet,
 		  .alchemical-vessel-instrument__lapis,
-		  .alchemical-vessel-instrument__thread,
-		  .alchemical-vessel-instrument__particle,
-		  .alchemical-vessel-instrument__stages,
-		  .chapters-orbit__node,
-		  .home-chapter-orbit__item a,
-		  .scene-host__pause {
-		    transition: none;
-		  }
+			  .alchemical-vessel-instrument__thread,
+			  .alchemical-vessel-instrument__particle,
+			  .alchemical-vessel-instrument__stages,
+			  .alchemical-tree-instrument__field,
+			  .alchemical-tree-instrument__root,
+			  .alchemical-tree-instrument__trunk,
+			  .alchemical-tree-instrument__branch,
+			  .alchemical-tree-instrument__thread,
+			  .alchemical-tree-instrument__mercurius,
+			  .alchemical-tree-instrument__wheel,
+			  .alchemical-tree-instrument__stage,
+			  .alchemical-tree-instrument__stone,
+			  .alchemical-tree-instrument__reflection,
+			  .chapters-orbit__node,
+			  .home-chapter-orbit__item a,
+			  .scene-host__pause {
+			    transition: none;
+			  }
 
   .atlas-constellation__core-glow {
     animation: none;
@@ -7951,12 +8454,26 @@ h3 {
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish,
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet,
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis,
-	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread,
-	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle,
-	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages {
-	    transition: none;
-	  }
-		}
+		  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread,
+		  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle,
+		  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages {
+		    transition: none;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection {
+		    animation: none;
+		    transition: none;
+		  }
+			}
 
 @media (max-width: 1120px) {
   .atlas-hero {
@@ -9630,19 +10147,198 @@ h3 {
 	    line-height: 0.96;
 	  }
 
-	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
-	    display: -webkit-box;
-	    margin-top: 0.18rem;
-	    font-size: 0.64rem;
-	    line-height: 1.24;
-	    -webkit-line-clamp: 2;
-	    -webkit-box-orient: vertical;
-	    overflow: hidden;
-	  }
+		  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+		    display: -webkit-box;
+		    margin-top: 0.18rem;
+		    font-size: 0.64rem;
+		    line-height: 1.24;
+		    -webkit-line-clamp: 2;
+		    -webkit-box-orient: vertical;
+		    overflow: hidden;
+		  }
 
-	  .home-hero {
-	    padding-top: 12.4rem;
-	  }
+		  .chapter-experience[data-chapter-id="ch11"] .chapter-stage__intro {
+		    justify-content: flex-start;
+		    padding-top: 10.25rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .chapter-sigil {
+		    display: none;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .chapter-stage__intro h1 {
+		    max-width: 10.8ch;
+		    font-size: clamp(1.92rem, 9.9vw, 2.72rem);
+		    line-height: 0.92;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .chapter-stage__intro p:not(.eyebrow) {
+		    margin-top: 0.66rem;
+		    max-width: 29ch;
+		    font-size: 0.88rem;
+		    line-height: 1.46;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .scene-host__pause {
+		    justify-content: center;
+		    width: 2.35rem;
+		    min-width: 2.35rem;
+		    padding-inline: 0;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .scene-host__pause span:not(.scene-host__pause-icon) {
+		    position: absolute;
+		    width: 1px;
+		    height: 1px;
+		    overflow: hidden;
+		    clip: rect(0, 0, 0, 0);
+		    white-space: nowrap;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument {
+		    min-height: 6.65rem;
+		    margin-top: 0.64rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::before {
+		    inset: 0.5rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field {
+		    width: 78%;
+		    height: 2.7rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk {
+		    height: 61%;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root {
+		    width: 5.4rem;
+		    height: 1.72rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch {
+		    width: 5.85rem;
+		    height: 2.2rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread {
+		    width: 6.65rem;
+		    height: 3.05rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius {
+		    width: 0.86rem;
+		    height: 2.28rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel {
+		    right: 8%;
+		    width: 3.7rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage {
+		    width: 0.38rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--black {
+		    transform: translate(-50%, -1.62rem);
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--white {
+		    transform: translate(1.25rem, -50%);
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--gold {
+		    transform: translate(-50%, 1.25rem);
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--red {
+		    transform: translate(-1.62rem, -50%);
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone {
+		    left: 22%;
+		    width: 1rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection {
+		    left: 22%;
+		    width: 3.2rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
+		    font-size: 0.5rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--mercurius {
+		    left: 6%;
+		    top: 12%;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--opus {
+		    left: 39%;
+		    top: 12%;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--lapis {
+		    right: 4%;
+		    top: 12%;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback {
+		    left: 1rem;
+		    right: 1rem;
+		    top: 33.75rem;
+		    width: auto;
+		    padding: 0.38rem 0.64rem;
+		    text-align: left;
+		    transform: none;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .alchemical-tree-instrument {
+		    min-height: 4.85rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .chapter-stage__reference-map {
+		    margin-top: 1.18rem;
+		    transform: translateY(3.25rem);
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
+		    margin: 0;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback h2,
+		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+		    position: static;
+		    width: auto;
+		    height: auto;
+		    overflow: visible;
+		    clip: auto;
+		    white-space: normal;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback h2 {
+		    margin: 0.08rem 0 0;
+		    font-size: 0.8rem;
+		    line-height: 0.96;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+		    display: -webkit-box;
+		    margin-top: 0.18rem;
+		    font-size: 0.63rem;
+		    line-height: 1.22;
+		    -webkit-line-clamp: 2;
+		    -webkit-box-orient: vertical;
+		    overflow: hidden;
+		  }
+
+		  .home-hero {
+		    padding-top: 12.4rem;
+		  }
 
   .hero-actions .button {
     width: 100%;

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -247,6 +247,32 @@ describe('Aion framework data contract', () => {
       'fish-symbol',
     ]);
   });
+
+  test('keeps Chapter 11 alchemical interpretation panels tied to Mercurius and lapis', () => {
+    expect(CHAPTER_SCENES.ch11.panels.map((panel) => panel.id)).toEqual([
+      'mercurius',
+      'opus-wheel',
+      'lapis',
+    ]);
+    expect(CHAPTER_SCENES.ch11.panels.map((panel) => panel.kicker)).toEqual([
+      'Mediator',
+      'Opus',
+      'Stone',
+    ]);
+    expect(CHAPTER_SCENES.ch11.motionGrammar).toBe('transformation');
+    expect(CHAPTER_SCENES.ch11.visualTheme).toContain('Mercurius');
+    expect(CHAPTER_SCENES.ch11.visualTheme).toContain('opus wheel');
+    expect(CHAPTER_SCENES.ch11.sceneModule).toBe('../visualizations/chapters/ch11/ThreeTreeViz.js');
+    expect(CHAPTER_SCENES.ch11.fallbackSummary).toContain('alchemical tree');
+    expect(CHAPTER_SCENES.ch11.fallbackSummary).toContain('Mercurius');
+    expect(CHAPTER_SCENES.ch11.fallbackSummary).toContain('opus cycle');
+
+    expect(getConceptsForChapter('ch11').map((concept) => concept.id)).toEqual([
+      'mercurius',
+      'coniunctio',
+      'lapis-philosophorum',
+    ]);
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- add a Chapter 11 philosophical tree instrument for Mercurius, the opus wheel, and lapis/Coniunctio
- add Ch11-scoped reference glyphs, mobile layout, and reduced-motion spacing
- pin Ch11 scene contracts and expand app shell, accessibility, and Pages artifact smoke coverage

## Visual QA
- local desktop/mobile/narrow screenshots reviewed for /journey/chapter/ch11
- visual control tower: 20 routes, 100% desktop scores, 0 technical blockers, no mobile/narrow overflow

## Verification
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- npm run build
- npm run test:e2e:app
- npm run test:a11y:app
- npm run build:pages
- npm run test:pages:artifact
- npm run test:visual:control-tower
