### PR TITLE
[codex] Polish symbols visual atlas

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -223,6 +223,44 @@ async function checkAtlasDynamicAccessibility(page, failures) {
   if (!emptyFieldVisible) failures.push('/atlas: empty constellation field is missing an accessible name');
 }
 
+async function checkSymbolsDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/symbols`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+
+  const fishField = page.getByRole('img', { name: /Fish symbol field/ });
+  const initialFieldVisible = await fishField.isVisible();
+  const initialFieldLabel = initialFieldVisible ? await fishField.getAttribute('aria-label') : null;
+  const initialDetail = await page.locator('#symbol-selected-detail h2').textContent();
+
+  if (!initialFieldVisible) failures.push('/symbols: active symbol field is missing an accessible image role');
+  if (!initialFieldLabel?.includes('Piscean fish pair') || !initialFieldLabel?.includes('Chapter 6')) failures.push(`/symbols: initial field label mismatch: ${initialFieldLabel}`);
+  if (!initialDetail?.includes('Fish')) failures.push(`/symbols: initial detail mismatch: ${initialDetail}`);
+
+  const sophia = page.getByRole('button', { name: /Select Sophia:/ });
+  await sophia.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const sophiaPressed = await sophia.getAttribute('aria-pressed');
+  const sophiaFieldLabel = await page.getByRole('img', { name: /Sophia symbol field/ }).getAttribute('aria-label');
+  const sophiaDetail = await page.locator('#symbol-selected-detail h2').textContent();
+  if (sophiaPressed !== 'true') failures.push(`/symbols: Sophia orbit button did not become pressed: ${sophiaPressed}`);
+  if (!sophiaFieldLabel?.includes('Sophia / wisdom figure') || !sophiaFieldLabel?.includes('The Syzygy')) failures.push(`/symbols: Sophia field label mismatch: ${sophiaFieldLabel}`);
+  if (!sophiaDetail?.includes('Sophia')) failures.push(`/symbols: Sophia detail mismatch: ${sophiaDetail}`);
+
+  const lapis = page.getByRole('button', { name: /Focus Lapis in the symbol field/ });
+  await lapis.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const lapisPressed = await lapis.getAttribute('aria-pressed');
+  const lapisFieldLabel = await page.getByRole('img', { name: /Lapis symbol field/ }).getAttribute('aria-label');
+  const lapisDetail = await page.locator('#symbol-selected-detail h2').textContent();
+  if (lapisPressed !== 'true') failures.push(`/symbols: Lapis panel button did not become pressed: ${lapisPressed}`);
+  if (!lapisFieldLabel?.includes('Lapis philosophorum') || !lapisFieldLabel?.toLowerCase().includes('individuation')) failures.push(`/symbols: Lapis field label mismatch: ${lapisFieldLabel}`);
+  if (!lapisDetail?.includes('Lapis')) failures.push(`/symbols: Lapis detail mismatch: ${lapisDetail}`);
+}
+
 async function checkChapterSixDynamicAccessibility(page, failures) {
   await page.goto(`${baseUrl}/journey/chapter/ch6`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
   await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
@@ -588,6 +626,7 @@ async function runAccessibilitySmoke() {
       await checkRoute(desktop, route, failures);
     }
     await checkAtlasDynamicAccessibility(desktop, failures);
+    await checkSymbolsDynamicAccessibility(desktop, failures);
     await checkChapterSixDynamicAccessibility(desktop, failures);
     await checkChapterSevenDynamicAccessibility(desktop, failures);
     await checkChapterEightDynamicAccessibility(desktop, failures);
@@ -600,7 +639,7 @@ async function runAccessibilitySmoke() {
     await desktop.close();
 
     const mobile = await browser.newPage({ viewport: mobileViewport });
-    for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch12', '/journey/chapter/ch13', '/journey/chapter/ch14']) {
+    for (const route of ['/', '/chapters', '/atlas', '/timeline', '/symbols', '/about', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch12', '/journey/chapter/ch13', '/journey/chapter/ch14']) {
       await checkRoute(mobile, `mobile ${route}`.replace('mobile ', ''), failures);
     }
     await mobile.close();

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -339,6 +339,63 @@ async function smokeAtlasVisualSearch(page, failures) {
   if (!emptyImageVisible) failures.push('atlas empty field did not expose empty accessible name');
 }
 
+async function smokeSymbolsVisualField(page, failures) {
+  await gotoAppRoute(page, '/symbols');
+
+  const orbitButtons = page.locator('.symbol-orbit__node');
+  const symbolPanels = page.locator('.symbol-panel');
+  const symbolField = page.getByRole('img', { name: /Fish symbol field/ });
+  const initialDetail = await page.locator('#symbol-selected-detail h2').textContent();
+  const initialFieldLabel = await symbolField.getAttribute('aria-label');
+  const initialActiveOrbitCount = await page.locator('.symbol-orbit__node[aria-pressed="true"]').count();
+  const initialActivePanelCount = await page.locator('.symbol-panel__activate[aria-pressed="true"]').count();
+  const initialConceptCount = await page.locator('.symbol-field__concept').count();
+  const initialChapterCount = await page.locator('.symbol-field__chapter').count();
+  const initialChapterLinkCount = await page.locator('.symbol-detail__chapter-links a').count();
+  const scrollYBeforeSelect = await page.evaluate(() => window.scrollY);
+
+  if (await orbitButtons.count() !== 9) failures.push(`symbols orbit button count mismatch: ${await orbitButtons.count()}`);
+  if (await symbolPanels.count() !== 9) failures.push(`symbols panel count mismatch: ${await symbolPanels.count()}`);
+  if (!await symbolField.isVisible()) failures.push('symbols active field is not visible');
+  if (!initialDetail?.includes('Fish')) failures.push(`symbols initial detail mismatch: ${initialDetail}`);
+  if (!initialFieldLabel?.includes('Piscean fish pair') || !initialFieldLabel?.includes('Chapter 6')) failures.push(`symbols initial field label mismatch: ${initialFieldLabel}`);
+  if (initialActiveOrbitCount !== 1) failures.push(`symbols active orbit count mismatch: ${initialActiveOrbitCount}`);
+  if (initialActivePanelCount !== 1) failures.push(`symbols active panel count mismatch: ${initialActivePanelCount}`);
+  if (initialConceptCount < 4) failures.push(`symbols concept node count too low: ${initialConceptCount}`);
+  if (initialChapterCount < 2) failures.push(`symbols chapter node count too low: ${initialChapterCount}`);
+  if (initialChapterLinkCount < 2) failures.push(`symbols chapter link count too low: ${initialChapterLinkCount}`);
+
+  const sophia = page.getByRole('button', { name: /Select Sophia:/ });
+  await sophia.click();
+  await page.waitForTimeout(100);
+
+  const sophiaPressed = await sophia.getAttribute('aria-pressed');
+  const sophiaDetail = await page.locator('#symbol-selected-detail h2').textContent();
+  const sophiaField = page.getByRole('img', { name: /Sophia symbol field/ });
+  const sophiaFieldLabel = await sophiaField.getAttribute('aria-label');
+  const scrollYAfterSelect = await page.evaluate(() => window.scrollY);
+  const sophiaChapterLinkVisible = await page.getByRole('link', { name: /03 · The Syzygy/ }).isVisible();
+
+  if (sophiaPressed !== 'true') failures.push(`symbols Sophia orbit did not become active: ${sophiaPressed}`);
+  if (!sophiaDetail?.includes('Sophia')) failures.push(`symbols detail did not follow Sophia selection: ${sophiaDetail}`);
+  if (!sophiaFieldLabel?.includes('Sophia / wisdom figure') || !sophiaFieldLabel?.includes('Syzygy')) failures.push(`symbols Sophia field label mismatch: ${sophiaFieldLabel}`);
+  if (!sophiaChapterLinkVisible) failures.push('symbols Sophia did not expose Chapter 3 link');
+  if (scrollYAfterSelect > scrollYBeforeSelect + 10) failures.push(`symbols orbit selection unexpectedly scrolled page: ${scrollYAfterSelect}`);
+
+  const lapisPanelButton = page.getByRole('button', { name: /Focus Lapis in the symbol field/ });
+  await lapisPanelButton.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const lapisPanelPressed = await lapisPanelButton.getAttribute('aria-pressed');
+  const lapisDetail = await page.locator('#symbol-selected-detail h2').textContent();
+  const lapisFieldLabel = await page.getByRole('img', { name: /Lapis symbol field/ }).getAttribute('aria-label');
+
+  if (lapisPanelPressed !== 'true') failures.push(`symbols Lapis panel did not become active: ${lapisPanelPressed}`);
+  if (!lapisDetail?.includes('Lapis')) failures.push(`symbols detail did not follow Lapis panel selection: ${lapisDetail}`);
+  if (!lapisFieldLabel?.includes('Lapis philosophorum') || !lapisFieldLabel?.toLowerCase().includes('individuation')) failures.push(`symbols Lapis field label mismatch: ${lapisFieldLabel}`);
+}
+
 async function smokeChapterRoutes(page, failures) {
   const browser = page.context().browser();
 
@@ -2509,7 +2566,7 @@ async function smokeChapterSceneControls(page, failures) {
 
 async function smokeMobile(page, failures) {
   await page.setViewportSize(mobileViewport);
-  for (const route of ['/', '/chapters', '/atlas', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch12', '/journey/chapter/ch13', '/journey/chapter/ch14']) {
+  for (const route of ['/', '/chapters', '/atlas', '/timeline', '/symbols', '/about', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch7', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch12', '/journey/chapter/ch13', '/journey/chapter/ch14']) {
     await gotoAppRoute(page, route);
     await assertHealthyShell(page, `mobile ${route}`, failures);
   }
@@ -3127,6 +3184,7 @@ async function runSmoke() {
     await smokeCanonicalRoutes(page, failures);
     await smokeHomeVisualDetail(page, failures);
     await smokeAtlasVisualSearch(page, failures);
+    await smokeSymbolsVisualField(page, failures);
     await smokeChapterRoutes(page, failures);
     await smokeKeyboard(page, failures);
     await smokeLegacyRedirect(page, failures);

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -19,7 +19,7 @@ const canonicalRoutes = [
   ...Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`),
 ];
 
-const mobileRoutes = ['/', '/chapters', '/atlas', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch12', '/journey/chapter/ch13', '/journey/chapter/ch14'];
+const mobileRoutes = ['/', '/chapters', '/atlas', '/timeline', '/symbols', '/about', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch12', '/journey/chapter/ch13', '/journey/chapter/ch14'];
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],

--- a/src/app/pages/SymbolsPage.css
+++ b/src/app/pages/SymbolsPage.css
@@ -1,0 +1,491 @@
+.symbols-hero {
+  position: relative;
+}
+
+.symbols-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0 50% 0 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 20% 42%, rgba(83, 216, 232, 0.12), transparent 22rem),
+    linear-gradient(90deg, rgba(5, 5, 8, 0.96), rgba(5, 5, 8, 0));
+}
+
+.symbols-hero > div {
+  position: relative;
+  z-index: 1;
+}
+
+.symbols-hero__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  max-width: 30rem;
+  margin-top: clamp(1.35rem, 3vw, 2.3rem);
+  border-top: 1px solid rgba(212, 175, 55, 0.2);
+  border-bottom: 1px solid rgba(212, 175, 55, 0.12);
+}
+
+.symbols-hero__metrics span {
+  display: grid;
+  gap: 0.16rem;
+  padding: 0.72rem 0.72rem 0.7rem 0;
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.symbols-hero__metrics span + span {
+  border-left: 1px solid rgba(212, 175, 55, 0.12);
+  padding-left: 0.82rem;
+}
+
+.symbols-hero__metrics strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: clamp(1.65rem, 3vw, 2.45rem);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.symbol-orbit--interactive {
+  isolation: isolate;
+}
+
+.symbol-orbit--interactive::before {
+  background:
+    radial-gradient(circle at 50% 50%, rgba(212, 175, 55, 0.08), transparent 48%),
+    rgba(3, 3, 7, 0.22);
+}
+
+.symbol-orbit--interactive::after {
+  box-shadow:
+    inset 0 0 0 1.6rem rgba(83, 216, 232, 0.018),
+    0 0 4rem rgba(83, 216, 232, 0.045);
+}
+
+.symbol-orbit__center {
+  gap: 0.1rem;
+}
+
+.symbol-orbit__center span {
+  display: block;
+  color: var(--cyan);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.symbol-orbit__center strong {
+  display: block;
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: clamp(1.1rem, 1.7vw, 1.42rem);
+  font-weight: 400;
+  line-height: 1.05;
+}
+
+.symbol-orbit__node {
+  font-family: var(--font-display);
+  line-height: 1;
+  transition:
+    transform 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring),
+    color 0.45s var(--motion-spring),
+    box-shadow 0.45s var(--motion-spring);
+}
+
+.symbol-orbit__node--active {
+  border-color: var(--gold);
+  background:
+    radial-gradient(circle at 50% 42%, rgba(212, 175, 55, 0.24), transparent 62%),
+    rgba(3, 3, 7, 0.88);
+  color: var(--text);
+  box-shadow:
+    0 0 0 0.24rem rgba(212, 175, 55, 0.07),
+    0 0 1.8rem rgba(212, 175, 55, 0.32);
+  transform: rotate(var(--angle)) translateX(min(15vw, 13.2rem)) rotate(calc(-1 * var(--angle))) scale(1.12);
+}
+
+.symbol-lab__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(18rem, 0.75fr);
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.symbol-lab {
+  scroll-margin-top: 7.5rem;
+}
+
+.symbol-field,
+.symbol-detail {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.018)),
+    rgba(5, 5, 8, 0.76);
+  box-shadow: var(--shadow-inset);
+}
+
+.symbol-field {
+  --symbol-tone: rgba(212, 175, 55, 0.82);
+  --symbol-soft: rgba(212, 175, 55, 0.16);
+  position: relative;
+  min-height: clamp(28rem, 58vw, 39rem);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.symbol-field[data-tone='cyan'] {
+  --symbol-tone: rgba(83, 216, 232, 0.86);
+  --symbol-soft: rgba(83, 216, 232, 0.16);
+}
+
+.symbol-field[data-tone='rose'] {
+  --symbol-tone: rgba(218, 112, 139, 0.82);
+  --symbol-soft: rgba(218, 112, 139, 0.16);
+}
+
+.symbol-field[data-tone='green'] {
+  --symbol-tone: rgba(136, 214, 167, 0.82);
+  --symbol-soft: rgba(136, 214, 167, 0.16);
+}
+
+.symbol-field::before,
+.symbol-field::after,
+.symbol-field__ring,
+.symbol-field__axis,
+.symbol-field__glyph,
+.symbol-field__index,
+.symbol-field__concept,
+.symbol-field__chapter {
+  position: absolute;
+  pointer-events: none;
+}
+
+.symbol-field::before,
+.symbol-field::after {
+  content: '';
+}
+
+.symbol-field::before {
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 49%, var(--symbol-soft), transparent 17rem),
+    radial-gradient(circle at 28% 26%, rgba(83, 216, 232, 0.08), transparent 14rem),
+    radial-gradient(circle at 72% 72%, rgba(212, 175, 55, 0.08), transparent 14rem);
+}
+
+.symbol-field::after {
+  inset: 0.62rem;
+  border: 1px solid rgba(244, 240, 232, 0.055);
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.symbol-field__ring {
+  left: 50%;
+  top: 50%;
+  border: 1px solid rgba(212, 175, 55, 0.18);
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.symbol-field__ring--outer {
+  width: min(78%, 32rem);
+  aspect-ratio: 1;
+  box-shadow:
+    inset 0 0 4rem rgba(83, 216, 232, 0.035),
+    0 0 5rem var(--symbol-soft);
+}
+
+.symbol-field__ring--inner {
+  width: min(45%, 18rem);
+  aspect-ratio: 1;
+  border-color: rgba(83, 216, 232, 0.24);
+  transform: translate(-50%, -50%) rotateX(58deg);
+}
+
+.symbol-field__axis {
+  left: 50%;
+  top: 50%;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.28), transparent);
+  opacity: 0.72;
+}
+
+.symbol-field__axis--horizontal {
+  width: 74%;
+  height: 1px;
+  transform: translate(-50%, -50%);
+}
+
+.symbol-field__axis--vertical {
+  width: 1px;
+  height: 74%;
+  transform: translate(-50%, -50%);
+}
+
+.symbol-field__glyph {
+  left: 50%;
+  top: 50%;
+  width: clamp(5.8rem, 13vw, 8.25rem);
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--symbol-tone) 58%, transparent);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 44%, color-mix(in srgb, var(--symbol-tone) 24%, transparent), transparent 68%),
+    rgba(3, 3, 7, 0.7);
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: clamp(2.3rem, 5vw, 4.6rem);
+  line-height: 1;
+  box-shadow:
+    0 0 0 0.7rem color-mix(in srgb, var(--symbol-tone) 8%, transparent),
+    0 0 3.5rem color-mix(in srgb, var(--symbol-tone) 26%, transparent);
+  transform: translate(-50%, -50%);
+}
+
+.symbol-field__index {
+  left: 1.1rem;
+  top: 1rem;
+  color: var(--cyan);
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+}
+
+.symbol-field__concept,
+.symbol-field__chapter {
+  --angle: calc((360deg / var(--node-count)) * var(--node-index));
+  left: 50%;
+  top: 50%;
+  display: grid;
+  place-items: center;
+  transform: rotate(var(--angle)) translateX(min(22vw, 13.7rem)) rotate(calc(-1 * var(--angle)));
+}
+
+.symbol-field__concept {
+  max-width: 8.4rem;
+  min-height: 2.35rem;
+  border: 1px solid rgba(83, 216, 232, 0.2);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.74);
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.66rem;
+  font-weight: 800;
+  line-height: 1.1;
+  padding: 0.48rem 0.64rem;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.symbol-field__chapter {
+  width: 2.2rem;
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in srgb, var(--symbol-tone) 46%, transparent);
+  border-radius: 50%;
+  background: rgba(3, 3, 7, 0.82);
+  color: var(--gold-soft);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 900;
+  transform: rotate(calc(var(--angle) + 17deg)) translateX(min(15vw, 9.4rem)) rotate(calc(-1 * (var(--angle) + 17deg)));
+}
+
+.symbol-detail {
+  display: grid;
+  align-content: start;
+  gap: 1rem;
+  padding: 1.2rem;
+}
+
+.symbol-detail h2 {
+  max-width: 10ch;
+  margin: 0;
+}
+
+.symbol-detail p:not(.eyebrow) {
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.symbol-detail__thread-group,
+.symbol-detail__chapter-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.symbol-detail__thread-group span,
+.symbol-detail__chapter-links a {
+  border: 1px solid rgba(212, 175, 55, 0.16);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.44);
+  color: rgba(244, 240, 232, 0.72);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  padding: 0.34rem 0.56rem;
+  text-decoration: none;
+}
+
+.symbol-detail__chapter-links a:hover,
+.symbol-detail__chapter-links a:focus-visible {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.symbol-panel {
+  display: grid;
+  align-content: start;
+  gap: 0.76rem;
+  scroll-margin-top: 7.5rem;
+}
+
+.symbol-panel--active,
+.symbol-panel:target {
+  border-color: rgba(212, 175, 55, 0.38);
+  background:
+    radial-gradient(circle at 18% 16%, rgba(212, 175, 55, 0.13), transparent 8rem),
+    var(--surface-machined);
+}
+
+.symbol-panel__activate {
+  display: inline-grid;
+  grid-template-columns: auto auto;
+  align-items: center;
+  justify-content: start;
+  gap: 0.72rem;
+  width: max-content;
+  max-width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+}
+
+.symbol-panel__activate > span:last-child {
+  border: 1px solid rgba(212, 175, 55, 0.14);
+  border-radius: 999px;
+  color: rgba(244, 240, 232, 0.64);
+  font-family: var(--font-ui);
+  font-size: 0.62rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  padding: 0.28rem 0.48rem;
+  text-transform: uppercase;
+}
+
+.symbol-panel__activate:hover > span:last-child,
+.symbol-panel__activate:focus-visible > span:last-child,
+.symbol-panel--active .symbol-panel__activate > span:last-child {
+  border-color: rgba(212, 175, 55, 0.34);
+  color: var(--gold-soft);
+}
+
+@media (max-width: 1120px) {
+  .symbol-lab__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .symbol-field {
+    min-height: clamp(25rem, 78vw, 34rem);
+  }
+}
+
+@media (max-width: 860px) {
+  .symbols-hero__metrics {
+    grid-template-columns: 1fr;
+    max-width: 18rem;
+    margin-top: 1rem;
+  }
+
+  .symbols-hero__metrics span,
+  .symbols-hero__metrics span + span {
+    border-left: 0;
+    padding: 0.5rem 0;
+  }
+
+  .symbols-hero__metrics span + span {
+    border-top: 1px solid rgba(212, 175, 55, 0.12);
+  }
+
+  .symbol-orbit__node--active {
+    transform: rotate(var(--angle)) translateX(min(34vw, 8.6rem)) rotate(calc(-1 * var(--angle))) scale(1.1);
+  }
+
+  .symbol-field {
+    min-height: 23.5rem;
+  }
+
+  .symbol-field__concept {
+    max-width: 6.6rem;
+    min-height: 1.95rem;
+    font-size: 0.56rem;
+    padding: 0.38rem 0.46rem;
+    transform: rotate(var(--angle)) translateX(min(33vw, 8.9rem)) rotate(calc(-1 * var(--angle)));
+  }
+
+  .symbol-field__chapter {
+    width: 1.85rem;
+    font-size: 0.62rem;
+    transform: rotate(calc(var(--angle) + 17deg)) translateX(min(24vw, 6.3rem)) rotate(calc(-1 * (var(--angle) + 17deg)));
+  }
+
+  .symbol-detail h2 {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 420px) {
+  .symbols-hero__metrics {
+    display: none;
+  }
+
+  .symbol-field {
+    min-height: 22rem;
+  }
+
+  .symbol-field__concept {
+    max-width: 5.7rem;
+    min-height: 1.65rem;
+    font-size: 0.48rem;
+    padding: 0.3rem 0.36rem;
+    transform: rotate(var(--angle)) translateX(min(29vw, 5.8rem)) rotate(calc(-1 * var(--angle)));
+  }
+
+  .symbol-field__chapter {
+    width: 0.5rem;
+    font-size: 0;
+    opacity: 0.82;
+    transform: rotate(calc(var(--angle) + 17deg)) translateX(min(19vw, 4.15rem)) rotate(calc(-1 * (var(--angle) + 17deg)));
+  }
+
+  .symbol-detail__chapter-links a {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .symbol-orbit__node,
+  .symbol-field__concept,
+  .symbol-field__chapter,
+  .symbol-detail__chapter-links a,
+  .symbol-panel__activate > span:last-child {
+    transition: none;
+  }
+}

--- a/src/app/pages/SymbolsPage.tsx
+++ b/src/app/pages/SymbolsPage.tsx
@@ -1,4 +1,9 @@
-import { getConcepts, getSymbols } from '../data/aionData';
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router';
+
+import { getChapters, getChapterRoute, getConcepts, getSymbols } from '../data/aionData';
+
+import './SymbolsPage.css';
 
 const glyphs: Record<string, string> = {
   fish: 'F',
@@ -12,9 +17,34 @@ const glyphs: Record<string, string> = {
   zodiac: 'Z',
 };
 
+const toneBySymbol: Record<string, string> = {
+  fish: 'cyan',
+  mandala: 'gold',
+  dragon: 'rose',
+  sophia: 'green',
+  sword: 'cyan',
+  lapis: 'gold',
+  cross: 'gold',
+  ouroboros: 'green',
+  zodiac: 'cyan',
+};
+
 export default function SymbolsPage() {
   const symbols = getSymbols();
   const concepts = getConcepts();
+  const chapters = getChapters();
+  const [activeSymbolId, setActiveSymbolId] = useState(symbols[0]?.id || '');
+  const activeSymbol = symbols.find((symbol) => symbol.id === activeSymbolId) || symbols[0];
+  const activeSymbolIndex = Math.max(0, symbols.findIndex((symbol) => symbol.id === activeSymbol.id));
+  const activeConcepts = useMemo(
+    () => concepts.filter((concept) => activeSymbol.conceptIds.includes(concept.id)),
+    [activeSymbol.conceptIds, concepts],
+  );
+  const relatedChapters = useMemo(
+    () => chapters.filter((chapter) => chapter.keyConceptIds.some((conceptId) => activeSymbol.conceptIds.includes(conceptId))),
+    [activeSymbol.conceptIds, chapters],
+  );
+  const symbolFieldLabel = `${activeSymbol.label} symbol field: ${activeSymbol.motif}. Linked concepts: ${activeConcepts.map((concept) => concept.label).join(', ') || 'none'}. Related chapters: ${relatedChapters.map((chapter) => `Chapter ${chapter.order}, ${chapter.title}`).join('; ') || 'none'}.`;
 
   return (
     <div className="page">
@@ -23,28 +53,112 @@ export default function SymbolsPage() {
           <p className="eyebrow">Symbols</p>
           <h1>Lexicon of recurring images</h1>
           <p className="lede">Symbols act as navigational objects, each carrying threads through chapters and concepts.</p>
+          <div className="symbols-hero__metrics" aria-label="Symbols route counts">
+            <span><strong>{String(symbols.length).padStart(2, '0')}</strong> images</span>
+            <span><strong>{String(activeConcepts.length).padStart(2, '0')}</strong> active threads</span>
+            <span><strong>{String(relatedChapters.length).padStart(2, '0')}</strong> chapter links</span>
+          </div>
         </div>
-        <div className="symbol-orbit" aria-label="Symbol orbit">
-          <div className="symbol-orbit__center">Self</div>
+        <div className="symbol-orbit symbol-orbit--interactive" aria-label="Symbol orbit">
+          <div id="symbol-selected-orbit-detail" className="symbol-orbit__center" aria-live="polite">
+            <span>{glyphs[activeSymbol.id] || activeSymbol.label[0]}</span>
+            <strong>{activeSymbol.label}</strong>
+          </div>
           {symbols.slice(0, 9).map((symbol, index) => (
-            <a
+            <button
               key={symbol.id}
-              className="symbol-orbit__node"
-              href={`#symbol-${symbol.id}`}
+              className={symbol.id === activeSymbol.id ? 'symbol-orbit__node symbol-orbit__node--active' : 'symbol-orbit__node'}
+              type="button"
               style={{ ['--node-index' as string]: index, ['--node-count' as string]: Math.min(symbols.length, 9) }}
-              aria-label={`Jump to ${symbol.label}`}
+              onClick={() => setActiveSymbolId(symbol.id)}
+              aria-controls="symbol-selected-detail symbol-selected-orbit-detail symbol-field"
+              aria-label={`Select ${symbol.label}: ${symbol.motif}`}
+              aria-pressed={symbol.id === activeSymbol.id}
             >
               {glyphs[symbol.id] || symbol.label[0]}
-            </a>
+            </button>
           ))}
         </div>
       </section>
-      <section className="symbol-grid section-band section-band--tight">
+
+      <section className="symbol-lab section-band section-band--tight" aria-labelledby="symbol-lab-title">
+        <div className="section-heading">
+          <p className="eyebrow">Active symbol field</p>
+          <h2 id="symbol-lab-title">Trace how an image carries concepts</h2>
+        </div>
+        <div className="symbol-lab__layout">
+          <div
+            id="symbol-field"
+            className="symbol-field"
+            data-tone={toneBySymbol[activeSymbol.id] || 'gold'}
+            role="img"
+            aria-label={symbolFieldLabel}
+          >
+            <span className="symbol-field__ring symbol-field__ring--outer" aria-hidden="true" />
+            <span className="symbol-field__ring symbol-field__ring--inner" aria-hidden="true" />
+            <span className="symbol-field__axis symbol-field__axis--horizontal" aria-hidden="true" />
+            <span className="symbol-field__axis symbol-field__axis--vertical" aria-hidden="true" />
+            <span className="symbol-field__glyph" aria-hidden="true">{glyphs[activeSymbol.id] || activeSymbol.label[0]}</span>
+            <span className="symbol-field__index" aria-hidden="true">{String(activeSymbolIndex + 1).padStart(2, '0')}</span>
+            {activeConcepts.slice(0, 6).map((concept, index) => (
+              <span
+                key={concept.id}
+                className="symbol-field__concept"
+                style={{ ['--node-index' as string]: index, ['--node-count' as string]: Math.min(activeConcepts.length, 6) }}
+                aria-hidden="true"
+              >
+                {concept.label}
+              </span>
+            ))}
+            {relatedChapters.slice(0, 7).map((chapter, index) => (
+              <span
+                key={chapter.id}
+                className="symbol-field__chapter"
+                style={{ ['--node-index' as string]: index, ['--node-count' as string]: Math.min(relatedChapters.length, 7) }}
+                aria-hidden="true"
+              >
+                {String(chapter.order).padStart(2, '0')}
+              </span>
+            ))}
+          </div>
+
+          <aside id="symbol-selected-detail" className="symbol-detail" aria-live="polite">
+            <p className="eyebrow">{activeSymbol.historicPeriod}</p>
+            <h2>{activeSymbol.label}</h2>
+            <p>{activeSymbol.motif}</p>
+            <div className="symbol-detail__thread-group" aria-label="Linked concepts">
+              {activeConcepts.map((concept) => (
+                <span key={concept.id}>{concept.label}</span>
+              ))}
+            </div>
+            <div className="symbol-detail__chapter-links" aria-label="Related chapters">
+              {relatedChapters.slice(0, 5).map((chapter) => (
+                <Link key={chapter.id} to={getChapterRoute(chapter.id)}>
+                  {String(chapter.order).padStart(2, '0')} · {chapter.title}
+                </Link>
+              ))}
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section className="symbol-grid section-band section-band--tight" aria-label="Recurring symbol index">
         {symbols.map((symbol) => {
           const linked = concepts.filter((concept) => symbol.conceptIds.includes(concept.id));
+          const isActive = symbol.id === activeSymbol.id;
           return (
-            <article key={symbol.id} id={`symbol-${symbol.id}`} className="symbol-panel">
-              <div className="symbol-panel__glyph" aria-hidden="true">{glyphs[symbol.id] || symbol.label[0]}</div>
+            <article key={symbol.id} id={`symbol-${symbol.id}`} className={isActive ? 'symbol-panel symbol-panel--active' : 'symbol-panel'}>
+              <button
+                className="symbol-panel__activate"
+                type="button"
+                onClick={() => setActiveSymbolId(symbol.id)}
+                aria-controls="symbol-selected-detail symbol-selected-orbit-detail symbol-field"
+                aria-label={`Focus ${symbol.label} in the symbol field`}
+                aria-pressed={isActive}
+              >
+                <span className="symbol-panel__glyph" aria-hidden="true">{glyphs[symbol.id] || symbol.label[0]}</span>
+                <span>{isActive ? 'In field' : 'Focus'}</span>
+              </button>
               <p className="eyebrow">{symbol.historicPeriod}</p>
               <h2>{symbol.label}</h2>
               <p>{symbol.motif}</p>


### PR DESCRIPTION
## Summary

Polishes `/symbols` as a visual-first symbolic atlas instrument rather than a static anchor grid.

- Adds a stateful symbol orbit with active selection, pressed state, and live readout.
- Adds an accessible active symbol field that maps the selected image to linked concepts and related chapters from canonical Aion data.
- Adds route-scoped Symbols CSS for the luxury scholarly atlas language, including responsive/narrow mobile simplification.
- Expands app, accessibility, and Pages smoke coverage for the new Symbols interaction and support-route mobile checks.

## Batch Record

Skill stack: orchestration-autopilot, frontend-design, high-end-visual-design, accessibility-review, webapp-testing, Aion skill-routing playbook, github:yeet.

Routes changed: `/symbols`.

Visual thesis: turn Symbols into a symbolic relay chamber where each image becomes a central field with concept threads and chapter satellites.

Browser evidence: `npm run test:visual:control-tower` generated desktop/mobile/narrow screenshots with `/symbols` scoring 100% and no blockers. Additional focused local Playwright pass checked the 320px symbol-lab crop, console errors, and horizontal overflow.

Checks:

- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm run build`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages`
- `npm run test:pages:artifact`
- `npm run test:visual:control-tower`
- `git diff --check`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .`

Residual debt: Timeline empty-state/orbit filtering, About mobile identity hierarchy, and broader performance work on the existing Three chunk remain future batches; this PR intentionally keeps support-route scope to Symbols.