### PR TITLE
[codex] Polish timeline aeon field

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -223,6 +223,57 @@ async function checkAtlasDynamicAccessibility(page, failures) {
   if (!emptyFieldVisible) failures.push('/atlas: empty constellation field is missing an accessible name');
 }
 
+async function checkTimelineDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/timeline`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+
+  const search = page.getByLabel('Search');
+  const category = page.getByLabel('Category');
+  const timelineField = page.getByRole('group', { name: /Timeline field:/ });
+  const orbitLabel = await page.locator('.timeline-orbit').getAttribute('aria-label');
+  const initialFieldLabel = await timelineField.getAttribute('aria-label');
+  const searchVisible = await search.isVisible();
+  const categoryVisible = await category.isVisible();
+  const fieldVisible = await timelineField.isVisible();
+  const initialActiveRailCount = await page.locator('.timeline-rail__item[aria-pressed="true"]').count();
+  const initialActiveFieldCount = await page.locator('.timeline-field__node[aria-pressed="true"]').count();
+  const firstOrbitControls = await page.locator('.timeline-orbit__node').first().getAttribute('aria-controls');
+  const firstFieldControls = await page.locator('.timeline-field__node').first().getAttribute('aria-controls');
+
+  if (!searchVisible) failures.push('/timeline: search input is not visible by label');
+  if (!categoryVisible) failures.push('/timeline: category select is not visible by label');
+  if (!fieldVisible) failures.push('/timeline: timeline field group is missing an accessible name');
+  if (!orbitLabel?.includes('12 events in view')) failures.push(`/timeline: initial orbit label mismatch: ${orbitLabel}`);
+  if (!initialFieldLabel?.includes('22 of 22 events visible')) failures.push(`/timeline: initial field label mismatch: ${initialFieldLabel}`);
+  if (initialActiveRailCount !== 1) failures.push(`/timeline: initial active rail count mismatch: ${initialActiveRailCount}`);
+  if (initialActiveFieldCount !== 1) failures.push(`/timeline: initial active field count mismatch: ${initialActiveFieldCount}`);
+  if (!firstOrbitControls?.includes('timeline-selected-detail') || !firstOrbitControls?.includes('timeline-field')) failures.push(`/timeline: orbit controls mismatch: ${firstOrbitControls}`);
+  if (!firstFieldControls?.includes('timeline-selected-detail') || !firstFieldControls?.includes('timeline-selected-orbit-detail')) failures.push(`/timeline: field controls mismatch: ${firstFieldControls}`);
+
+  const freudRail = page.getByRole('button', { name: /1907 · Encounters First meeting with Sigmund Freud/ });
+  await freudRail.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const freudPressed = await freudRail.getAttribute('aria-pressed');
+  const freudDetail = await page.locator('#timeline-selected-detail h2').textContent();
+  const freudOrbit = await page.locator('#timeline-selected-orbit-detail').textContent();
+  if (freudPressed !== 'true') failures.push(`/timeline: Freud rail did not become pressed: ${freudPressed}`);
+  if (!freudDetail?.includes('First meeting with Sigmund Freud')) failures.push(`/timeline: Freud detail mismatch: ${freudDetail}`);
+  if (!freudOrbit?.includes('1907') || !freudOrbit?.includes('First meeting with Sigmund Freud')) failures.push(`/timeline: Freud orbit mismatch: ${freudOrbit}`);
+
+  await search.fill('not-a-real-term');
+  await page.waitForTimeout(100);
+  const emptyDetail = await page.locator('#timeline-selected-detail h2').textContent();
+  const emptyStatus = await page.locator('.timeline-field__empty').textContent();
+  const emptyFieldLabel = await timelineField.getAttribute('aria-label');
+  const emptyPressedCount = await page.locator('.timeline-rail__item[aria-pressed="true"], .timeline-field__node[aria-pressed="true"], .timeline-orbit__node[aria-pressed="true"]').count();
+  if (!emptyDetail?.includes('Adjust the field')) failures.push(`/timeline: empty detail mismatch: ${emptyDetail}`);
+  if (!emptyStatus?.includes('No matching events')) failures.push(`/timeline: empty status mismatch: ${emptyStatus}`);
+  if (!emptyFieldLabel?.includes('0 of 22 events visible')) failures.push(`/timeline: empty field label mismatch: ${emptyFieldLabel}`);
+  if (emptyPressedCount !== 0) failures.push(`/timeline: empty state still has pressed controls: ${emptyPressedCount}`);
+}
+
 async function checkSymbolsDynamicAccessibility(page, failures) {
   await page.goto(`${baseUrl}/symbols`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
   await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
@@ -626,6 +677,7 @@ async function runAccessibilitySmoke() {
       await checkRoute(desktop, route, failures);
     }
     await checkAtlasDynamicAccessibility(desktop, failures);
+    await checkTimelineDynamicAccessibility(desktop, failures);
     await checkSymbolsDynamicAccessibility(desktop, failures);
     await checkChapterSixDynamicAccessibility(desktop, failures);
     await checkChapterSevenDynamicAccessibility(desktop, failures);

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -339,6 +339,87 @@ async function smokeAtlasVisualSearch(page, failures) {
   if (!emptyImageVisible) failures.push('atlas empty field did not expose empty accessible name');
 }
 
+async function smokeTimelineVisualField(page, failures) {
+  await gotoAppRoute(page, '/timeline');
+
+  const search = page.getByLabel('Search');
+  const category = page.getByLabel('Category');
+  const orbitButtons = page.locator('.timeline-orbit__node');
+  const railItems = page.locator('.timeline-rail__item');
+  const fieldNodes = page.locator('.timeline-field__node');
+  const timelineField = page.getByRole('group', { name: /Timeline field:/ });
+  const initialDetail = await page.locator('#timeline-selected-detail h2').textContent();
+  const initialOrbitLabel = await page.locator('.timeline-orbit').getAttribute('aria-label');
+  const initialFieldLabel = await timelineField.getAttribute('aria-label');
+  const initialActiveRailCount = await page.locator('.timeline-rail__item[aria-pressed="true"]').count();
+  const initialActiveFieldCount = await page.locator('.timeline-field__node[aria-pressed="true"]').count();
+
+  if (await orbitButtons.count() !== 12) failures.push(`timeline initial orbit button count mismatch: ${await orbitButtons.count()}`);
+  if (await railItems.count() !== 22) failures.push(`timeline initial rail count mismatch: ${await railItems.count()}`);
+  if (await fieldNodes.count() !== 22) failures.push(`timeline initial field node count mismatch: ${await fieldNodes.count()}`);
+  if (!initialDetail?.includes('Born in Kesswil')) failures.push(`timeline initial detail mismatch: ${initialDetail}`);
+  if (!initialOrbitLabel?.includes('12 events in view')) failures.push(`timeline initial orbit label mismatch: ${initialOrbitLabel}`);
+  if (!initialFieldLabel?.includes('22 of 22 events visible')) failures.push(`timeline initial field label mismatch: ${initialFieldLabel}`);
+  if (initialActiveRailCount !== 1) failures.push(`timeline initial active rail count mismatch: ${initialActiveRailCount}`);
+  if (initialActiveFieldCount !== 1) failures.push(`timeline initial active field count mismatch: ${initialActiveFieldCount}`);
+
+  const freudRail = page.getByRole('button', { name: /1907 · Encounters First meeting with Sigmund Freud/ });
+  await freudRail.click();
+  await page.waitForTimeout(100);
+  const freudPressed = await freudRail.getAttribute('aria-pressed');
+  const freudDetail = await page.locator('#timeline-selected-detail h2').textContent();
+  const freudOrbitCore = await page.locator('#timeline-selected-orbit-detail').textContent();
+  if (freudPressed !== 'true') failures.push(`timeline Freud rail did not become active: ${freudPressed}`);
+  if (!freudDetail?.includes('First meeting with Sigmund Freud')) failures.push(`timeline Freud detail mismatch: ${freudDetail}`);
+  if (!freudOrbitCore?.includes('1907') || !freudOrbitCore?.includes('First meeting with Sigmund Freud')) failures.push(`timeline Freud orbit core mismatch: ${freudOrbitCore}`);
+
+  await search.fill('Aion');
+  await page.waitForTimeout(100);
+  const aionRailCount = await railItems.count();
+  const aionOrbitCount = await orbitButtons.count();
+  const aionFieldCount = await fieldNodes.count();
+  const aionDetail = await page.locator('#timeline-selected-detail h2').textContent();
+  const aionResult = await page.locator('.timeline-controls__result').textContent();
+  const aionFieldLabel = await timelineField.getAttribute('aria-label');
+  if (aionRailCount !== 1) failures.push(`timeline Aion rail count mismatch: ${aionRailCount}`);
+  if (aionOrbitCount !== 1) failures.push(`timeline Aion orbit count mismatch: ${aionOrbitCount}`);
+  if (aionFieldCount !== 1) failures.push(`timeline Aion field count mismatch: ${aionFieldCount}`);
+  if (!aionDetail?.includes('Publishes "Aion"')) failures.push(`timeline Aion detail mismatch: ${aionDetail}`);
+  if (!aionResult?.includes('1 of 22 events visible')) failures.push(`timeline Aion result mismatch: ${aionResult}`);
+  if (!aionFieldLabel?.includes('1 of 22 events visible')) failures.push(`timeline Aion field label mismatch: ${aionFieldLabel}`);
+
+  await search.fill('');
+  await category.selectOption('concepts');
+  await page.waitForTimeout(100);
+  const conceptsRailCount = await railItems.count();
+  const conceptsOrbitCount = await orbitButtons.count();
+  const conceptsFieldCount = await fieldNodes.count();
+  const conceptsDetail = await page.locator('#timeline-selected-detail h2').textContent();
+  const conceptsActiveRailCount = await page.locator('.timeline-rail__item[aria-pressed="true"]').count();
+  if (conceptsRailCount !== 4) failures.push(`timeline concepts rail count mismatch: ${conceptsRailCount}`);
+  if (conceptsOrbitCount !== 4) failures.push(`timeline concepts orbit count mismatch: ${conceptsOrbitCount}`);
+  if (conceptsFieldCount !== 4) failures.push(`timeline concepts field count mismatch: ${conceptsFieldCount}`);
+  if (!conceptsDetail?.includes('Seven Sermons to the Dead')) failures.push(`timeline concepts detail mismatch: ${conceptsDetail}`);
+  if (conceptsActiveRailCount !== 1) failures.push(`timeline concepts active rail count mismatch: ${conceptsActiveRailCount}`);
+
+  await search.fill('not-a-real-term');
+  await page.waitForTimeout(100);
+  const emptyRailCount = await railItems.count();
+  const emptyOrbitCount = await orbitButtons.count();
+  const emptyFieldCount = await fieldNodes.count();
+  const emptyDetail = await page.locator('#timeline-selected-detail h2').textContent();
+  const emptyMessageVisible = await page.locator('.timeline-field__empty').isVisible();
+  const emptyResult = await page.locator('.timeline-controls__result').textContent();
+  const emptyOrbitCore = await page.locator('#timeline-selected-orbit-detail').textContent();
+  if (emptyRailCount !== 0) failures.push(`timeline empty rail still rendered items: ${emptyRailCount}`);
+  if (emptyOrbitCount !== 0) failures.push(`timeline empty orbit still rendered buttons: ${emptyOrbitCount}`);
+  if (emptyFieldCount !== 0) failures.push(`timeline empty field still rendered nodes: ${emptyFieldCount}`);
+  if (!emptyDetail?.includes('Adjust the field')) failures.push(`timeline empty detail mismatch: ${emptyDetail}`);
+  if (!emptyMessageVisible) failures.push('timeline empty field message is not visible');
+  if (!emptyResult?.includes('0 of 22 events visible')) failures.push(`timeline empty result mismatch: ${emptyResult}`);
+  if (!emptyOrbitCore?.includes('No match') || !emptyOrbitCore?.includes('Adjust the field')) failures.push(`timeline empty orbit core mismatch: ${emptyOrbitCore}`);
+}
+
 async function smokeSymbolsVisualField(page, failures) {
   await gotoAppRoute(page, '/symbols');
 
@@ -3184,6 +3265,7 @@ async function runSmoke() {
     await smokeCanonicalRoutes(page, failures);
     await smokeHomeVisualDetail(page, failures);
     await smokeAtlasVisualSearch(page, failures);
+    await smokeTimelineVisualField(page, failures);
     await smokeSymbolsVisualField(page, failures);
     await smokeChapterRoutes(page, failures);
     await smokeKeyboard(page, failures);

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -147,6 +147,22 @@ async function checkChapterCanvas(page, route, failures) {
   if (pixels <= 8) failures.push(`blank or near-blank chapter canvas: ${route} (${pixels} sampled pixels)`);
 }
 
+async function checkTimelineArtifact(page, failures) {
+  await checkShellRoute(page, '/timeline', failures);
+
+  const title = await page.locator('h1').first().textContent();
+  const railCount = await page.locator('.timeline-rail__item').count();
+  const fieldNodeCount = await page.locator('.timeline-field__node').count();
+  const detailVisible = await page.locator('#timeline-selected-detail').isVisible();
+  const fieldLabel = await page.getByRole('group', { name: /Timeline field:/ }).getAttribute('aria-label');
+
+  if (!title?.includes('Jung in symbolic time')) failures.push(`/timeline artifact title mismatch: ${title}`);
+  if (railCount !== 22) failures.push(`/timeline artifact rail count mismatch: ${railCount}`);
+  if (fieldNodeCount !== 22) failures.push(`/timeline artifact field count mismatch: ${fieldNodeCount}`);
+  if (!detailVisible) failures.push('/timeline artifact detail is not visible');
+  if (!fieldLabel?.includes('22 of 22 events visible')) failures.push(`/timeline artifact field label mismatch: ${fieldLabel}`);
+}
+
 async function runSmoke() {
   const server = createArtifactServer();
   await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
@@ -166,6 +182,7 @@ async function runSmoke() {
         await checkChapterCanvas(desktop, route, failures);
       }
     }
+    await checkTimelineArtifact(desktop, failures);
 
     const legacyChapter = await desktop.goto(`${baseUrl}/chapters/chapter-7.html`, {
       waitUntil: 'domcontentloaded',

--- a/src/app/pages/TimelinePage.css
+++ b/src/app/pages/TimelinePage.css
@@ -1,0 +1,477 @@
+.timeline-hero {
+  position: relative;
+}
+
+.timeline-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0 52% 0 0;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 18% 42%, rgba(212, 175, 55, 0.14), transparent 22rem),
+    radial-gradient(circle at 68% 56%, rgba(83, 216, 232, 0.09), transparent 24rem),
+    linear-gradient(90deg, rgba(5, 5, 8, 0.97), rgba(5, 5, 8, 0));
+}
+
+.timeline-hero > div {
+  position: relative;
+  z-index: 1;
+}
+
+.timeline-hero__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  max-width: 31rem;
+  margin-top: clamp(1.35rem, 3vw, 2.35rem);
+  border-top: 1px solid rgba(212, 175, 55, 0.2);
+  border-bottom: 1px solid rgba(212, 175, 55, 0.12);
+}
+
+.timeline-hero__metrics span {
+  display: grid;
+  gap: 0.18rem;
+  padding: 0.72rem 0.72rem 0.7rem 0;
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.timeline-hero__metrics span + span {
+  border-left: 1px solid rgba(212, 175, 55, 0.12);
+  padding-left: 0.82rem;
+}
+
+.timeline-hero__metrics strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: clamp(1.65rem, 3vw, 2.45rem);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.timeline-orbit {
+  isolation: isolate;
+}
+
+.timeline-orbit::before {
+  background:
+    radial-gradient(circle at 50% 50%, rgba(212, 175, 55, 0.08), transparent 48%),
+    rgba(3, 3, 7, 0.2);
+}
+
+.timeline-orbit::after {
+  box-shadow:
+    inset 0 0 0 1.6rem rgba(83, 216, 232, 0.018),
+    0 0 4rem rgba(83, 216, 232, 0.045);
+}
+
+.timeline-orbit__core {
+  gap: 0.18rem;
+}
+
+.timeline-orbit__core span {
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.timeline-orbit__core strong {
+  display: block;
+  color: var(--gold-soft);
+  font-size: clamp(0.94rem, 1.28vw, 1.18rem);
+  max-width: 8.5rem;
+}
+
+.timeline-orbit__node {
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  transition:
+    transform 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring),
+    color 0.45s var(--motion-spring),
+    box-shadow 0.45s var(--motion-spring);
+}
+
+.timeline-orbit__node--active {
+  border-color: var(--gold);
+  background:
+    radial-gradient(circle at 50% 42%, rgba(212, 175, 55, 0.24), transparent 62%),
+    rgba(3, 3, 7, 0.88);
+  color: var(--text);
+  box-shadow:
+    0 0 0 0.24rem rgba(212, 175, 55, 0.07),
+    0 0 1.8rem rgba(212, 175, 55, 0.32);
+  transform: rotate(var(--angle)) translateX(min(15vw, 13.2rem)) rotate(calc(-1 * var(--angle))) scale(1.12);
+}
+
+.timeline-orbit__empty {
+  position: absolute;
+  left: 50%;
+  top: calc(50% + 6.8rem);
+  width: min(15rem, 78%);
+  margin: 0;
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-align: center;
+  text-transform: uppercase;
+  transform: translateX(-50%);
+}
+
+.timeline-layout {
+  grid-template-columns: minmax(14rem, 0.36fr) minmax(0, 1fr) minmax(18rem, 0.52fr);
+  scroll-margin-top: 7.5rem;
+}
+
+.timeline-controls {
+  align-content: start;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.018)),
+    rgba(5, 5, 8, 0.66);
+  box-shadow: var(--shadow-inset);
+  padding: 1rem;
+}
+
+.timeline-controls label {
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.62rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.timeline-controls__result {
+  margin-top: 0.25rem;
+  border-top: 1px solid rgba(212, 175, 55, 0.14);
+  color: var(--gold-soft);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  padding-top: 0.8rem;
+  text-transform: uppercase;
+}
+
+.timeline-field-stack {
+  display: grid;
+  gap: 1rem;
+  scroll-margin-top: 7.5rem;
+}
+
+.timeline-field {
+  position: relative;
+  min-height: clamp(28rem, 44vw, 36rem);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 26% 24%, rgba(83, 216, 232, 0.08), transparent 14rem),
+    radial-gradient(circle at 70% 72%, rgba(212, 175, 55, 0.1), transparent 16rem),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.065), rgba(255, 255, 255, 0.018)),
+    rgba(5, 5, 8, 0.76);
+  box-shadow: var(--shadow-inset);
+  isolation: isolate;
+}
+
+.timeline-field::before {
+  content: '';
+  position: absolute;
+  inset: 1rem;
+  border: 1px solid rgba(244, 240, 232, 0.055);
+  border-radius: calc(var(--radius) - 2px);
+  pointer-events: none;
+}
+
+.timeline-field__axis {
+  position: absolute;
+  left: 1.35rem;
+  right: 1.35rem;
+  top: 50%;
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid rgba(244, 240, 232, 0.16);
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.62rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  padding-top: 0.55rem;
+  text-transform: uppercase;
+  transform: translateY(-50%);
+}
+
+.timeline-field__row {
+  --row-top: calc(17% + (var(--row-index) * 20%));
+  position: absolute;
+  left: 1.35rem;
+  right: 1.35rem;
+  top: var(--row-top);
+  border-top: 1px solid rgba(212, 175, 55, 0.11);
+  pointer-events: none;
+}
+
+.timeline-field__row::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: -1px;
+  width: 4.2rem;
+  height: 1px;
+  background: var(--row-tone, rgba(212, 175, 55, 0.5));
+  opacity: 0.75;
+}
+
+.timeline-field__row[data-tone='cyan'] {
+  --row-tone: rgba(83, 216, 232, 0.72);
+}
+
+.timeline-field__row[data-tone='green'] {
+  --row-tone: rgba(136, 214, 167, 0.68);
+}
+
+.timeline-field__row[data-tone='rose'] {
+  --row-tone: rgba(218, 112, 139, 0.68);
+}
+
+.timeline-field__row span {
+  position: absolute;
+  left: 0;
+  top: -1.7rem;
+  max-width: 7.5rem;
+  background: rgba(5, 5, 8, 0.78);
+  color: rgba(244, 240, 232, 0.62);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  padding-right: 0.45rem;
+  text-transform: uppercase;
+}
+
+.timeline-field__node {
+  position: absolute;
+  left: var(--event-x);
+  top: calc(17% + (var(--row-index) * 20%));
+  display: grid;
+  place-items: center;
+  width: 2.15rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.24);
+  border-radius: 50%;
+  background: rgba(3, 3, 7, 0.86);
+  color: var(--gold-soft);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 0.54rem;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  transform: translate(-50%, -50%);
+  transition:
+    transform 0.45s var(--motion-spring),
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring),
+    box-shadow 0.45s var(--motion-spring);
+}
+
+.timeline-field__node[data-tone='cyan'] {
+  border-color: rgba(83, 216, 232, 0.36);
+}
+
+.timeline-field__node[data-tone='green'] {
+  border-color: rgba(136, 214, 167, 0.34);
+}
+
+.timeline-field__node[data-tone='rose'] {
+  border-color: rgba(218, 112, 139, 0.34);
+}
+
+.timeline-field__node:hover,
+.timeline-field__node:focus-visible,
+.timeline-field__node--active {
+  border-color: var(--line-strong);
+  background:
+    radial-gradient(circle at 50% 44%, rgba(212, 175, 55, 0.26), transparent 64%),
+    rgba(3, 3, 7, 0.94);
+  box-shadow:
+    0 0 0 0.24rem rgba(212, 175, 55, 0.07),
+    0 0 1.8rem rgba(212, 175, 55, 0.28);
+  transform: translate(-50%, -50%) scale(1.12);
+}
+
+.timeline-field__empty {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 0.35rem;
+  padding: 2rem;
+  text-align: center;
+}
+
+.timeline-field__empty strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: clamp(1.7rem, 4vw, 2.55rem);
+  font-weight: 400;
+}
+
+.timeline-field__empty span {
+  max-width: 18rem;
+  color: var(--muted);
+}
+
+.timeline-rail {
+  max-height: 30rem;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.timeline-rail__item {
+  transition:
+    border-color 0.38s var(--motion-spring),
+    background 0.38s var(--motion-spring),
+    transform 0.38s var(--motion-spring);
+}
+
+.timeline-rail__item:hover,
+.timeline-rail__item:focus-visible,
+.timeline-rail__item--active {
+  transform: translateX(0.16rem);
+}
+
+.timeline-detail {
+  min-height: 19rem;
+}
+
+.timeline-detail h2 {
+  margin: 0;
+  max-width: 12ch;
+}
+
+.timeline-detail p:not(.eyebrow) {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.timeline-detail--empty {
+  border-color: rgba(218, 112, 139, 0.2);
+}
+
+@media (max-width: 1120px) {
+  .timeline-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline-field {
+    min-height: clamp(26rem, 78vw, 34rem);
+  }
+}
+
+@media (max-width: 860px) {
+  .timeline-hero__metrics {
+    grid-template-columns: 1fr;
+    max-width: 18rem;
+    margin-top: 1rem;
+  }
+
+  .timeline-hero__metrics span,
+  .timeline-hero__metrics span + span {
+    border-left: 0;
+    padding: 0.5rem 0;
+  }
+
+  .timeline-hero__metrics span + span {
+    border-top: 1px solid rgba(212, 175, 55, 0.12);
+  }
+
+  .timeline-orbit__node--active {
+    transform: rotate(var(--angle)) translateX(min(34vw, 8.6rem)) rotate(calc(-1 * var(--angle))) scale(1.1);
+  }
+
+  .timeline-field {
+    min-height: 24rem;
+  }
+
+  .timeline-field__row {
+    left: 0.95rem;
+    right: 0.95rem;
+  }
+
+  .timeline-field__row span {
+    max-width: 5.6rem;
+    font-size: 0.5rem;
+  }
+
+  .timeline-field__node {
+    width: 1.85rem;
+    font-size: 0.46rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .timeline-hero__metrics {
+    display: none;
+  }
+
+  .timeline-field {
+    min-height: 22rem;
+  }
+
+  .timeline-field__axis {
+    left: 0.9rem;
+    right: 0.9rem;
+    font-size: 0.52rem;
+  }
+
+  .timeline-field__row span {
+    width: 0.5rem;
+    overflow: hidden;
+    color: transparent;
+    padding-right: 0;
+  }
+
+  .timeline-field__row span::before {
+    content: '';
+    display: block;
+    width: 0.42rem;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: var(--row-tone, rgba(212, 175, 55, 0.56));
+  }
+
+  .timeline-field__node {
+    width: 1.55rem;
+    font-size: 0;
+  }
+
+  .timeline-field__node::before {
+    content: '';
+    width: 0.38rem;
+    aspect-ratio: 1;
+    border-radius: 50%;
+    background: var(--gold-soft);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline-orbit__node,
+  .timeline-field__node,
+  .timeline-rail__item {
+    transition: none;
+  }
+}

--- a/src/app/pages/TimelinePage.tsx
+++ b/src/app/pages/TimelinePage.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react';
 
 import { TIMELINE_CATEGORIES, TIMELINE_EVENTS } from '../../features/timeline/timeline-data.js';
 
+import './TimelinePage.css';
+
 type TimelineEvent = {
   id: string;
   date: string;
@@ -10,8 +12,31 @@ type TimelineEvent = {
   summary: string;
 };
 
+type TimelineCategory = {
+  id: string;
+  label: string;
+};
+
 function year(date: string) {
   return date.slice(0, 4);
+}
+
+function categoryTone(categoryId: string) {
+  const tones: Record<string, string> = {
+    personal: 'gold',
+    publications: 'cyan',
+    encounters: 'green',
+    concepts: 'rose',
+  };
+  return tones[categoryId] || 'gold';
+}
+
+function buildOrbitEvents(events: TimelineEvent[], selectedId: string | null) {
+  if (events.length <= 12) return events;
+  const selectedIndex = events.findIndex((event) => event.id === selectedId);
+  const anchorIndex = selectedIndex >= 0 ? selectedIndex : 0;
+  const start = Math.min(Math.max(anchorIndex - 5, 0), Math.max(events.length - 12, 0));
+  return events.slice(start, start + 12);
 }
 
 export default function TimelinePage() {
@@ -19,7 +44,11 @@ export default function TimelinePage() {
   const [query, setQuery] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const events = TIMELINE_EVENTS as TimelineEvent[];
-  const categories = TIMELINE_CATEGORIES as { id: string; label: string }[];
+  const categories = TIMELINE_CATEGORIES as TimelineCategory[];
+  const categoryRows = categories.filter((item) => item.id !== 'all');
+  const categoryLabels = Object.fromEntries(categories.map((item) => [item.id, item.label]));
+  const firstYear = Math.min(...events.map((event) => Number(year(event.date))));
+  const lastYear = Math.max(...events.map((event) => Number(year(event.date))));
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -30,8 +59,9 @@ export default function TimelinePage() {
     });
   }, [category, events, query]);
 
-  const selected = filtered.find((event) => event.id === selectedId) || filtered[0] || events[0];
-  const orbitEvents = events.slice(0, 12);
+  const selected = filtered.find((event) => event.id === selectedId) || filtered[0] || null;
+  const orbitEvents = buildOrbitEvents(filtered, selected?.id || selectedId);
+  const resultSummary = `${filtered.length} of ${events.length} events visible`;
 
   return (
     <div className="page">
@@ -40,26 +70,44 @@ export default function TimelinePage() {
           <p className="eyebrow">Timeline</p>
           <h1>Jung in symbolic time</h1>
           <p className="lede">A focused chronology places Aion inside a longer rhythm of life, publication, encounter, and concept formation.</p>
-        </div>
-        <div className="timeline-orbit" aria-label="Timeline orbit">
-          <div id="timeline-selected-orbit-detail" className="timeline-orbit__core" aria-live="polite">
-            <span>{year(selected.date)}</span>
-            <strong>{selected.title}</strong>
+          <div className="timeline-hero__metrics" aria-label="Timeline counts">
+            <span><strong>{events.length}</strong> events</span>
+            <span><strong>{filtered.length}</strong> visible</span>
+            <span><strong>{lastYear - firstYear}</strong> year field</span>
           </div>
-          {orbitEvents.map((event, index) => (
-            <button
-              key={event.id}
-              className={event.id === selected.id ? 'timeline-orbit__node timeline-orbit__node--active' : 'timeline-orbit__node'}
-              type="button"
-              style={{ ['--node-index' as string]: index, ['--node-count' as string]: orbitEvents.length }}
-              onClick={() => setSelectedId(event.id)}
-              aria-controls="timeline-selected-detail timeline-selected-orbit-detail"
-              aria-label={`Select ${year(event.date)}: ${event.title}`}
-              aria-pressed={event.id === selected.id}
-            >
-              {year(event.date).slice(2)}
-            </button>
-          ))}
+        </div>
+        <div className="timeline-orbit" aria-label={`Timeline orbit, ${orbitEvents.length} events in view`}>
+          <div id="timeline-selected-orbit-detail" className="timeline-orbit__core" aria-live="polite">
+            {selected ? (
+              <>
+                <span>{year(selected.date)}</span>
+                <strong>{selected.title}</strong>
+              </>
+            ) : (
+              <>
+                <span>No match</span>
+                <strong>Adjust the field</strong>
+              </>
+            )}
+          </div>
+          {orbitEvents.length > 0 ? (
+            orbitEvents.map((event, index) => (
+              <button
+                key={event.id}
+                className={event.id === selected?.id ? 'timeline-orbit__node timeline-orbit__node--active' : 'timeline-orbit__node'}
+                type="button"
+                style={{ ['--node-index' as string]: index, ['--node-count' as string]: orbitEvents.length }}
+                onClick={() => setSelectedId(event.id)}
+                aria-controls="timeline-selected-detail timeline-selected-orbit-detail timeline-field"
+                aria-label={`Select ${year(event.date)}: ${event.title}`}
+                aria-pressed={event.id === selected?.id}
+              >
+                {year(event.date).slice(2)}
+              </button>
+            ))
+          ) : (
+            <p className="timeline-orbit__empty">No events in this filter</p>
+          )}
         </div>
       </section>
       <section className="timeline-layout section-band section-band--tight">
@@ -74,27 +122,91 @@ export default function TimelinePage() {
               </option>
             ))}
           </select>
+          <output className="timeline-controls__result" htmlFor="timeline-search timeline-category" aria-live="polite">
+            {resultSummary}
+          </output>
         </div>
-        <ol className="timeline-rail">
-          {filtered.map((event) => (
-            <li key={event.id}>
-              <button
-                type="button"
-                className={event.id === selected.id ? 'timeline-rail__item timeline-rail__item--active' : 'timeline-rail__item'}
-                onClick={() => setSelectedId(event.id)}
-                aria-controls="timeline-selected-detail timeline-selected-orbit-detail"
-                aria-pressed={event.id === selected.id}
+        <div className="timeline-field-stack">
+          <div
+            id="timeline-field"
+            className={filtered.length > 0 ? 'timeline-field' : 'timeline-field timeline-field--empty'}
+            role="group"
+            aria-label={`Timeline field: ${resultSummary}. Years ${firstYear} to ${lastYear}.`}
+          >
+            <div className="timeline-field__axis" aria-hidden="true">
+              <span>{firstYear}</span>
+              <span>{lastYear}</span>
+            </div>
+            {categoryRows.map((item, index) => (
+              <div
+                key={item.id}
+                className="timeline-field__row"
+                data-tone={categoryTone(item.id)}
+                style={{ ['--row-index' as string]: index }}
+                aria-hidden="true"
               >
-                <span>{year(event.date)}</span>
-                <strong>{event.title}</strong>
-              </button>
-            </li>
-          ))}
-        </ol>
-        <aside id="timeline-selected-detail" className="timeline-detail" aria-live="polite">
-          <p className="eyebrow">{selected.category}</p>
-          <h2>{selected.title}</h2>
-          <p>{selected.summary}</p>
+                <span>{item.label}</span>
+              </div>
+            ))}
+            {filtered.map((event) => {
+              const eventYear = Number(year(event.date));
+              const rowIndex = Math.max(0, categoryRows.findIndex((item) => item.id === event.category));
+              const x = 10 + ((eventYear - firstYear) / Math.max(lastYear - firstYear, 1)) * 80;
+              return (
+                <button
+                  key={event.id}
+                  className={event.id === selected?.id ? 'timeline-field__node timeline-field__node--active' : 'timeline-field__node'}
+                  data-tone={categoryTone(event.category)}
+                  type="button"
+                  style={{ ['--event-x' as string]: `${x}%`, ['--row-index' as string]: rowIndex }}
+                  onClick={() => setSelectedId(event.id)}
+                  aria-controls="timeline-selected-detail timeline-selected-orbit-detail"
+                  aria-label={`Select ${year(event.date)} ${categoryLabels[event.category]} event: ${event.title}`}
+                  aria-pressed={event.id === selected?.id}
+                  title={`${year(event.date)} · ${event.title}`}
+                >
+                  <span>{year(event.date).slice(2)}</span>
+                </button>
+              );
+            })}
+            {filtered.length === 0 ? (
+              <div className="timeline-field__empty" role="status">
+                <strong>No matching events</strong>
+                <span>Loosen the search or choose another category.</span>
+              </div>
+            ) : null}
+          </div>
+          <ol className="timeline-rail" aria-label="Visible timeline events">
+            {filtered.map((event) => (
+              <li key={event.id}>
+                <button
+                  type="button"
+                  className={event.id === selected?.id ? 'timeline-rail__item timeline-rail__item--active' : 'timeline-rail__item'}
+                  onClick={() => setSelectedId(event.id)}
+                  aria-controls="timeline-selected-detail timeline-selected-orbit-detail timeline-field"
+                  aria-pressed={event.id === selected?.id}
+                >
+                  <span>{year(event.date)} · {categoryLabels[event.category]}</span>
+                  <strong>{event.title}</strong>
+                </button>
+              </li>
+            ))}
+          </ol>
+        </div>
+        <aside id="timeline-selected-detail" className={selected ? 'timeline-detail' : 'timeline-detail timeline-detail--empty'} aria-live="polite">
+          {selected ? (
+            <>
+              <p className="eyebrow">{categoryLabels[selected.category] || selected.category}</p>
+              <h2>{selected.title}</h2>
+              <p>{selected.summary}</p>
+            </>
+          ) : (
+            <>
+              <p className="eyebrow">No matching events</p>
+              <h2>Adjust the field</h2>
+              <p>No event matches the current search and category. The visual field has intentionally cleared instead of showing an unrelated detail.</p>
+            </>
+          )}
         </aside>
       </section>
     </div>


### PR DESCRIPTION
## Summary

Polishes `/timeline` into a visual-first time-field instrument and fixes stale filter behavior.

- Replaces stale empty-result fallback with explicit no-match states across orbit, field, and detail.
- Aligns orbit/rail/detail with the active filtered event set.
- Adds an interactive category/time field with event nodes, category rows, responsive narrow-screen simplification, and accessible group labels.
- Adds Timeline-specific app smoke, accessibility smoke, and Pages artifact assertions.

## Batch Record

Skill stack: orchestration-autopilot, frontend-design, high-end-visual-design, data-visualization, accessibility-review, webapp-testing, Aion skill-routing playbook, github:yeet.

Routes changed: `/timeline`.

Visual thesis: turn chronology into an aeon field where life, publications, encounters, and concepts occupy visible strata across Jung's symbolic time.

Browser evidence: `npm run test:visual:control-tower` generated desktop/mobile/narrow screenshots with `/timeline` scoring 100% and no blockers. Additional focused local Playwright pass checked the Timeline field at desktop/mobile/narrow, console errors, node containment, and horizontal overflow.

Checks:

- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages`
- `npm run test:pages:artifact`
- `npm run test:visual:control-tower`
- `git diff --check`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .`

Residual debt: About mobile identity hierarchy and broader Three chunk performance work remain future batches; this PR intentionally keeps support-route scope to Timeline.