### PR TITLE
feat: polish chapter fourteen final synthesis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run app shell smoke
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: npm run test:e2e:app
 
       - name: Run app accessibility smoke

--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -535,6 +535,45 @@ async function checkChapterThirteenDynamicAccessibility(page, failures) {
   if (!paradoxDescription?.includes('Paradox: Wisdom includes rupture')) failures.push(`/journey/chapter/ch13: paradox scene description mismatch: ${paradoxDescription}`);
 }
 
+async function checkChapterFourteenDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/journey/chapter/ch14`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+  const instrument = page.getByRole('img', { name: /Final synthesis mandala/ });
+  const instrumentVisible = await instrument.isVisible();
+  const initialInstrumentLabel = instrumentVisible ? await instrument.getAttribute('aria-label') : null;
+  const initialDescription = await page.locator('#scene-host-description-ch14').textContent();
+
+  if (!instrumentVisible) failures.push('/journey/chapter/ch14: final synthesis instrument is missing an accessible image role');
+  if (!initialInstrumentLabel?.includes('Current emphasis: Synthesis') || !initialInstrumentLabel?.includes('earlier motifs gather')) failures.push(`/journey/chapter/ch14: initial instrument label mismatch: ${initialInstrumentLabel}`);
+  if (!initialDescription?.includes('Synthesis: The book gathers into one field')) failures.push(`/journey/chapter/ch14: initial scene description mismatch: ${initialDescription}`);
+
+  const axis = page.getByRole('button', { name: /02\s+Axis/ });
+  await axis.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const axisPressed = await axis.getAttribute('aria-pressed');
+  const axisLabel = await instrument.getAttribute('aria-label');
+  const axisDescription = await page.locator('#scene-host-description-ch14').textContent();
+  if (axisPressed !== 'true') failures.push(`/journey/chapter/ch14: axis button did not become pressed: ${axisPressed}`);
+  if (!axisLabel?.includes('Current emphasis: Axis') || !axisLabel?.includes('The goal is right relation')) failures.push(`/journey/chapter/ch14: axis instrument label mismatch: ${axisLabel}`);
+  if (!axisDescription?.includes('Axis: Ego and Self stay in relation')) failures.push(`/journey/chapter/ch14: axis scene description mismatch: ${axisDescription}`);
+
+  const individuation = page.getByRole('button', { name: /03\s+Path/ });
+  await individuation.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const individuationPressed = await individuation.getAttribute('aria-pressed');
+  const individuationLabel = await instrument.getAttribute('aria-label');
+  const individuationDescription = await page.locator('#scene-host-description-ch14').textContent();
+  if (individuationPressed !== 'true') failures.push(`/journey/chapter/ch14: individuation button did not become pressed: ${individuationPressed}`);
+  if (!individuationLabel?.includes('Current emphasis: Path') || !individuationLabel?.includes('Aion ends with motion')) failures.push(`/journey/chapter/ch14: path instrument label mismatch: ${individuationLabel}`);
+  if (!individuationDescription?.includes('Path: Individuation keeps moving')) failures.push(`/journey/chapter/ch14: path scene description mismatch: ${individuationDescription}`);
+}
+
 async function runAccessibilitySmoke() {
   const server = startPreviewServer();
   const failures = [];
@@ -557,6 +596,7 @@ async function runAccessibilitySmoke() {
     await checkChapterElevenDynamicAccessibility(desktop, failures);
     await checkChapterTwelveDynamicAccessibility(desktop, failures);
     await checkChapterThirteenDynamicAccessibility(desktop, failures);
+    await checkChapterFourteenDynamicAccessibility(desktop, failures);
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -956,6 +956,92 @@ async function smokeReducedMotion(browser, failures) {
       failures.push(`reduced-motion Chapter 13 fallback overlaps the reference map at 320x568: fallback bottom ${Math.round(fallbackBottom)}, map top ${Math.round(chapterThirteenNarrowReferenceMapBox.y)}`);
     }
   }
+
+  await page.setViewportSize(mobileViewport);
+  await gotoAppRoute(page, '/journey/chapter/ch14');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterFourteenFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterFourteenReducedMotionAttribute = await page.locator('.chapter-experience').getAttribute('data-reduced-motion');
+  const chapterFourteenReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterFourteenReferenceCount = await chapterFourteenReferenceNodes.count();
+  const chapterFourteenPanelIds = await chapterFourteenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterFourteenPauseControlCount = await page.locator('.scene-host__pause').count();
+  const chapterFourteenCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterFourteenFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterFourteenFallbackBox = await page.locator('.scene-host__fallback').boundingBox();
+  const chapterFourteenFallbackHeadingBox = await page.locator('.scene-host__fallback h2').boundingBox();
+  const chapterFourteenFallbackBodyBox = await page.locator('.scene-host__fallback p:not(.eyebrow)').boundingBox();
+  const chapterFourteenInstrumentCount = await page.locator('.final-synthesis-instrument').count();
+  const chapterFourteenInstrumentBox = await page.locator('.final-synthesis-instrument').boundingBox();
+  const chapterFourteenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+  const chapterFourteenInstrumentMotion = await page.locator('.final-synthesis-instrument__field, .final-synthesis-instrument__axis, .final-synthesis-instrument__orbit, .final-synthesis-instrument__motif-ring, .final-synthesis-instrument__motif, .final-synthesis-instrument__quaternity, .final-synthesis-instrument__point, .final-synthesis-instrument__ego, .final-synthesis-instrument__self, .final-synthesis-instrument__path, .final-synthesis-instrument__mark').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterFourteenAnimatedParts = chapterFourteenInstrumentMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterFourteenTransitioningParts = chapterFourteenInstrumentMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
+
+  if (!chapterFourteenFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 14 scene');
+  if (chapterFourteenReducedMotionAttribute !== 'true') failures.push('Chapter 14 did not record reduced-motion state');
+  if (chapterFourteenReferenceCount !== 3) failures.push(`reduced-motion Chapter 14 reference node count mismatch: ${chapterFourteenReferenceCount}`);
+  if (chapterFourteenPanelIds.join(',') !== 'gather,axis,aeon') failures.push(`reduced-motion Chapter 14 reference nodes out of order: ${chapterFourteenPanelIds.join(',')}`);
+  if (chapterFourteenPauseControlCount !== 0) failures.push(`reduced-motion Chapter 14 rendered pause controls: ${chapterFourteenPauseControlCount}`);
+  if (chapterFourteenCanvasCount !== 0) failures.push(`reduced-motion Chapter 14 rendered canvas: ${chapterFourteenCanvasCount}`);
+  if (chapterFourteenInstrumentCount !== 1) failures.push(`reduced-motion Chapter 14 final synthesis instrument count mismatch: ${chapterFourteenInstrumentCount}`);
+  if (chapterFourteenAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 14 final synthesis instrument still animates: ${JSON.stringify(chapterFourteenAnimatedParts)}`);
+  if (chapterFourteenTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 14 final synthesis instrument still transitions: ${JSON.stringify(chapterFourteenTransitioningParts)}`);
+  if (!chapterFourteenFallbackText?.includes('final synthesis mandala') || !chapterFourteenFallbackText?.includes('fourfold ordering field') || !chapterFourteenFallbackText?.includes('individuation')) {
+    failures.push('reduced-motion chapter fallback lost Chapter 14 final synthesis teaching summary');
+  }
+  if (!chapterFourteenFallbackHeadingBox || chapterFourteenFallbackHeadingBox.width < 20 || chapterFourteenFallbackHeadingBox.height < 8) {
+    failures.push(`reduced-motion Chapter 14 fallback heading is not visibly rendered: ${chapterFourteenFallbackHeadingBox ? `${Math.round(chapterFourteenFallbackHeadingBox.width)}x${Math.round(chapterFourteenFallbackHeadingBox.height)}` : 'missing'}`);
+  }
+  if (!chapterFourteenFallbackBodyBox || chapterFourteenFallbackBodyBox.width < 40 || chapterFourteenFallbackBodyBox.height < 8) {
+    failures.push(`reduced-motion Chapter 14 fallback body is not visibly rendered: ${chapterFourteenFallbackBodyBox ? `${Math.round(chapterFourteenFallbackBodyBox.width)}x${Math.round(chapterFourteenFallbackBodyBox.height)}` : 'missing'}`);
+  }
+  if (chapterFourteenFallbackBox && chapterFourteenInstrumentBox) {
+    const instrumentBottom = chapterFourteenInstrumentBox.y + chapterFourteenInstrumentBox.height;
+    if (chapterFourteenFallbackBox.y < instrumentBottom + 6) {
+      failures.push(`reduced-motion Chapter 14 fallback overlaps the final synthesis instrument on mobile: fallback top ${Math.round(chapterFourteenFallbackBox.y)}, instrument bottom ${Math.round(instrumentBottom)}`);
+    }
+  }
+  if (chapterFourteenFallbackBox && chapterFourteenReferenceMapBox) {
+    const fallbackBottom = chapterFourteenFallbackBox.y + chapterFourteenFallbackBox.height;
+    if (fallbackBottom > chapterFourteenReferenceMapBox.y - 6) {
+      failures.push(`reduced-motion Chapter 14 fallback overlaps the reference map on mobile: fallback bottom ${Math.round(fallbackBottom)}, map top ${Math.round(chapterFourteenReferenceMapBox.y)}`);
+    }
+  }
+
+  await page.setViewportSize(narrowMobileViewport);
+  await gotoAppRoute(page, '/journey/chapter/ch14');
+  await page.locator('.scene-host__fallback').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterFourteenNarrowFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  const chapterFourteenNarrowCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterFourteenNarrowFallbackBox = await page.locator('.scene-host__fallback').boundingBox();
+  const chapterFourteenNarrowInstrumentBox = await page.locator('.final-synthesis-instrument').boundingBox();
+  const chapterFourteenNarrowReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+  const chapterFourteenNarrowScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+  if (!chapterFourteenNarrowFallbackVisible) failures.push('reduced-motion Chapter 14 fallback is not visible at 320x568');
+  if (chapterFourteenNarrowCanvasCount !== 0) failures.push(`reduced-motion Chapter 14 rendered canvas at 320x568: ${chapterFourteenNarrowCanvasCount}`);
+  if (chapterFourteenNarrowScrollWidth > narrowMobileViewport.width + 2) {
+    failures.push(`reduced-motion Chapter 14 horizontal overflow at 320x568: ${chapterFourteenNarrowScrollWidth}`);
+  }
+  if (chapterFourteenNarrowFallbackBox && chapterFourteenNarrowInstrumentBox) {
+    const instrumentBottom = chapterFourteenNarrowInstrumentBox.y + chapterFourteenNarrowInstrumentBox.height;
+    if (chapterFourteenNarrowFallbackBox.y < instrumentBottom + 6) {
+      failures.push(`reduced-motion Chapter 14 fallback overlaps the final synthesis instrument at 320x568: fallback top ${Math.round(chapterFourteenNarrowFallbackBox.y)}, instrument bottom ${Math.round(instrumentBottom)}`);
+    }
+  }
+  if (chapterFourteenNarrowFallbackBox && chapterFourteenNarrowReferenceMapBox) {
+    const fallbackBottom = chapterFourteenNarrowFallbackBox.y + chapterFourteenNarrowFallbackBox.height;
+    if (fallbackBottom > chapterFourteenNarrowReferenceMapBox.y - 6) {
+      failures.push(`reduced-motion Chapter 14 fallback overlaps the reference map at 320x568: fallback bottom ${Math.round(fallbackBottom)}, map top ${Math.round(chapterFourteenNarrowReferenceMapBox.y)}`);
+    }
+  }
+
   if (threeRequests.length > 0) failures.push(`reduced-motion requested Three asset: ${threeRequests.join(', ')}`);
 
   failures.push(...routeFailures.notFound.map((url) => `reduced-motion 404 response: ${url}`));
@@ -2306,14 +2392,119 @@ async function smokeChapterSceneControls(page, failures) {
   }
 
   await gotoAppRoute(page, '/journey/chapter/ch14');
-  const aeon = page.getByRole('button', { name: /03\s+Aeon/ });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterFourteenReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterFourteenReferenceCount = await chapterFourteenReferenceNodes.count();
+  const chapterFourteenPanelIds = await chapterFourteenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterFourteenInstrument = page.locator('.final-synthesis-instrument');
+  const chapterFourteenInstrumentCount = await chapterFourteenInstrument.count();
+  const chapterFourteenInstrumentRole = chapterFourteenInstrumentCount > 0 ? await chapterFourteenInstrument.getAttribute('role') : null;
+  const chapterFourteenInstrumentLabel = chapterFourteenInstrumentCount > 0 ? await chapterFourteenInstrument.getAttribute('aria-label') : null;
+  const chapterFourteenInstrumentPanel = chapterFourteenInstrumentCount > 0 ? await chapterFourteenInstrument.getAttribute('data-active-panel') : null;
+  const chapterFourteenMotifCount = await page.locator('.final-synthesis-instrument__motif').count();
+  const chapterFourteenPointCount = await page.locator('.final-synthesis-instrument__point').count();
+  const chapterFourteenMarkCount = await page.locator('.final-synthesis-instrument__mark').count();
+  const chapterFourteenInstrumentLabelCount = await page.locator('.final-synthesis-instrument__label').count();
+  const chapterFourteenInitialDescription = await page.locator('#scene-host-description-ch14').textContent();
+  const chapterFourteenInstrumentMarksVisible = await page.locator('.final-synthesis-instrument__field, .final-synthesis-instrument__axis, .final-synthesis-instrument__orbit, .final-synthesis-instrument__motif-ring, .final-synthesis-instrument__motif, .final-synthesis-instrument__quaternity, .final-synthesis-instrument__point, .final-synthesis-instrument__ego, .final-synthesis-instrument__self, .final-synthesis-instrument__path, .final-synthesis-instrument__mark').evaluateAll((nodes) => nodes.length >= 23 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  const chapterFourteenReferenceGlyphsVisible = await page.locator('.chapter-stage__reference-node[data-panel-id="gather"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="axis"] .chapter-stage__reference-mark, .chapter-stage__reference-node[data-panel-id="aeon"] .chapter-stage__reference-mark').evaluateAll((nodes) => nodes.length === 3 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    const before = window.getComputedStyle(node, '::before');
+    const after = window.getComputedStyle(node, '::after');
+    return styles.display !== 'none'
+      && Number(styles.opacity) > 0
+      && box.width > 0
+      && box.height > 0
+      && before.content !== 'none'
+      && after.content !== 'none'
+      && Number.parseFloat(before.width) > 0
+      && Number.parseFloat(before.height) > 0
+      && Number.parseFloat(after.width) > 0
+      && Number.parseFloat(after.height) > 0;
+  }));
+
+  if (chapterFourteenReferenceCount !== 3) failures.push(`chapter 14 reference node count mismatch: ${chapterFourteenReferenceCount}`);
+  if (chapterFourteenPanelIds.join(',') !== 'gather,axis,aeon') failures.push(`chapter 14 reference nodes out of order: ${chapterFourteenPanelIds.join(',')}`);
+  if (chapterFourteenInstrumentCount !== 1) failures.push(`chapter 14 final synthesis instrument count mismatch: ${chapterFourteenInstrumentCount}`);
+  if (chapterFourteenInstrumentRole !== 'img') failures.push(`chapter 14 final synthesis instrument role mismatch: ${chapterFourteenInstrumentRole}`);
+  if (!chapterFourteenInstrumentLabel?.includes('Final synthesis mandala') || !chapterFourteenInstrumentLabel?.includes('fourfold Self field') || !chapterFourteenInstrumentLabel?.includes('Current emphasis: Synthesis')) {
+    failures.push(`chapter 14 final synthesis instrument label missing teaching text: ${chapterFourteenInstrumentLabel}`);
+  }
+  if (chapterFourteenInstrumentPanel !== 'gather') failures.push(`chapter 14 final synthesis instrument did not start on synthesis panel: ${chapterFourteenInstrumentPanel}`);
+  if (chapterFourteenMotifCount !== 6) failures.push(`chapter 14 final synthesis motif count mismatch: ${chapterFourteenMotifCount}`);
+  if (chapterFourteenPointCount !== 4) failures.push(`chapter 14 final synthesis quaternity point count mismatch: ${chapterFourteenPointCount}`);
+  if (chapterFourteenMarkCount !== 3) failures.push(`chapter 14 final synthesis path mark count mismatch: ${chapterFourteenMarkCount}`);
+  if (chapterFourteenInstrumentLabelCount !== 3) failures.push(`chapter 14 final synthesis label count mismatch: ${chapterFourteenInstrumentLabelCount}`);
+  if (!chapterFourteenInitialDescription?.includes('Synthesis: The book gathers into one field')) failures.push(`chapter 14 initial scene description mismatch: ${chapterFourteenInitialDescription}`);
+  if (!chapterFourteenInstrumentMarksVisible) failures.push('chapter 14 final synthesis instrument marks are not visibly rendered');
+  if (!chapterFourteenReferenceGlyphsVisible) failures.push('chapter 14 reference glyphs are not visibly rendered');
+
+  const axis = page.getByRole('button', { name: /02\s+Axis/ });
+  await activateSceneButton(axis);
+  await page.waitForTimeout(250);
+
+  const axisPressed = await axis.getAttribute('aria-pressed');
+  const axisPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="axis"]').count();
+  const axisDescription = await page.locator('#scene-host-description-ch14').textContent();
+  const axisInstrumentPanel = await chapterFourteenInstrument.getAttribute('data-active-panel');
+  const axisInstrumentLabel = await chapterFourteenInstrument.getAttribute('aria-label');
+  const axisVisualPartsVisible = await page.locator('.final-synthesis-instrument__axis, .final-synthesis-instrument__quaternity, .final-synthesis-instrument__point, .final-synthesis-instrument__ego, .final-synthesis-instrument__self').evaluateAll((nodes) => nodes.length === 9 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
+  if (axisPressed !== 'true') failures.push(`chapter 14 axis scene control did not become active: ${axisPressed}`);
+  if (axisPanelActive !== 1) failures.push(`chapter 14 axis panel did not become active: ${axisPanelActive}`);
+  if (axisInstrumentPanel !== 'axis') failures.push(`chapter 14 final synthesis instrument did not follow axis panel: ${axisInstrumentPanel}`);
+  if (!axisInstrumentLabel?.includes('Current emphasis: Axis') || !axisInstrumentLabel?.includes('The goal is right relation')) {
+    failures.push(`chapter 14 final synthesis instrument label did not follow axis panel: ${axisInstrumentLabel}`);
+  }
+  if (!axisVisualPartsVisible) failures.push('chapter 14 final synthesis axis visual parts are not visibly rendered');
+  if (!axisDescription?.includes('Axis: Ego and Self stay in relation')) failures.push(`chapter 14 scene description did not follow axis panel: ${axisDescription}`);
+
+  const aeon = page.getByRole('button', { name: /03\s+Path/ });
   await activateSceneButton(aeon);
   await page.waitForTimeout(250);
 
   const aeonPressed = await aeon.getAttribute('aria-pressed');
+  const aeonPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="aeon"]').count();
+  const aeonDescription = await page.locator('#scene-host-description-ch14').textContent();
+  const aeonInstrumentPanel = await chapterFourteenInstrument.getAttribute('data-active-panel');
+  const aeonInstrumentLabel = await chapterFourteenInstrument.getAttribute('aria-label');
+  const aeonVisualPartsVisible = await page.locator('.final-synthesis-instrument__field--future, .final-synthesis-instrument__path, .final-synthesis-instrument__mark, .final-synthesis-instrument__orbit, .final-synthesis-instrument__self').evaluateAll((nodes) => nodes.length === 8 && nodes.every((node) => {
+    const styles = window.getComputedStyle(node);
+    const box = node.getBoundingClientRect();
+    return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
+  }));
   const chapterFourteenScrollY = await page.evaluate(() => window.scrollY);
   if (aeonPressed !== 'true') failures.push(`chapter 14 scene control did not become active: ${aeonPressed}`);
+  if (aeonPanelActive !== 1) failures.push(`chapter 14 aeon panel did not become active: ${aeonPanelActive}`);
+  if (aeonInstrumentPanel !== 'aeon') failures.push(`chapter 14 final synthesis instrument did not follow path panel: ${aeonInstrumentPanel}`);
+  if (!aeonInstrumentLabel?.includes('Current emphasis: Path') || !aeonInstrumentLabel?.includes('Aion ends with motion')) {
+    failures.push(`chapter 14 final synthesis instrument label did not follow path panel: ${aeonInstrumentLabel}`);
+  }
+  if (!aeonVisualPartsVisible) failures.push('chapter 14 final synthesis individuation visual parts are not visibly rendered');
+  if (!aeonDescription?.includes('Path: Individuation keeps moving')) failures.push(`chapter 14 scene description did not follow path panel: ${aeonDescription}`);
   if (chapterFourteenScrollY > 10) failures.push(`chapter 14 scene control unexpectedly scrolled page: ${chapterFourteenScrollY}`);
+
+  const chapterFourteenCanvas = page.locator('.scene-host canvas').first();
+  const chapterFourteenCanvasCount = await chapterFourteenCanvas.count();
+  const chapterFourteenFallbackVisible = await page.locator('.scene-host__fallback').isVisible();
+  if (chapterFourteenCanvasCount !== 1) {
+    failures.push(`chapter 14 expected one ready canvas but found ${chapterFourteenCanvasCount}; fallback visible: ${chapterFourteenFallbackVisible}`);
+  } else {
+    const chapterFourteenCanvasBox = await chapterFourteenCanvas.boundingBox();
+    const chapterFourteenPixelSample = await waitForCanvasPixels(chapterFourteenCanvas);
+    if (!chapterFourteenCanvasBox || chapterFourteenCanvasBox.width < 300 || chapterFourteenCanvasBox.height < 300) {
+      failures.push(`chapter 14 canvas geometry too small: ${chapterFourteenCanvasBox ? `${Math.round(chapterFourteenCanvasBox.width)}x${Math.round(chapterFourteenCanvasBox.height)}` : 'missing'}`);
+    }
+    recordCanvasPixelFailure(failures, 'chapter 14', chapterFourteenPixelSample);
+  }
 }
 
 async function smokeMobile(page, failures) {
@@ -2845,6 +3036,77 @@ async function smokeMobile(page, failures) {
       }
       const chapterThirteenPixelSample = await waitForCanvasPixels(chapterThirteenCanvas);
       recordCanvasPixelFailure(failures, `mobile chapter 13 at ${viewport.width}x${viewport.height}`, chapterThirteenPixelSample);
+    }
+
+    await gotoAppRoute(page, '/journey/chapter/ch14');
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+    const chapterFourteenNavBox = await page.locator('.app-nav').boundingBox();
+    const chapterFourteenHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
+    const chapterFourteenReferenceNodes = page.locator('.chapter-stage__reference-node');
+    const chapterFourteenReferenceCount = await chapterFourteenReferenceNodes.count();
+    const chapterFourteenPanelIds = await chapterFourteenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterFourteenScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterFourteenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const chapterFourteenInstrumentBox = await page.locator('.final-synthesis-instrument').boundingBox();
+    const chapterFourteenReferenceGlyphLayout = await chapterFourteenReferenceNodes.evaluateAll((nodes) => nodes.map((node) => {
+      const label = node.querySelector('.chapter-stage__reference-label');
+      const mark = node.querySelector('.chapter-stage__reference-mark');
+      if (!label || !mark) return { panelId: node.getAttribute('data-panel-id'), ok: false };
+      const before = window.getComputedStyle(mark, '::before');
+      const after = window.getComputedStyle(mark, '::after');
+      const labelBox = label.getBoundingClientRect();
+      const nodeBox = node.getBoundingClientRect();
+      const beforeLeft = Number.parseFloat(before.left);
+      const beforeWidth = Number.parseFloat(before.width);
+      const afterLeft = Number.parseFloat(after.left);
+      const afterWidth = Number.parseFloat(after.width);
+      const beforeRight = beforeLeft + (before.transform === 'none' ? beforeWidth : beforeWidth / 2);
+      const afterRight = afterLeft + (after.transform === 'none' ? afterWidth : afterWidth / 2);
+      const labelLeft = labelBox.left - nodeBox.left;
+      return {
+        panelId: node.getAttribute('data-panel-id'),
+        ok: [beforeLeft, beforeWidth, afterLeft, afterWidth].every(Number.isFinite)
+          && beforeWidth > 0
+          && afterWidth > 0
+          && beforeRight < labelLeft - 4
+          && afterRight < labelLeft - 4,
+      };
+    }));
+    if (!chapterFourteenNavBox || !chapterFourteenHeadingBox) {
+      failures.push(`mobile chapter 14 geometry missing at ${viewport.width}x${viewport.height}`);
+      continue;
+    }
+
+    const chapterFourteenNavBottom = chapterFourteenNavBox.y + chapterFourteenNavBox.height;
+    if (chapterFourteenNavBottom > chapterFourteenHeadingBox.y - 1) {
+      failures.push(`mobile nav overlaps chapter 14 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterFourteenNavBottom)}, heading top ${Math.round(chapterFourteenHeadingBox.y)}`);
+    }
+    if (chapterFourteenReferenceCount !== 3) failures.push(`mobile chapter 14 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterFourteenReferenceCount}`);
+    if (chapterFourteenPanelIds.join(',') !== 'gather,axis,aeon') failures.push(`mobile chapter 14 reference nodes out of order at ${viewport.width}x${viewport.height}: ${chapterFourteenPanelIds.join(',')}`);
+    if (chapterFourteenScrollWidth > viewport.width + 2) failures.push(`mobile chapter 14 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterFourteenScrollWidth}`);
+    if (chapterFourteenReferenceMapBox && chapterFourteenReferenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 14 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterFourteenReferenceMapBox.width)}`);
+    }
+    for (const glyph of chapterFourteenReferenceGlyphLayout) {
+      if (!glyph.ok) failures.push(`mobile chapter 14 reference glyph overlaps label rail at ${viewport.width}x${viewport.height}: ${glyph.panelId}`);
+    }
+    if (!chapterFourteenInstrumentBox) failures.push(`mobile chapter 14 final synthesis instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterFourteenInstrumentBox && chapterFourteenInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 14 final synthesis instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterFourteenInstrumentBox.width)}`);
+    }
+
+    const chapterFourteenCanvas = page.locator('.scene-host canvas').first();
+    const chapterFourteenCanvasCount = await chapterFourteenCanvas.count();
+    if (chapterFourteenCanvasCount !== 1) {
+      failures.push(`mobile chapter 14 expected one ready canvas at ${viewport.width}x${viewport.height} but found ${chapterFourteenCanvasCount}`);
+    } else {
+      const chapterFourteenCanvasBox = await chapterFourteenCanvas.boundingBox();
+      const minCanvasWidth = viewport.width <= 320 ? 260 : 300;
+      if (!chapterFourteenCanvasBox || chapterFourteenCanvasBox.width < minCanvasWidth || chapterFourteenCanvasBox.height < 260) {
+        failures.push(`mobile chapter 14 canvas geometry too small at ${viewport.width}x${viewport.height}: ${chapterFourteenCanvasBox ? `${Math.round(chapterFourteenCanvasBox.width)}x${Math.round(chapterFourteenCanvasBox.height)}` : 'missing'}`);
+      }
+      const chapterFourteenPixelSample = await waitForCanvasPixels(chapterFourteenCanvas);
+      recordCanvasPixelFailure(failures, `mobile chapter 14 at ${viewport.width}x${viewport.height}`, chapterFourteenPixelSample);
     }
   }
 }

--- a/src/app/components/Chapter14FinalSynthesisInstrument.tsx
+++ b/src/app/components/Chapter14FinalSynthesisInstrument.tsx
@@ -1,0 +1,51 @@
+import type { LearningPanel } from '../types';
+
+const synthesisMotifs = ['ego', 'shadow', 'syzygy', 'fish', 'alchemy', 'gnosis'] as const;
+const synthesisQuaternityPoints = ['north', 'east', 'south', 'west'] as const;
+const synthesisAeonMarks = ['past', 'threshold', 'future'] as const;
+
+export default function Chapter14FinalSynthesisInstrument({
+  activePanel,
+  activePanelId,
+}: {
+  activePanel: LearningPanel;
+  activePanelId: string;
+}) {
+  const label = `Final synthesis mandala: earlier motifs gather around a fourfold Self field, the ego and Self axis stays relational, and the individuation path remains dynamic rather than closed. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
+
+  return (
+    <div
+      className="final-synthesis-instrument"
+      data-active-panel={activePanelId}
+      role="img"
+      aria-label={label}
+    >
+      <span className="final-synthesis-instrument__field final-synthesis-instrument__field--memory" aria-hidden="true" />
+      <span className="final-synthesis-instrument__field final-synthesis-instrument__field--future" aria-hidden="true" />
+      <span className="final-synthesis-instrument__axis final-synthesis-instrument__axis--vertical" aria-hidden="true" />
+      <span className="final-synthesis-instrument__axis final-synthesis-instrument__axis--horizontal" aria-hidden="true" />
+      <span className="final-synthesis-instrument__orbit final-synthesis-instrument__orbit--outer" aria-hidden="true" />
+      <span className="final-synthesis-instrument__orbit final-synthesis-instrument__orbit--inner" aria-hidden="true" />
+      <span className="final-synthesis-instrument__motif-ring" aria-hidden="true">
+        {synthesisMotifs.map((motif) => (
+          <span key={motif} className={`final-synthesis-instrument__motif final-synthesis-instrument__motif--${motif}`} />
+        ))}
+      </span>
+      <span className="final-synthesis-instrument__quaternity" aria-hidden="true">
+        {synthesisQuaternityPoints.map((point) => (
+          <span key={point} className={`final-synthesis-instrument__point final-synthesis-instrument__point--${point}`} />
+        ))}
+      </span>
+      <span className="final-synthesis-instrument__ego" aria-hidden="true" />
+      <span className="final-synthesis-instrument__self" aria-hidden="true" />
+      <span className="final-synthesis-instrument__path" aria-hidden="true">
+        {synthesisAeonMarks.map((mark) => (
+          <span key={mark} className={`final-synthesis-instrument__mark final-synthesis-instrument__mark--${mark}`} />
+        ))}
+      </span>
+      <span className="final-synthesis-instrument__label final-synthesis-instrument__label--gather" aria-hidden="true">motifs gather</span>
+      <span className="final-synthesis-instrument__label final-synthesis-instrument__label--axis" aria-hidden="true">ego/Self axis</span>
+      <span className="final-synthesis-instrument__label final-synthesis-instrument__label--aeon" aria-hidden="true">living path</span>
+    </div>
+  );
+}

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 
+import Chapter14FinalSynthesisInstrument from '../components/Chapter14FinalSynthesisInstrument';
 import ChapterSigil from '../components/ChapterSigil';
 import SceneHost from '../components/SceneHost';
 import {
@@ -455,6 +456,9 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="gnostic-constellation-instrument__label gnostic-constellation-instrument__label--fourfold" aria-hidden="true">fourfold pattern</span>
               <span className="gnostic-constellation-instrument__label gnostic-constellation-instrument__label--paradox" aria-hidden="true">rupture</span>
             </div>
+          )}
+          {chapter.id === 'ch14' && (
+            <Chapter14FinalSynthesisInstrument activePanel={activePanel} activePanelId={activePanelId} />
           )}
           <div className="chapter-stage__thesis-map" aria-label="Chapter visual sequence">
             {experience.panels.map((panel, index) => (

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -7478,6 +7478,506 @@ h3 {
   box-shadow: 0 0 1.2rem rgba(204, 109, 134, 0.24);
 }
 
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__scrim {
+  background:
+    radial-gradient(circle at 54% 40%, rgba(255, 227, 156, 0.1), transparent 20rem),
+    radial-gradient(circle at 66% 58%, rgba(83, 216, 232, 0.1), transparent 22rem),
+    radial-gradient(circle at 48% 72%, rgba(91, 214, 143, 0.08), transparent 20rem),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.92), rgba(3, 3, 7, 0.22) 47%, rgba(3, 3, 7, 0.64) 100%);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__intro h1 {
+  max-width: 10.2ch;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node {
+  background:
+    radial-gradient(circle at 50% 24%, rgba(255, 227, 156, 0.11), transparent 2.5rem),
+    radial-gradient(circle at 72% 72%, rgba(91, 214, 143, 0.08), transparent 2.8rem),
+    linear-gradient(145deg, rgba(244, 240, 232, 0.05), rgba(3, 3, 7, 0.28) 52%, rgba(5, 20, 24, 0.22));
+}
+
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="gather"] .chapter-stage__reference-mark::before {
+  top: 0.76rem;
+  width: 2.65rem;
+  height: 2.65rem;
+  border: 1px solid rgba(255, 227, 156, 0.23);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(255, 227, 156, 0.9) 0 0.16rem, transparent 0.19rem),
+    radial-gradient(circle at 50% 13%, rgba(244, 240, 232, 0.84) 0 0.12rem, transparent 0.15rem),
+    radial-gradient(circle at 87% 50%, rgba(204, 109, 134, 0.8) 0 0.12rem, transparent 0.15rem),
+    radial-gradient(circle at 50% 87%, rgba(91, 214, 143, 0.82) 0 0.12rem, transparent 0.15rem),
+    radial-gradient(circle at 13% 50%, rgba(83, 216, 232, 0.8) 0 0.12rem, transparent 0.15rem);
+  box-shadow: 0 0 1.5rem rgba(212, 175, 55, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="gather"] .chapter-stage__reference-mark::after {
+  top: 1.98rem;
+  width: 2.38rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(83, 216, 232, 0.4), rgba(255, 227, 156, 0.52), rgba(204, 109, 134, 0.35));
+  transform: translateX(-50%) rotate(-18deg);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="axis"] .chapter-stage__reference-mark::before {
+  top: 0.74rem;
+  width: 1px;
+  height: 3.1rem;
+  background: linear-gradient(180deg, rgba(255, 227, 156, 0.68), rgba(244, 240, 232, 0.26), rgba(83, 216, 232, 0.46));
+  box-shadow: 0 0 1.1rem rgba(83, 216, 232, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="axis"] .chapter-stage__reference-mark::after {
+  top: 2.12rem;
+  width: 2.6rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.42), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="aeon"] .chapter-stage__reference-mark::before {
+  top: 0.88rem;
+  width: 2.72rem;
+  height: 2.42rem;
+  border: 1px solid rgba(83, 216, 232, 0.28);
+  border-left-color: rgba(255, 227, 156, 0.52);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 1.1rem rgba(83, 216, 232, 0.08),
+    0 0 1.2rem rgba(83, 216, 232, 0.14);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="aeon"] .chapter-stage__reference-mark::after {
+  top: 1.98rem;
+  width: 2.7rem;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 227, 156, 0.3), rgba(91, 214, 143, 0.58), rgba(83, 216, 232, 0.34));
+  transform: translateX(-50%) rotate(14deg);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument {
+  position: relative;
+  width: min(31rem, 100%);
+  min-height: clamp(8.3rem, 12.4vh, 9.6rem);
+  overflow: hidden;
+  margin-top: 0.82rem;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 50% 20%, rgba(255, 227, 156, 0.16), transparent 4.8rem),
+    radial-gradient(circle at 28% 58%, rgba(83, 216, 232, 0.1), transparent 5rem),
+    radial-gradient(circle at 74% 58%, rgba(91, 214, 143, 0.12), transparent 4.8rem),
+    linear-gradient(108deg, rgba(5, 7, 12, 0.9), rgba(8, 11, 16, 0.74) 52%, rgba(3, 18, 20, 0.68));
+  box-shadow:
+    var(--shadow-inset),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.25);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::before,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::before {
+  inset: 0.58rem;
+  border: 1px solid rgba(255, 227, 156, 0.08);
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::after {
+  left: 50%;
+  top: 56%;
+  width: 78%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.16), transparent);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__ego,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__self,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__path,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label {
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field {
+  top: 18%;
+  width: 35%;
+  height: 64%;
+  border-radius: 50%;
+  opacity: 0.34;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field--memory {
+  left: 7%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.13), transparent 72%);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field--future {
+  right: 7%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(91, 214, 143, 0.14), transparent 72%);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis {
+  left: 50%;
+  top: 55%;
+  opacity: 0.34;
+  transition: opacity 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis--vertical {
+  width: 1px;
+  height: 5.9rem;
+  background: linear-gradient(180deg, rgba(255, 227, 156, 0.42), rgba(244, 240, 232, 0.16), rgba(83, 216, 232, 0.34));
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis--horizontal {
+  width: 12.1rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.28), transparent);
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit {
+  left: 50%;
+  top: 55%;
+  border: 1px solid rgba(83, 216, 232, 0.18);
+  border-radius: 50%;
+  opacity: 0.5;
+  transform: translate(-50%, -50%) rotate(-12deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit--outer {
+  width: 16.6rem;
+  height: 5.5rem;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit--inner {
+  width: 10.2rem;
+  height: 3.5rem;
+  border-color: rgba(255, 227, 156, 0.18);
+  transform: translate(-50%, -50%) rotate(18deg);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring {
+  left: 26%;
+  top: 55%;
+  width: 7.5rem;
+  aspect-ratio: 1;
+  opacity: 0.72;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif {
+  width: 0.54rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  opacity: 0.58;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif--ego {
+  left: 50%;
+  top: 5%;
+  background: rgba(244, 240, 232, 0.92);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif--shadow {
+  left: 86%;
+  top: 28%;
+  background: rgba(196, 166, 246, 0.86);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif--syzygy {
+  left: 86%;
+  top: 72%;
+  background: rgba(204, 109, 134, 0.86);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif--fish {
+  left: 50%;
+  top: 95%;
+  width: 0.72rem;
+  height: 0.32rem;
+  background: rgba(83, 216, 232, 0.9);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif--alchemy {
+  left: 14%;
+  top: 72%;
+  background: rgba(255, 173, 112, 0.88);
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif--gnosis {
+  left: 14%;
+  top: 28%;
+  background: rgba(91, 214, 143, 0.9);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity {
+  left: 52%;
+  top: 55%;
+  width: 6.5rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(244, 240, 232, 0.18);
+  border-radius: 50%;
+  opacity: 0.75;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity::before,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.32), transparent);
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity::before {
+  width: 90%;
+  height: 1px;
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity::after {
+  width: 1px;
+  height: 90%;
+  transform: translate(-50%, -50%);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point {
+  width: 0.58rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  opacity: 0.72;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point--north {
+  left: 50%;
+  top: 1%;
+  background: rgba(255, 227, 156, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point--east {
+  left: 99%;
+  top: 50%;
+  background: rgba(83, 216, 232, 0.9);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point--south {
+  left: 50%;
+  top: 99%;
+  background: rgba(91, 214, 143, 0.9);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point--west {
+  left: 1%;
+  top: 50%;
+  background: rgba(204, 109, 134, 0.88);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__ego {
+  left: 52%;
+  top: 31%;
+  width: 0.58rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: rgba(244, 240, 232, 0.96);
+  box-shadow:
+    0 0 0 0.44rem rgba(244, 240, 232, 0.06),
+    0 0 1.3rem rgba(244, 240, 232, 0.2);
+  opacity: 0.72;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__self {
+  left: 52%;
+  top: 55%;
+  width: 0.86rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: rgba(255, 227, 156, 0.95);
+  box-shadow:
+    0 0 0 0.72rem rgba(212, 175, 55, 0.08),
+    0 0 1.65rem rgba(212, 175, 55, 0.32);
+  opacity: 0.86;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__path {
+  right: 12%;
+  top: 55%;
+  width: 6.8rem;
+  height: 4rem;
+  border-top: 1px solid rgba(91, 214, 143, 0.28);
+  border-right: 1px solid rgba(83, 216, 232, 0.2);
+  border-radius: 50%;
+  opacity: 0.5;
+  transform: translateY(-50%) rotate(12deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark {
+  width: 0.5rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  opacity: 0.62;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark--past {
+  left: 14%;
+  top: 70%;
+  background: rgba(255, 173, 112, 0.82);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark--threshold {
+  left: 54%;
+  top: 24%;
+  background: rgba(91, 214, 143, 0.9);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark--future {
+  left: 88%;
+  top: 52%;
+  background: rgba(83, 216, 232, 0.9);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label--gather {
+  left: 6%;
+  top: 13%;
+  color: rgba(143, 231, 237, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label--axis {
+  left: 40%;
+  top: 13%;
+  color: rgba(255, 227, 156, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label--aeon {
+  right: 7%;
+  top: 13%;
+  color: rgba(91, 214, 143, 0.94);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__field--memory,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__motif-ring,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__motif,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__orbit {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__motif-ring {
+  transform: translate(-50%, -50%) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__motif {
+  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__axis,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__quaternity,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__point,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__ego,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__self {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__quaternity {
+  border-color: rgba(255, 227, 156, 0.34);
+  box-shadow:
+    inset 0 0 1.1rem rgba(83, 216, 232, 0.08),
+    0 0 1.75rem rgba(212, 175, 55, 0.2);
+  transform: translate(-50%, -50%) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__ego {
+  transform: translate(-50%, -50%) scale(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__self {
+  transform: translate(-50%, -50%) scale(1.16);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__field--future,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__path,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__mark,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__orbit,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__self {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__path {
+  border-color: rgba(91, 214, 143, 0.42);
+  transform: translateY(-50%) rotate(12deg) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__mark {
+  box-shadow: 0 0 1.1rem rgba(91, 214, 143, 0.24);
+}
+
 @keyframes alchemical-tree-wheel {
   from {
     transform: translateY(-50%) rotate(0deg);
@@ -9343,6 +9843,17 @@ h3 {
 			  .gnostic-constellation-instrument__center,
 			  .gnostic-constellation-instrument__rupture,
 			  .gnostic-constellation-instrument__shard,
+			  .final-synthesis-instrument__field,
+			  .final-synthesis-instrument__axis,
+			  .final-synthesis-instrument__orbit,
+			  .final-synthesis-instrument__motif-ring,
+			  .final-synthesis-instrument__motif,
+			  .final-synthesis-instrument__quaternity,
+			  .final-synthesis-instrument__point,
+			  .final-synthesis-instrument__ego,
+			  .final-synthesis-instrument__self,
+			  .final-synthesis-instrument__path,
+			  .final-synthesis-instrument__mark,
 			  .chapters-orbit__node,
 			  .home-chapter-orbit__item a,
 			  .scene-host__pause {
@@ -9473,6 +9984,21 @@ h3 {
 		  .chapter-experience[data-chapter-id="ch13"] .gnostic-constellation-instrument__center,
 		  .chapter-experience[data-chapter-id="ch13"] .gnostic-constellation-instrument__rupture,
 		  .chapter-experience[data-chapter-id="ch13"] .gnostic-constellation-instrument__shard {
+		    animation: none;
+		    transition: none;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__ego,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__self,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__path,
+		  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark {
 		    animation: none;
 		    transition: none;
 		  }
@@ -9990,6 +10516,212 @@ h3 {
   .chapter-experience[data-chapter-id="ch13"] .chapter-stage__reference-node[data-panel-id="paradox"] .chapter-stage__reference-mark::after {
     width: 2.1rem;
     transform: translate(-50%, -50%) rotate(-14deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__scrim {
+    background:
+      linear-gradient(180deg, rgba(3, 3, 7, 0.93), rgba(3, 3, 7, 0.6) 48%, rgba(3, 3, 7, 0.86)),
+      linear-gradient(90deg, rgba(3, 3, 7, 0.95), rgba(3, 3, 7, 0.54) 68%, rgba(3, 3, 7, 0.4));
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__intro h1 {
+    max-width: 8.7ch;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .scene-host__pause {
+    justify-content: center;
+    width: 2.35rem;
+    min-width: 2.35rem;
+    padding-inline: 0;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .scene-host__pause span:not(.scene-host__pause-icon) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument {
+    min-height: 6.75rem;
+    margin-top: 0.64rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::before {
+    inset: 0.5rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field {
+    top: 22%;
+    width: 28%;
+    height: 54%;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis--horizontal {
+    width: 7.5rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis--vertical {
+    height: 4.25rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit--outer {
+    width: 10.25rem;
+    height: 3.55rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit--inner {
+    width: 6.8rem;
+    height: 2.35rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring {
+    left: 24%;
+    width: 5.3rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif {
+    width: 0.42rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif--fish {
+    width: 0.6rem;
+    height: 0.28rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity {
+    left: 53%;
+    width: 4.45rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point,
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__ego {
+    width: 0.46rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__self {
+    left: 53%;
+    width: 0.64rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__path {
+    right: 7%;
+    width: 4.4rem;
+    height: 3.05rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark {
+    width: 0.42rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label {
+    font-size: 0.5rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label--gather {
+    left: 5%;
+    top: 12%;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label--axis {
+    left: 39%;
+    top: 12%;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label--aeon {
+    right: 5%;
+    top: 12%;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="gather"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="gather"] .chapter-stage__reference-mark::after,
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="axis"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="axis"] .chapter-stage__reference-mark::after,
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="aeon"] .chapter-stage__reference-mark::before,
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="aeon"] .chapter-stage__reference-mark::after {
+    left: 1.35rem;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="gather"] .chapter-stage__reference-mark::before {
+    width: 1.92rem;
+    height: 1.92rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="gather"] .chapter-stage__reference-mark::after {
+    width: 1.9rem;
+    transform: translate(-50%, -50%) rotate(-18deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="axis"] .chapter-stage__reference-mark::before {
+    width: 1px;
+    height: 2.2rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="axis"] .chapter-stage__reference-mark::after {
+    width: 2.1rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="aeon"] .chapter-stage__reference-mark::before {
+    width: 2rem;
+    height: 1.78rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__reference-node[data-panel-id="aeon"] .chapter-stage__reference-mark::after {
+    width: 2.05rem;
+    transform: translate(-50%, -50%) rotate(14deg);
+  }
+
+  .chapter-experience[data-chapter-id="ch14"][data-reduced-motion="true"] .scene-host__fallback {
+    left: 1rem;
+    right: 1rem;
+    top: 41rem;
+    width: auto;
+    padding: 0.38rem 0.64rem;
+    text-align: left;
+    transform: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"][data-reduced-motion="true"] .final-synthesis-instrument {
+    min-height: 4.85rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"][data-reduced-motion="true"] .chapter-stage__reference-map {
+    margin-top: 1.18rem;
+    transform: translateY(8.5rem);
+  }
+
+  .chapter-experience[data-chapter-id="ch14"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
+    margin: 0;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"][data-reduced-motion="true"] .scene-host__fallback h2,
+  .chapter-experience[data-chapter-id="ch14"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+    position: static;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"][data-reduced-motion="true"] .scene-host__fallback h2 {
+    margin: 0.08rem 0 0;
+    font-size: 0.8rem;
+    line-height: 0.96;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
+    display: -webkit-box;
+    margin-top: 0.18rem;
+    font-size: 0.63rem;
+    line-height: 1.22;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 
   .chapter-experience[data-chapter-id="ch13"][data-reduced-motion="true"] .scene-host__fallback {
@@ -10852,6 +11584,39 @@ h3 {
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__intro {
+    justify-content: flex-start;
+    width: min(22.5rem, calc(100% - 2rem));
+    padding-top: 10.2rem;
+    padding-bottom: 1.4rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-sigil {
+    display: none;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__intro h1 {
+    max-width: 11.5ch;
+    font-size: clamp(2.42rem, 12vw, 3.05rem);
+    line-height: 0.9;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .chapter-stage__intro p:not(.eyebrow) {
+    display: -webkit-box;
+    max-width: 28ch;
+    margin-top: 0.6rem;
+    overflow: hidden;
+    font-size: 0.9rem;
+    line-height: 1.42;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+  }
+
+  .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument {
+    min-height: 5.8rem;
+    margin-top: 0.54rem;
   }
 
   .chapter-experience[data-chapter-id="ch7"] .chapter-stage__intro {

--- a/src/app/visualization/chapterScenes.ts
+++ b/src/app/visualization/chapterScenes.ts
@@ -172,15 +172,15 @@ export const CHAPTER_SCENES: Record<ChapterId, ChapterExperience> = {
   },
   ch14: {
     chapterId: 'ch14',
-    visualTheme: 'Final aeon mandala synthesis',
+    visualTheme: 'Final Self mandala, quaternity, and individuation path',
     sceneModule: '../visualizations/chapters/ch14/ThreeAeonFinalViz.js',
     motionGrammar: 'integration',
-    fallbackSummary: 'A final mandala gathers ego, shadow, syzygy, fish, alchemy, and Gnosis into a living image of the Self.',
-    checkpoints: ['Gather the earlier motifs.', 'Trace the ego/Self axis.', 'Name the final dynamic.'],
+    fallbackSummary: 'A final synthesis mandala gathers earlier motifs around the Self, shows a fourfold ordering field, and keeps individuation visible as a living path.',
+    checkpoints: ['Gather the earlier motifs around the Self.', 'Trace the ego/Self axis.', 'Name the final individuation dynamic.'],
     panels: [
-      { id: 'gather', kicker: 'Synthesis', title: 'The book folds into one image', body: 'Earlier motifs return as parts of a larger psychic architecture.', insight: 'Completion is a constellation, not a slogan.' },
-      { id: 'axis', kicker: 'Axis', title: 'Ego and Self are held together', body: 'The final structure preserves relation between conscious standpoint and totality.', insight: 'The goal is right relation.' },
-      { id: 'aeon', kicker: 'Aeon', title: 'The image keeps moving', body: 'The Self is dynamic, cyclical, and historical.', insight: 'Aion ends with motion, not closure.' },
+      { id: 'gather', kicker: 'Synthesis', title: 'The book gathers into one field', body: 'Earlier motifs return as parts of a larger Self image.', insight: 'Completion is a constellation, not a slogan.' },
+      { id: 'axis', kicker: 'Axis', title: 'Ego and Self stay in relation', body: 'The final structure preserves the conscious standpoint inside a wider totality.', insight: 'The goal is right relation.' },
+      { id: 'aeon', kicker: 'Path', title: 'Individuation keeps moving', body: 'Wholeness remains dynamic, cyclical, and historical.', insight: 'Aion ends with motion, not closure.' },
     ],
   },
 };

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -325,6 +325,32 @@ describe('Aion framework data contract', () => {
       'opposites',
     ]);
   });
+
+  test('keeps Chapter 14 final synthesis panels tied to Self, quaternity, and individuation', () => {
+    expect(CHAPTER_SCENES.ch14.panels.map((panel) => panel.id)).toEqual([
+      'gather',
+      'axis',
+      'aeon',
+    ]);
+    expect(CHAPTER_SCENES.ch14.panels.map((panel) => panel.kicker)).toEqual([
+      'Synthesis',
+      'Axis',
+      'Path',
+    ]);
+    expect(CHAPTER_SCENES.ch14.motionGrammar).toBe('integration');
+    expect(CHAPTER_SCENES.ch14.visualTheme).toContain('Final Self mandala');
+    expect(CHAPTER_SCENES.ch14.visualTheme).toContain('individuation path');
+    expect(CHAPTER_SCENES.ch14.sceneModule).toBe('../visualizations/chapters/ch14/ThreeAeonFinalViz.js');
+    expect(CHAPTER_SCENES.ch14.fallbackSummary).toContain('final synthesis mandala');
+    expect(CHAPTER_SCENES.ch14.fallbackSummary).toContain('fourfold ordering field');
+    expect(CHAPTER_SCENES.ch14.fallbackSummary).toContain('individuation');
+
+    expect(getConceptsForChapter('ch14').map((concept) => concept.id)).toEqual([
+      'self',
+      'quaternity',
+      'individuation',
+    ]);
+  });
 });
 
 describe('Aion framework route contract', () => {


### PR DESCRIPTION
## Summary
- Add a Chapter 14 final synthesis instrument that visualizes earlier motifs gathering around the Self, the ego/Self axis, and the continuing individuation path.
- Tighten Chapter 14 panel copy, fallback summary, mobile layout, and reduced-motion behavior.
- Add Chapter 14-specific contract, app-shell smoke, canvas, mobile, reduced-motion, and accessibility coverage.

## Visual QA
- Control tower inspected 20 canonical routes across desktop, mobile, and 320px narrow viewports.
- Fresh Chapter 14 mobile/narrow screenshots confirm the final synthesis instrument appears in the first mobile viewport with no overflow.
- App-shell smoke covers Chapter 14 keyboard panel changes, nonblank canvas, reduced-motion fallback, and legacy redirect safety.

## Checks
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- npm run test:visual:control-tower
- npm run test:e2e:app
- npm run test:a11y:app
- npm run build:pages
- npm run test:pages:artifact
- git diff --check
- rg -n "^(<<<<<<<|=======|>>>>>>>)" .

## Notes
- Vite still reports the known large chunk warning for shared React/Three bundles.
- Shared styles.css continues to grow; a future route-style split would reduce blast radius for chapter polish batches.