### PR TITLE
[codex] Polish chapters arc hub

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -184,6 +184,48 @@ async function checkRoute(page, route, failures) {
   }
 }
 
+async function checkChaptersDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/chapters`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+
+  const arcHub = page.getByLabel('Interactive chapter arc hub');
+  const orbit = page.getByLabel('Interactive chapter orbit');
+  const selectedDetail = page.locator('#chapters-selected-detail');
+  const arcButtons = page.locator('.chapters-arc-map__cluster');
+  const orbitButtons = page.locator('.chapters-orbit__node');
+  const selectedLink = page.locator('.chapters-selected-panel__link');
+  const chapterOneButton = page.getByRole('button', { name: /Preview chapter 1: The Ego/ });
+  const chapterFourteenButton = page.getByRole('button', { name: /Preview chapter 14: The Structure and Dynamics of the Self/ });
+
+  if (!await arcHub.isVisible()) failures.push('/chapters: arc hub is not exposed by label');
+  if (!await orbit.isVisible()) failures.push('/chapters: chapter orbit is not exposed by label');
+  if (await arcButtons.count() !== 7) failures.push(`/chapters: arc button count mismatch: ${await arcButtons.count()}`);
+  if (await orbitButtons.count() !== 14) failures.push(`/chapters: orbit button count mismatch: ${await orbitButtons.count()}`);
+  if (await page.locator('.chapters-orbit__node[aria-controls~="chapters-selected-detail"]').count() !== 14) {
+    failures.push('/chapters: orbit buttons do not all control selected detail');
+  }
+  if (await page.locator('.chapters-orbit__node[aria-pressed="true"]').count() !== 1) {
+    failures.push('/chapters: initial orbit pressed count is not one');
+  }
+
+  await chapterOneButton.focus();
+  await chapterOneButton.press('End');
+  await page.waitForTimeout(100);
+  const chapterFourteenPressed = await chapterFourteenButton.getAttribute('aria-pressed');
+  const detailChapter = await selectedDetail.getAttribute('data-selected-chapter');
+  const linkHref = await selectedLink.getAttribute('href');
+  if (chapterFourteenPressed !== 'true') failures.push(`/chapters: End key did not select chapter 14: ${chapterFourteenPressed}`);
+  if (detailChapter !== 'ch14') failures.push(`/chapters: selected detail did not announce chapter 14: ${detailChapter}`);
+  if (linkHref !== '/journey/chapter/ch14') failures.push(`/chapters: selected chapter link mismatch after keyboard selection: ${linkHref}`);
+
+  await chapterFourteenButton.press('Home');
+  await page.waitForTimeout(100);
+  const chapterOnePressed = await chapterOneButton.getAttribute('aria-pressed');
+  const resetChapter = await selectedDetail.getAttribute('data-selected-chapter');
+  if (chapterOnePressed !== 'true') failures.push(`/chapters: Home key did not return to chapter 1: ${chapterOnePressed}`);
+  if (resetChapter !== 'ch1') failures.push(`/chapters: selected detail did not return to chapter 1: ${resetChapter}`);
+}
+
 async function checkAtlasDynamicAccessibility(page, failures) {
   await page.goto(`${baseUrl}/atlas`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
   await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
@@ -676,6 +718,7 @@ async function runAccessibilitySmoke() {
     for (const route of [...canonicalRoutes, ...chapterRoutes]) {
       await checkRoute(desktop, route, failures);
     }
+    await checkChaptersDynamicAccessibility(desktop, failures);
     await checkAtlasDynamicAccessibility(desktop, failures);
     await checkTimelineDynamicAccessibility(desktop, failures);
     await checkSymbolsDynamicAccessibility(desktop, failures);

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -249,6 +249,116 @@ async function smokeHomeVisualDetail(page, failures) {
   }
 }
 
+async function smokeChaptersArcHub(page, failures) {
+  await gotoAppRoute(page, '/chapters');
+
+  const orbitNodes = page.locator('.chapters-orbit__node');
+  const arcControls = page.locator('.chapters-arc-map__cluster');
+  const chapterCards = page.locator('.chapter-card');
+  const selectedDetail = page.locator('#chapters-selected-detail');
+  const selectedChapterLink = page.locator('.chapters-selected-panel__link');
+  const heroCta = page.locator('.chapters-action');
+  const initialSelectedChapter = await selectedDetail.getAttribute('data-selected-chapter');
+  const initialSelectedTitle = await selectedDetail.locator('h2').textContent();
+  const initialPressedCount = await page.locator('.chapters-orbit__node[aria-pressed="true"]').count();
+  const initialConceptCount = await page.locator('.chapters-orbit__concepts span').count();
+  const initialArcCount = await arcControls.count();
+
+  if (await orbitNodes.count() !== 14) failures.push(`chapters orbit node count mismatch: ${await orbitNodes.count()}`);
+  if (initialArcCount !== 7) failures.push(`chapters arc control count mismatch: ${initialArcCount}`);
+  if (await chapterCards.count() !== 14) failures.push(`chapters card count mismatch: ${await chapterCards.count()}`);
+  if (initialSelectedChapter !== 'ch1') failures.push(`chapters initial selected chapter mismatch: ${initialSelectedChapter}`);
+  if (!initialSelectedTitle?.includes('The Ego')) failures.push(`chapters initial selected title mismatch: ${initialSelectedTitle}`);
+  if (initialPressedCount !== 1) failures.push(`chapters initial pressed orbit count mismatch: ${initialPressedCount}`);
+  if (initialConceptCount < 2) failures.push(`chapters initial concept chips missing: ${initialConceptCount}`);
+
+  const synthesisArc = page.getByRole('button', { name: /Synthesis\s+14–14/ });
+  await synthesisArc.click();
+  await page.waitForTimeout(100);
+
+  const chapterFourteenPressed = await page.getByRole('button', { name: /Preview chapter 14: The Structure and Dynamics of the Self/ }).getAttribute('aria-pressed');
+  const chapterFourteenTitle = await selectedDetail.locator('h2').textContent();
+  const chapterFourteenMotion = await selectedDetail.getAttribute('data-motion-grammar');
+  const chapterFourteenHref = await selectedChapterLink.getAttribute('href');
+  const chapterFourteenHeroHref = await heroCta.getAttribute('href');
+  const chapterFourteenActiveCardCount = await page.locator('.chapter-card--active[data-chapter-id="ch14"]').count();
+  const scrollYAfterArcSelect = await page.evaluate(() => window.scrollY);
+
+  if (chapterFourteenPressed !== 'true') failures.push(`chapters chapter 14 orbit did not become pressed: ${chapterFourteenPressed}`);
+  if (!chapterFourteenTitle?.includes('The Structure and Dynamics of the Self')) failures.push(`chapters detail did not update to chapter 14: ${chapterFourteenTitle}`);
+  if (chapterFourteenMotion !== 'integration') failures.push(`chapters chapter 14 motion grammar mismatch: ${chapterFourteenMotion}`);
+  if (chapterFourteenHref !== '/journey/chapter/ch14') failures.push(`chapters selected panel link mismatch: ${chapterFourteenHref}`);
+  if (chapterFourteenHeroHref !== '/journey/chapter/ch14') failures.push(`chapters hero CTA link mismatch: ${chapterFourteenHeroHref}`);
+  if (chapterFourteenActiveCardCount !== 1) failures.push(`chapters active chapter 14 card count mismatch: ${chapterFourteenActiveCardCount}`);
+  if (scrollYAfterArcSelect > 10) failures.push(`chapters arc selection unexpectedly scrolled page: ${scrollYAfterArcSelect}`);
+
+  const chapterFourteenButton = page.getByRole('button', { name: /Preview chapter 14:/ });
+  await chapterFourteenButton.press('ArrowRight');
+  await page.waitForTimeout(100);
+  const wrappedTitle = await selectedDetail.locator('h2').textContent();
+  const chapterOnePressed = await page.getByRole('button', { name: /Preview chapter 1: The Ego/ }).getAttribute('aria-pressed');
+  if (!wrappedTitle?.includes('The Ego')) failures.push(`chapters arrow navigation did not wrap to chapter 1: ${wrappedTitle}`);
+  if (chapterOnePressed !== 'true') failures.push(`chapters arrow navigation did not press chapter 1: ${chapterOnePressed}`);
+}
+
+async function smokeChaptersMobileLayout(page, failures, viewport) {
+  await gotoAppRoute(page, '/chapters');
+
+  const layout = await page.evaluate(() => {
+    const rect = (element) => {
+      if (!element) return null;
+      const box = element.getBoundingClientRect();
+      return {
+        left: box.left,
+        right: box.right,
+        top: box.top,
+        bottom: box.bottom,
+        width: box.width,
+        height: box.height,
+      };
+    };
+    const intersects = (a, b) => !!a && !!b
+      && a.right > b.left
+      && b.right > a.left
+      && a.bottom > b.top
+      && b.bottom > a.top;
+    const center = rect(document.querySelector('.chapters-orbit__center'));
+    const nodeOverlaps = [...document.querySelectorAll('.chapters-orbit__node')]
+      .map((node) => ({ label: node.textContent?.trim(), box: rect(node) }))
+      .filter((node) => intersects(node.box, center))
+      .map((node) => node.label);
+    const stage = rect(document.querySelector('.chapters-stage'));
+    const orbit = rect(document.querySelector('.chapters-orbit'));
+    const action = document.querySelector('.chapters-action');
+
+    return {
+      arcCount: document.querySelectorAll('.chapters-arc-map__cluster').length,
+      orbitCount: document.querySelectorAll('.chapters-orbit__node').length,
+      cardCount: document.querySelectorAll('.chapter-card').length,
+      pressedCount: document.querySelectorAll('.chapters-orbit__node[aria-pressed="true"]').length,
+      liveRegions: document.querySelectorAll('[aria-live]').length,
+      scrollWidth: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      stageTop: stage?.top,
+      orbitTop: orbit?.top,
+      nodeOverlaps,
+      actionAfterContent: action ? getComputedStyle(action, '::after').content : null,
+    };
+  });
+
+  const label = `${viewport.width}x${viewport.height}`;
+  if (layout.arcCount !== 7) failures.push(`mobile chapters arc count mismatch at ${label}: ${layout.arcCount}`);
+  if (layout.orbitCount !== 14) failures.push(`mobile chapters orbit count mismatch at ${label}: ${layout.orbitCount}`);
+  if (layout.cardCount !== 14) failures.push(`mobile chapters card count mismatch at ${label}: ${layout.cardCount}`);
+  if (layout.pressedCount !== 1) failures.push(`mobile chapters pressed count mismatch at ${label}: ${layout.pressedCount}`);
+  if (layout.liveRegions !== 1) failures.push(`mobile chapters live region count mismatch at ${label}: ${layout.liveRegions}`);
+  if (layout.scrollWidth > layout.viewportWidth + 2) failures.push(`mobile chapters horizontal overflow at ${label}: ${layout.scrollWidth}`);
+  if (layout.orbitTop === undefined || layout.orbitTop > layout.viewportHeight) failures.push(`mobile chapters visual orbit misses first viewport at ${label}: ${Math.round(layout.orbitTop ?? -1)}`);
+  if (layout.nodeOverlaps.length > 0) failures.push(`mobile chapters orbit nodes overlap center at ${label}: ${layout.nodeOverlaps.join(', ')}`);
+  if (layout.actionAfterContent !== 'none') failures.push(`mobile chapters primary CTA has duplicate pseudo arrow at ${label}: ${layout.actionAfterContent}`);
+}
+
 async function smokeAtlasVisualSearch(page, failures) {
   await gotoAppRoute(page, '/atlas');
 
@@ -2668,6 +2778,8 @@ async function smokeMobile(page, failures) {
       failures.push(`mobile nav overlaps home hero copy at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(navBottom)}, copy top ${Math.round(heroCopyBox.y)}`);
     }
 
+    await smokeChaptersMobileLayout(page, failures, viewport);
+
     await gotoAppRoute(page, '/journey/chapter/ch1');
     const chapterNavBox = await page.locator('.app-nav').boundingBox();
     const chapterHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
@@ -3264,6 +3376,7 @@ async function runSmoke() {
 
     await smokeCanonicalRoutes(page, failures);
     await smokeHomeVisualDetail(page, failures);
+    await smokeChaptersArcHub(page, failures);
     await smokeAtlasVisualSearch(page, failures);
     await smokeTimelineVisualField(page, failures);
     await smokeSymbolsVisualField(page, failures);

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -163,6 +163,33 @@ async function checkTimelineArtifact(page, failures) {
   if (!fieldLabel?.includes('22 of 22 events visible')) failures.push(`/timeline artifact field label mismatch: ${fieldLabel}`);
 }
 
+async function checkChaptersArtifact(page, failures) {
+  await checkShellRoute(page, '/chapters', failures);
+
+  const title = await page.locator('h1').first().textContent();
+  const arcCount = await page.locator('.chapters-arc-map__cluster').count();
+  const orbitCount = await page.locator('.chapters-orbit__node').count();
+  const cardCount = await page.locator('.chapter-card').count();
+  const selectedDetail = page.locator('#chapters-selected-detail');
+  const initialChapter = await selectedDetail.getAttribute('data-selected-chapter');
+
+  if (!title?.includes('Fourteen chapters as one psyche arc')) failures.push(`/chapters artifact title mismatch: ${title}`);
+  if (arcCount !== 7) failures.push(`/chapters artifact arc count mismatch: ${arcCount}`);
+  if (orbitCount !== 14) failures.push(`/chapters artifact orbit count mismatch: ${orbitCount}`);
+  if (cardCount !== 14) failures.push(`/chapters artifact card count mismatch: ${cardCount}`);
+  if (initialChapter !== 'ch1') failures.push(`/chapters artifact initial selected chapter mismatch: ${initialChapter}`);
+
+  await page.getByRole('button', { name: /Synthesis\s+14–14/ }).click();
+  await page.waitForTimeout(100);
+  const selectedChapter = await selectedDetail.getAttribute('data-selected-chapter');
+  const selectedLink = await page.locator('.chapters-selected-panel__link').getAttribute('href');
+  const pressedCount = await page.locator('.chapters-orbit__node[aria-pressed="true"]').count();
+
+  if (selectedChapter !== 'ch14') failures.push(`/chapters artifact selected chapter did not update: ${selectedChapter}`);
+  if (selectedLink !== `${basePath}/journey/chapter/ch14`) failures.push(`/chapters artifact selected link mismatch: ${selectedLink}`);
+  if (pressedCount !== 1) failures.push(`/chapters artifact pressed orbit count mismatch: ${pressedCount}`);
+}
+
 async function runSmoke() {
   const server = createArtifactServer();
   await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
@@ -182,6 +209,7 @@ async function runSmoke() {
         await checkChapterCanvas(desktop, route, failures);
       }
     }
+    await checkChaptersArtifact(desktop, failures);
     await checkTimelineArtifact(desktop, failures);
 
     const legacyChapter = await desktop.goto(`${baseUrl}/chapters/chapter-7.html`, {

--- a/src/app/pages/ChaptersPage.css
+++ b/src/app/pages/ChaptersPage.css
@@ -1,0 +1,399 @@
+.page--chapters {
+  --chapters-panel: linear-gradient(145deg, rgba(255, 255, 255, 0.072), rgba(255, 255, 255, 0.018));
+  --chapters-panel-deep: linear-gradient(160deg, rgba(11, 12, 16, 0.94), rgba(5, 5, 8, 0.82));
+  --chapters-line: rgba(255, 255, 255, 0.1);
+  --chapters-gold-line: rgba(212, 175, 55, 0.28);
+}
+
+.page--chapters .chapters-hero {
+  position: relative;
+  min-height: 100dvh;
+  grid-template-columns: minmax(18rem, 0.78fr) minmax(0, 1.42fr);
+  gap: clamp(2rem, 4vw, 4rem);
+  overflow: visible;
+}
+
+.page--chapters .chapters-hero::before {
+  content: '';
+  position: absolute;
+  inset: 8rem 54% 4rem 0;
+  z-index: -1;
+  pointer-events: none;
+  border-left: 1px solid rgba(212, 175, 55, 0.14);
+  background:
+    radial-gradient(circle at 12% 22%, rgba(212, 175, 55, 0.14), transparent 16rem),
+    linear-gradient(90deg, rgba(83, 216, 232, 0.09), transparent 72%);
+}
+
+.page--chapters .chapters-hero__copy h1 {
+  max-width: 8.7ch;
+  text-wrap: balance;
+}
+
+.chapters-hero__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: clamp(1.4rem, 3vw, 2rem);
+  border-top: 1px solid rgba(212, 175, 55, 0.18);
+  border-bottom: 1px solid rgba(212, 175, 55, 0.18);
+}
+
+.chapters-hero__metrics span {
+  display: grid;
+  gap: 0.12rem;
+  padding: 0.72rem 0.85rem 0.72rem 0;
+}
+
+.chapters-hero__metrics span + span {
+  border-left: 1px solid rgba(212, 175, 55, 0.13);
+  padding-left: 0.85rem;
+}
+
+.chapters-hero__metrics strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: clamp(1.85rem, 4vw, 2.8rem);
+  font-weight: 400;
+  line-height: 0.9;
+}
+
+.chapters-hero__metrics small {
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.chapters-action {
+  gap: 0.7rem;
+  padding-right: 0.52rem;
+}
+
+.page--chapters .chapters-action::after {
+  content: none;
+  display: none;
+}
+
+.chapters-action__puck {
+  width: 2rem;
+  height: 2rem;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(5, 5, 8, 0.22);
+  transition: transform 0.48s var(--motion-spring), background 0.48s var(--motion-spring);
+}
+
+.chapters-action:hover .chapters-action__puck,
+.chapters-action:focus-visible .chapters-action__puck {
+  transform: translateX(0.16rem) scale(1.04);
+  background: rgba(5, 5, 8, 0.32);
+}
+
+.chapters-stage {
+  display: grid;
+  grid-template-columns: minmax(24rem, 1fr) minmax(17rem, 0.62fr);
+  gap: 0.85rem;
+  align-items: start;
+}
+
+.chapters-arc-map {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.42rem;
+  padding: 0.38rem;
+  border: 1px solid var(--chapters-line);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.026);
+}
+
+.chapters-arc-map__cluster {
+  min-height: 3.35rem;
+  display: grid;
+  align-content: center;
+  gap: 0.22rem;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012)),
+    radial-gradient(circle at calc((var(--arc-index) + 1) / var(--arc-count) * 100%) 0%, rgba(212, 175, 55, 0.1), transparent 65%);
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0.62rem 0.52rem;
+  text-align: left;
+  transition:
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring),
+    color 0.45s var(--motion-spring),
+    transform 0.45s var(--motion-spring);
+}
+
+.chapters-arc-map__cluster:hover,
+.chapters-arc-map__cluster:focus-visible {
+  border-color: rgba(212, 175, 55, 0.28);
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+.chapters-arc-map__cluster--active {
+  border-color: rgba(212, 175, 55, 0.42);
+  background:
+    linear-gradient(145deg, rgba(212, 175, 55, 0.16), rgba(255, 255, 255, 0.036)),
+    radial-gradient(circle at 50% 0%, rgba(83, 216, 232, 0.09), transparent 68%);
+  color: var(--text);
+}
+
+.chapters-arc-map__cluster span {
+  color: inherit;
+  font-family: var(--font-ui);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.chapters-arc-map__cluster strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: 1.02rem;
+  font-weight: 500;
+}
+
+.page--chapters .chapters-orbit {
+  --orbit-radius: min(16vw, 10.6rem);
+  height: min(68vh, 35rem);
+  min-height: 31rem;
+  border-color: rgba(255, 255, 255, 0.095);
+  border-radius: var(--radius);
+  background:
+    radial-gradient(circle at 50% 45%, rgba(212, 175, 55, 0.16), transparent 9rem),
+    radial-gradient(circle at 42% 58%, rgba(83, 216, 232, 0.1), transparent 15rem),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.054), rgba(255, 255, 255, 0.012));
+  box-shadow: var(--shadow-inset), 0 2rem 6rem rgba(0, 0, 0, 0.22);
+}
+
+.page--chapters .chapters-orbit::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, transparent 49.8%, rgba(212, 175, 55, 0.08) 50%, transparent 50.2%),
+    linear-gradient(180deg, transparent 49.8%, rgba(83, 216, 232, 0.07) 50%, transparent 50.2%);
+  opacity: 0.76;
+}
+
+.chapters-orbit__axis {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  pointer-events: none;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.12), transparent);
+}
+
+.chapters-orbit__axis--horizontal {
+  width: 82%;
+  height: 1px;
+  transform: translate(-50%, -50%);
+}
+
+.chapters-orbit__axis--vertical {
+  width: 1px;
+  height: 82%;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.1), transparent);
+}
+
+.page--chapters .chapters-orbit__rings {
+  inset: 13%;
+  box-shadow:
+    0 0 0 3.1rem rgba(212, 175, 55, 0.02),
+    0 0 0 6.2rem rgba(83, 216, 232, 0.012),
+    inset 0 0 5rem rgba(83, 216, 232, 0.04);
+}
+
+.page--chapters .chapters-orbit__center {
+  width: min(18rem, calc(100% - 3.4rem));
+}
+
+.page--chapters .chapters-orbit__center strong {
+  max-width: 8.6ch;
+  font-size: clamp(2rem, 3.8vw, 3.15rem);
+  text-wrap: balance;
+}
+
+.page--chapters .chapters-orbit__center p {
+  margin-top: 0.52rem;
+  color: var(--gold-soft);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.page--chapters .chapters-orbit__node {
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  box-shadow: 0 0 0 0 rgba(212, 175, 55, 0);
+}
+
+.page--chapters .chapters-orbit__node--active {
+  box-shadow: 0 0 2.2rem rgba(212, 175, 55, 0.3);
+}
+
+.page--chapters .chapters-orbit__concepts {
+  bottom: 1rem;
+}
+
+.chapters-selected-panel {
+  display: grid;
+  align-content: start;
+  gap: 0.58rem;
+  border: 1px solid var(--chapters-line);
+  border-radius: var(--radius);
+  background: var(--chapters-panel-deep);
+  box-shadow: var(--shadow-inset);
+  min-width: 0;
+  min-height: min(68vh, 35rem);
+  padding: clamp(0.85rem, 1.6vw, 1.1rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.chapters-selected-panel::before {
+  content: '';
+  position: absolute;
+  inset: -4rem -5rem auto auto;
+  width: 13rem;
+  aspect-ratio: 1;
+  border: 1px solid rgba(212, 175, 55, 0.13);
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.chapters-selected-panel__kicker {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.45rem;
+  color: var(--gold);
+  font-family: var(--font-ui);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.chapters-selected-panel h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(1.85rem, 2.75vw, 2.85rem);
+  line-height: 0.95;
+  text-wrap: balance;
+}
+
+.chapters-selected-panel p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.42;
+}
+
+.chapters-selected-panel__motion,
+.chapters-selected-panel__insight {
+  display: grid;
+  gap: 0.32rem;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.032);
+  padding: 0.58rem;
+}
+
+.chapters-selected-panel__motion span,
+.chapters-selected-panel__insight span {
+  color: var(--cyan);
+  font-family: var(--font-ui);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.chapters-selected-panel__motion strong,
+.chapters-selected-panel__insight strong {
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  line-height: 1.25;
+}
+
+.chapters-selected-panel__checkpoints {
+  display: grid;
+  gap: 0.42rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chapters-selected-panel__checkpoints li {
+  position: relative;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  padding-left: 1.1rem;
+}
+
+.chapters-selected-panel__checkpoints li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.48rem;
+  width: 0.4rem;
+  height: 0.4rem;
+  border: 1px solid rgba(212, 175, 55, 0.48);
+  border-radius: 50%;
+  background: rgba(212, 175, 55, 0.14);
+}
+
+.chapters-selected-panel__link {
+  min-height: 2.7rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  border: 1px solid rgba(212, 175, 55, 0.24);
+  border-radius: 999px;
+  color: var(--gold-soft);
+  font-family: var(--font-ui);
+  font-size: 0.84rem;
+  font-weight: 800;
+  padding: 0.58rem 0.62rem 0.58rem 0.95rem;
+  text-decoration: none;
+  transition:
+    border-color 0.45s var(--motion-spring),
+    background 0.45s var(--motion-spring),
+    transform 0.45s var(--motion-spring);
+}
+
+.chapters-selected-panel__link span {
+  width: 1.85rem;
+  height: 1.85rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(212, 175, 55, 0.13);
+}
+
+.chapters-selected-panel__link:hover,
+.chapters-selected-panel__link:focus-visible {
+  border-color: rgba(212, 175, 55, 0.42);
+  background: rgba(212, 175, 55, 0.06);
+  transform: translateY(-1px);
+}

--- a/src/app/pages/ChaptersPage.tsx
+++ b/src/app/pages/ChaptersPage.tsx
@@ -1,9 +1,36 @@
-import { useState } from 'react';
+import { useState, type KeyboardEvent } from 'react';
 import { Link } from 'react-router';
 
 import ChapterSigil from '../components/ChapterSigil';
 import { getChapterRoute, getChapters, getConceptsForChapter } from '../data/aionData';
 import { CHAPTER_SCENES } from '../visualization/chapterScenes';
+import './ChaptersPage.css';
+import './ChaptersPageSequence.css';
+import './ChaptersPageResponsive.css';
+
+const motionLabels = {
+  opposition: 'Opposition',
+  integration: 'Integration',
+  transformation: 'Transformation',
+  'cyclical-return': 'Cyclical return',
+} as const;
+
+const motionNotes = {
+  opposition: 'The chapter teaches through tension, mirror, and excluded counter-image.',
+  integration: 'The chapter teaches by holding separated symbolic fields in relation.',
+  transformation: 'The chapter teaches through staged change, vessel, strata, and symbolic pressure.',
+  'cyclical-return': 'The chapter teaches through mandala, orbit, recurrence, and return.',
+} as const;
+
+const clusterNotes: Record<string, string> = {
+  Identity: 'Ego and shadow establish the starting tension of conscious life.',
+  'Relational Psyche': 'Inner figures make relation to the unconscious visible.',
+  Selfhood: 'The Self appears through mandala, Christ-symbol, and the excluded fourth.',
+  'Aeon & Fish': 'Fish, prophecy, and historical anxiety turn time into symbolic weather.',
+  Alchemy: 'The opus gives transformation a vessel, method, and symbolic language.',
+  Gnosis: 'Gnostic images turn fullness, fall, wisdom, and paradox into a cosmic diagram.',
+  Synthesis: 'The final chapter gathers the arc into one dynamic Self-field.',
+};
 
 export default function ChaptersPage() {
   const chapters = getChapters();
@@ -11,17 +38,69 @@ export default function ChaptersPage() {
   const selected = chapters.find((chapter) => chapter.id === selectedId) || chapters[0];
   const selectedConcepts = getConceptsForChapter(selected.id);
   const selectedScene = CHAPTER_SCENES[selected.id];
+  const selectedPanel = selectedScene.panels[0];
+  const chapterArcs = chapters.reduce<Array<{ cluster: string; chapters: typeof chapters }>>((arcs, chapter) => {
+    const existing = arcs.find((arc) => arc.cluster === chapter.cluster);
+    if (existing) {
+      existing.chapters.push(chapter);
+      return arcs;
+    }
+    arcs.push({ cluster: chapter.cluster, chapters: [chapter] });
+    return arcs;
+  }, []);
+  const selectedArc = chapterArcs.find((arc) => arc.cluster === selected.cluster) || chapterArcs[0];
+  const selectedArcIndex = selectedArc.chapters.findIndex((chapter) => chapter.id === selected.id) + 1;
+  const selectedChapterIndex = chapters.findIndex((chapter) => chapter.id === selected.id);
+
+  function selectByIndex(index: number) {
+    const nextIndex = (index + chapters.length) % chapters.length;
+    const nextChapter = chapters[nextIndex];
+    setSelectedId(nextChapter.id);
+    window.requestAnimationFrame(() => {
+      document.querySelector<HTMLButtonElement>(`[data-chapter-orbit-node="${nextChapter.id}"]`)?.focus();
+    });
+  }
+
+  function handleOrbitKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    const nextKeyMap: Record<string, number> = {
+      ArrowRight: index + 1,
+      ArrowDown: index + 1,
+      ArrowLeft: index - 1,
+      ArrowUp: index - 1,
+      Home: 0,
+      End: chapters.length - 1,
+    };
+    const nextIndex = nextKeyMap[event.key];
+    if (nextIndex === undefined) return;
+    event.preventDefault();
+    selectByIndex(nextIndex);
+  }
 
   return (
     <div className="page page--chapters">
       <section className="chapters-hero section-band">
         <div className="chapters-hero__copy">
           <p className="eyebrow">Complete route</p>
-          <h1>Fourteen chapters as visual instruments</h1>
+          <h1>Fourteen chapters as one psyche arc</h1>
           <p className="lede">Aion moves from the small light of ego through shadow, symbolic history, alchemy, Gnosis, and the final dynamics of the Self.</p>
+          <div className="chapters-hero__metrics" aria-label="Chapter route metrics">
+            <span>
+              <strong>{chapters.length}</strong>
+              <small>Chapters</small>
+            </span>
+            <span>
+              <strong>{chapterArcs.length}</strong>
+              <small>Arcs</small>
+            </span>
+            <span>
+              <strong>{selected.order}</strong>
+              <small>Selected</small>
+            </span>
+          </div>
           <div className="hero-actions" aria-label="Chapter actions">
-            <Link className="button button--primary" to={getChapterRoute(selected.id)}>
-              Enter selected chapter
+            <Link className="button button--primary chapters-action" to={getChapterRoute(selected.id)}>
+              <span>Enter selected chapter</span>
+              <span className="chapters-action__puck" aria-hidden="true">→</span>
             </Link>
             <Link className="button button--ghost" to="/atlas">
               Open Atlas
@@ -29,51 +108,144 @@ export default function ChaptersPage() {
           </div>
         </div>
 
-        <div className="chapters-orbit" aria-label="Interactive chapter orbit">
-          <div className="chapters-orbit__rings" aria-hidden="true" />
-          <div id="chapters-selected-detail" className="chapters-orbit__center" aria-live="polite">
-            <ChapterSigil chapter={selected} compact />
-            <span>Chapter {selected.order}</span>
-            <strong>{selected.title}</strong>
-            <p>{selectedScene.visualTheme}</p>
+        <div className="chapters-stage" role="group" aria-label="Interactive chapter arc hub">
+          <div className="chapters-arc-map" role="group" aria-label="Book arc clusters">
+            {chapterArcs.map((arc, index) => {
+              const firstChapter = arc.chapters[0];
+              const lastChapter = arc.chapters[arc.chapters.length - 1];
+              const active = arc.cluster === selected.cluster;
+              return (
+                <button
+                  key={arc.cluster}
+                  className={active ? 'chapters-arc-map__cluster chapters-arc-map__cluster--active' : 'chapters-arc-map__cluster'}
+                  type="button"
+                  style={{
+                    ['--arc-index' as string]: index,
+                    ['--arc-count' as string]: chapterArcs.length,
+                  }}
+                  aria-pressed={active}
+                  aria-controls="chapters-selected-detail"
+                  onClick={() => setSelectedId(firstChapter.id)}
+                >
+                  <span>{arc.cluster}</span>
+                  <strong>{String(firstChapter.order).padStart(2, '0')}–{String(lastChapter.order).padStart(2, '0')}</strong>
+                </button>
+              );
+            })}
           </div>
-          {chapters.map((chapter) => (
-            <button
-              key={chapter.id}
-              className={chapter.id === selected.id ? 'chapters-orbit__node chapters-orbit__node--active' : 'chapters-orbit__node'}
-              type="button"
-              onClick={() => setSelectedId(chapter.id)}
-              style={{ ['--node-index' as string]: chapter.order - 1, ['--node-count' as string]: chapters.length }}
-              aria-controls="chapters-selected-detail"
-              aria-label={`Preview chapter ${chapter.order}: ${chapter.title}`}
-              aria-pressed={chapter.id === selected.id}
-            >
-              {String(chapter.order).padStart(2, '0')}
-            </button>
-          ))}
-          <div className="chapters-orbit__concepts" aria-label="Selected chapter concepts">
-            {selectedConcepts.map((concept) => (
-              <span key={concept.id}>{concept.label}</span>
+
+          <div className="chapters-orbit" role="group" aria-label="Interactive chapter orbit" data-selected-order={selected.order}>
+            <div className="chapters-orbit__rings" aria-hidden="true" />
+            <div className="chapters-orbit__axis chapters-orbit__axis--vertical" aria-hidden="true" />
+            <div className="chapters-orbit__axis chapters-orbit__axis--horizontal" aria-hidden="true" />
+            <div id="chapters-orbit-detail" className="chapters-orbit__center" aria-hidden="true">
+              <ChapterSigil chapter={selected} compact />
+              <span>Chapter {selected.order} · {selected.cluster}</span>
+              <strong>{selected.title}</strong>
+              <p>{motionLabels[selectedScene.motionGrammar]}</p>
+            </div>
+            {chapters.map((chapter, index) => (
+              <button
+                key={chapter.id}
+                className={chapter.id === selected.id ? 'chapters-orbit__node chapters-orbit__node--active' : 'chapters-orbit__node'}
+                type="button"
+                onClick={() => setSelectedId(chapter.id)}
+                onKeyDown={(event) => handleOrbitKeyDown(event, index)}
+                data-chapter-orbit-node={chapter.id}
+                style={{ ['--node-index' as string]: chapter.order - 1, ['--node-count' as string]: chapters.length }}
+                aria-controls="chapters-selected-detail"
+                aria-label={`Preview chapter ${chapter.order}: ${chapter.title}`}
+                aria-pressed={chapter.id === selected.id}
+              >
+                {String(chapter.order).padStart(2, '0')}
+              </button>
             ))}
+            <div className="chapters-orbit__concepts" role="group" aria-label="Selected chapter concepts">
+              {selectedConcepts.map((concept) => (
+                <span key={concept.id}>{concept.label}</span>
+              ))}
+            </div>
           </div>
+
+          <aside
+            id="chapters-selected-detail"
+            className="chapters-selected-panel"
+            aria-live="polite"
+            aria-atomic="true"
+            data-selected-chapter={selected.id}
+            data-motion-grammar={selectedScene.motionGrammar}
+          >
+            <div className="chapters-selected-panel__kicker">
+              <span>{selected.cluster}</span>
+              <span>{selectedArcIndex} of {selectedArc.chapters.length} in arc</span>
+            </div>
+            <h2>{selected.title}</h2>
+            <p>{selected.summary}</p>
+            <div className="chapters-selected-panel__motion">
+              <span>{motionLabels[selectedScene.motionGrammar]}</span>
+              <strong>{selectedScene.visualTheme}</strong>
+              <p>{motionNotes[selectedScene.motionGrammar]}</p>
+            </div>
+            <div className="chapters-selected-panel__insight">
+              <span>{selectedPanel.kicker}</span>
+              <strong>{selectedPanel.title}</strong>
+              <p>{selectedPanel.insight}</p>
+            </div>
+            <ul className="chapters-selected-panel__checkpoints" aria-label="Selected chapter checkpoints">
+              {selectedScene.checkpoints.map((checkpoint) => (
+                <li key={checkpoint}>{checkpoint}</li>
+              ))}
+            </ul>
+            <Link className="chapters-selected-panel__link" to={getChapterRoute(selected.id)}>
+              Open Chapter {selected.order}
+              <span aria-hidden="true">→</span>
+            </Link>
+          </aside>
         </div>
       </section>
 
       <section className="chapter-sequence section-band section-band--tight" aria-label="Chapter sequence">
-        {chapters.map((chapter) => (
-          <Link key={chapter.id} to={getChapterRoute(chapter.id)} className="chapter-card">
-            <ChapterSigil chapter={chapter} compact />
-            <div>
-              <span>{String(chapter.order).padStart(2, '0')} · {chapter.cluster}</span>
-              <h2>{chapter.title}</h2>
-              <div className="chip-row" aria-label="Key concepts">
-                {getConceptsForChapter(chapter.id).map((concept) => (
-                  <span key={concept.id}>{concept.label}</span>
-                ))}
-              </div>
-            </div>
-          </Link>
-        ))}
+        <div className="chapter-sequence__intro">
+          <p className="eyebrow">Guided sequence</p>
+          <h2>Read the route as a changing symbolic field</h2>
+          <p>{clusterNotes[selected.cluster]}</p>
+        </div>
+        <div className="chapter-sequence__grid">
+          {chapters.map((chapter) => {
+            const scene = CHAPTER_SCENES[chapter.id];
+            return (
+              <Link
+                key={chapter.id}
+                to={getChapterRoute(chapter.id)}
+                className={chapter.id === selected.id ? 'chapter-card chapter-card--active' : 'chapter-card'}
+                data-chapter-id={chapter.id}
+                data-motion-grammar={scene.motionGrammar}
+                aria-current={chapter.id === selected.id ? 'true' : undefined}
+              >
+                <ChapterSigil chapter={chapter} compact />
+                <div className="chapter-card__body">
+                  <span>{String(chapter.order).padStart(2, '0')} · {chapter.cluster}</span>
+                  <h3>{chapter.title}</h3>
+                  <p>{chapter.summary}</p>
+                  <div className="chapter-card__theme">
+                    <span>{motionLabels[scene.motionGrammar]}</span>
+                    <strong>{scene.visualTheme}</strong>
+                  </div>
+                  <div className="chip-row" aria-label="Key concepts">
+                    {getConceptsForChapter(chapter.id).map((concept) => (
+                      <span key={concept.id}>{concept.label}</span>
+                    ))}
+                  </div>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+        <div className="chapters-progress" aria-label="Selected chapter position">
+          <span style={{ ['--progress' as string]: `${(selectedChapterIndex / (chapters.length - 1)) * 100}%` }} />
+          <strong>Chapter {selected.order} / {chapters.length}</strong>
+          <small>{selected.cluster}</small>
+        </div>
       </section>
     </div>
   );

--- a/src/app/pages/ChaptersPageResponsive.css
+++ b/src/app/pages/ChaptersPageResponsive.css
@@ -1,0 +1,187 @@
+@media (max-width: 1080px) {
+  .page--chapters .chapters-hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .chapters-stage {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .chapters-arc-map {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .page--chapters .chapters-hero {
+    padding-top: 10rem;
+  }
+
+  .page--chapters .chapters-hero__copy h1 {
+    max-width: 100%;
+    font-size: clamp(3rem, 13vw, 4rem);
+  }
+
+  .page--chapters .chapters-hero__copy .lede {
+    font-size: 1.02rem;
+    line-height: 1.5;
+  }
+
+  .chapters-hero__metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .chapters-hero__metrics span + span {
+    border-left: 1px solid rgba(212, 175, 55, 0.13);
+    border-top: 0;
+    padding-left: 0.55rem;
+  }
+
+  .chapters-hero__metrics span {
+    padding-block: 0.52rem;
+  }
+
+  .chapters-hero__metrics strong {
+    font-size: clamp(1.45rem, 8vw, 2rem);
+  }
+
+  .chapters-arc-map {
+    display: flex;
+    overflow-x: auto;
+    scroll-padding-inline: 0.5rem;
+    scroll-snap-type: x proximity;
+  }
+
+  .chapters-arc-map__cluster {
+    min-width: 8.2rem;
+    scroll-snap-align: start;
+  }
+
+  .page--chapters .chapters-orbit {
+    --orbit-radius: min(34vw, 8.5rem);
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 0.42rem 0.28rem;
+    align-content: center;
+    place-items: center;
+    height: auto;
+    min-height: 26rem;
+    padding: 1rem 0.72rem 0.86rem;
+  }
+
+  .page--chapters .chapters-orbit__center {
+    position: relative;
+    left: auto;
+    top: auto;
+    grid-column: 1 / -1;
+    width: min(16rem, 100%);
+    transform: none;
+    z-index: 1;
+  }
+
+  .page--chapters .chapters-orbit__center strong {
+    font-size: clamp(1.75rem, 8vw, 2.4rem);
+  }
+
+  .page--chapters .chapters-orbit__node {
+    position: relative;
+    left: auto;
+    top: auto;
+    width: 2.3rem;
+    height: 2.3rem;
+    font-size: 0.68rem;
+    transform: none;
+  }
+
+  .page--chapters .chapters-orbit__node--active {
+    transform: none;
+  }
+
+  .page--chapters .chapters-orbit__concepts {
+    position: relative;
+    left: auto;
+    right: auto;
+    bottom: auto;
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .chapters-selected-panel h2 {
+    font-size: clamp(2rem, 10vw, 2.75rem);
+  }
+
+  .chapter-sequence__intro,
+  .chapter-sequence__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .page--chapters .chapter-card {
+    min-height: 0;
+  }
+
+  .chapters-progress {
+    grid-template-columns: 1fr;
+    gap: 0.42rem;
+  }
+}
+
+@media (max-width: 390px) {
+  .page--chapters .chapters-orbit {
+    --orbit-radius: min(34vw, 7.4rem);
+    min-height: 24rem;
+    gap: 0.38rem 0.2rem;
+    padding-inline: 0.52rem;
+  }
+
+  .page--chapters .chapters-orbit__node {
+    width: 2rem;
+    height: 2rem;
+    font-size: 0.62rem;
+  }
+
+  .page--chapters .chapters-orbit__concepts span {
+    padding-inline: 0.48rem;
+    font-size: 0.68rem;
+  }
+}
+
+@media (max-width: 430px) {
+  .page--chapters .chapters-hero__copy > .eyebrow {
+    display: none;
+  }
+
+  .page--chapters .chapters-hero__copy h1 {
+    font-size: clamp(2.2rem, 10.5vw, 3rem);
+  }
+
+  .page--chapters .chapters-hero__copy .lede {
+    display: none;
+  }
+
+  .chapters-hero__metrics {
+    display: none;
+  }
+
+  .page--chapters .hero-actions .button--ghost {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chapters-action__puck,
+  .chapters-arc-map__cluster,
+  .chapters-selected-panel__link,
+  .page--chapters .chapters-orbit__node {
+    transition: none;
+  }
+
+  .chapters-action:hover .chapters-action__puck,
+  .chapters-action:focus-visible .chapters-action__puck,
+  .chapters-arc-map__cluster:hover,
+  .chapters-arc-map__cluster:focus-visible,
+  .chapters-selected-panel__link:hover,
+  .chapters-selected-panel__link:focus-visible {
+    transform: none;
+  }
+}

--- a/src/app/pages/ChaptersPageSequence.css
+++ b/src/app/pages/ChaptersPageSequence.css
@@ -1,0 +1,121 @@
+.page--chapters .chapter-sequence {
+  display: block;
+}
+
+.chapter-sequence__intro {
+  display: grid;
+  grid-template-columns: minmax(0, 0.62fr) minmax(0, 0.38fr);
+  gap: clamp(1rem, 4vw, 3rem);
+  align-items: end;
+  margin-bottom: clamp(1.2rem, 4vw, 2rem);
+}
+
+.chapter-sequence__intro .eyebrow {
+  grid-column: 1 / -1;
+}
+
+.chapter-sequence__intro h2 {
+  max-width: 13ch;
+  font-size: clamp(2.7rem, 6vw, 5.6rem);
+  line-height: 0.9;
+}
+
+.chapter-sequence__intro p:not(.eyebrow) {
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.55;
+}
+
+.chapter-sequence__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.page--chapters .chapter-card {
+  min-height: 13.5rem;
+  align-items: start;
+  border-color: rgba(255, 255, 255, 0.085);
+  background:
+    var(--chapters-panel),
+    radial-gradient(circle at 88% 16%, rgba(212, 175, 55, 0.08), transparent 9rem);
+}
+
+.page--chapters .chapter-card--active {
+  border-color: rgba(212, 175, 55, 0.38);
+  background:
+    linear-gradient(145deg, rgba(212, 175, 55, 0.12), rgba(255, 255, 255, 0.025)),
+    radial-gradient(circle at 88% 16%, rgba(83, 216, 232, 0.1), transparent 9rem);
+}
+
+.chapter-card__body {
+  min-width: 0;
+}
+
+.page--chapters .chapter-card h3 {
+  margin: 0.25rem 0 0.48rem;
+  color: var(--text);
+  font-family: var(--font-display);
+  font-size: clamp(1.7rem, 3.4vw, 2.9rem);
+  font-weight: 400;
+  line-height: 0.94;
+  text-wrap: balance;
+}
+
+.page--chapters .chapter-card p {
+  display: -webkit-box;
+  margin: 0 0 0.72rem;
+  color: var(--muted);
+  line-height: 1.45;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.chapter-card__theme {
+  display: grid;
+  gap: 0.16rem;
+  margin-bottom: 0.7rem;
+}
+
+.chapter-card__theme span {
+  color: var(--cyan);
+  font-family: var(--font-ui);
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.chapter-card__theme strong {
+  color: rgba(244, 240, 232, 0.88);
+  font-family: var(--font-ui);
+  font-size: 0.82rem;
+  line-height: 1.25;
+}
+
+.chapters-progress {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.8rem;
+  align-items: center;
+  margin-top: 1rem;
+  color: var(--dim);
+  font-family: var(--font-ui);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.chapters-progress span {
+  --progress: 0%;
+  height: 1px;
+  display: block;
+  background:
+    linear-gradient(90deg, rgba(212, 175, 55, 0.86) 0 var(--progress), rgba(255, 255, 255, 0.12) var(--progress) 100%);
+}
+
+.chapters-progress strong {
+  color: var(--gold-soft);
+}


### PR DESCRIPTION
## Summary

Rebuilds `/chapters` as a visual-first chapter arc hub instead of a simple chapter list. The route now presents Aion as seven symbolic arcs with a selectable chapter orbit, live selected-detail panel, concise motion grammar, concept chips, and a richer guided sequence grid.

## Skill stack

- `orchestration-autopilot` with reviewer/test-verifier subagents
- `frontend-design`
- `accessibility-review`
- `webapp-testing`
- Browser/Playwright visual QA
- `github:yeet`

## Routes changed

- `/chapters`

## Visual thesis

Fourteen chapters become one navigable psyche arc: Identity, Relational Psyche, Selfhood, Aeon & Fish, Alchemy, Gnosis, and Synthesis. Desktop keeps the luxury scholarly atlas feel with a large serif route thesis plus chapter orbit; mobile trims text and brings the visual field into the first viewport.

## Browser evidence

- Local Playwright screenshots captured at 1440x1000, 390x844, and 320x568.
- Checked no console errors, no unexpected failed requests, no body horizontal overflow.
- Verified `/chapters` has 7 arc controls, 14 orbit nodes, 14 cards, one selected chapter, one live region, no duplicate CTA pseudo-arrow.
- Added smoke coverage for 390px and 320px mobile orbit overlap and first-viewport visual presence.

## Checks

- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages && npm run test:pages:artifact`
- `npm run test:visual:control-tower`
- `git diff --check`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .`

## Residual debt

- Vite still reports the existing large `three` chunk warning; this is not new to the route polish and remains a later performance-hardening batch.
- The generated Control Tower screenshots remain uncommitted evidence under `test-results/`.
