### PR TITLE
[codex] Polish About orientation instrument

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -354,6 +354,52 @@ async function checkSymbolsDynamicAccessibility(page, failures) {
   if (!lapisDetail?.includes('Lapis')) failures.push(`/symbols: Lapis detail mismatch: ${lapisDetail}`);
 }
 
+async function checkAboutDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/about`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+
+  const orientation = page.getByRole('group', { name: /Aion orientation instrument/ });
+  const controls = page.getByRole('group', { name: /Learning orientation modes/ });
+  const detail = page.locator('#about-orientation-detail');
+  const field = page.getByRole('img', { name: /Aion learning orientation field/ });
+  const modeButtons = page.locator('.about-orientation-node');
+  const detailLive = await detail.getAttribute('aria-live');
+  const detailAtomic = await detail.getAttribute('aria-atomic');
+  const controlsCount = await modeButtons.count();
+  const controlsWithTargets = await page.locator('.about-orientation-node[aria-controls~="about-orientation-detail"][aria-controls~="about-orientation-field"]').count();
+  const initialPressed = await page.locator('.about-orientation-node[aria-pressed="true"]').count();
+
+  if (!await orientation.isVisible()) failures.push('/about: orientation group is missing an accessible name');
+  if (!await controls.isVisible()) failures.push('/about: orientation controls group is missing an accessible name');
+  if (!await field.isVisible()) failures.push('/about: orientation field image is missing an accessible name');
+  if (detailLive !== 'polite') failures.push(`/about: detail live region mismatch: ${detailLive}`);
+  if (detailAtomic !== 'true') failures.push(`/about: detail live region should be atomic: ${detailAtomic}`);
+  if (controlsCount !== 4) failures.push(`/about: orientation button count mismatch: ${controlsCount}`);
+  if (controlsWithTargets !== 4) failures.push(`/about: orientation buttons controls mismatch: ${controlsWithTargets}`);
+  if (initialPressed !== 1) failures.push(`/about: initial pressed count mismatch: ${initialPressed}`);
+
+  const map = page.getByRole('button', { name: /Map: See concepts as relations/ });
+  await map.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+  const mapPressed = await map.getAttribute('aria-pressed');
+  const mapDetail = await detail.textContent();
+  if (mapPressed !== 'true') failures.push(`/about: Map button did not become pressed: ${mapPressed}`);
+  if (!mapDetail?.includes('See concepts as relations') || !mapDetail?.includes('Concept graph')) failures.push(`/about: Map detail did not update: ${mapDetail}`);
+
+  const verify = page.getByRole('button', { name: /Verify: Keep the orientation honest/ });
+  await verify.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+  const verifyPressed = await verify.getAttribute('aria-pressed');
+  const verifyDetail = await detail.textContent();
+  if (verifyPressed !== 'true') failures.push(`/about: Verify button did not become pressed: ${verifyPressed}`);
+  if (!verifyDetail?.includes('Keep the orientation honest') || !verifyDetail?.includes('Quality gate')) failures.push(`/about: Verify detail did not update: ${verifyDetail}`);
+
+  const finalPressed = await page.locator('.about-orientation-node[aria-pressed="true"]').count();
+  if (finalPressed !== 1) failures.push(`/about: final pressed count mismatch: ${finalPressed}`);
+}
+
 async function checkChapterSixDynamicAccessibility(page, failures) {
   await page.goto(`${baseUrl}/journey/chapter/ch6`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
   await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
@@ -722,6 +768,7 @@ async function runAccessibilitySmoke() {
     await checkAtlasDynamicAccessibility(desktop, failures);
     await checkTimelineDynamicAccessibility(desktop, failures);
     await checkSymbolsDynamicAccessibility(desktop, failures);
+    await checkAboutDynamicAccessibility(desktop, failures);
     await checkChapterSixDynamicAccessibility(desktop, failures);
     await checkChapterSevenDynamicAccessibility(desktop, failures);
     await checkChapterEightDynamicAccessibility(desktop, failures);

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -587,6 +587,77 @@ async function smokeSymbolsVisualField(page, failures) {
   if (!lapisFieldLabel?.includes('Lapis philosophorum') || !lapisFieldLabel?.toLowerCase().includes('individuation')) failures.push(`symbols Lapis field label mismatch: ${lapisFieldLabel}`);
 }
 
+async function smokeAboutOrientation(page, failures) {
+  await gotoAppRoute(page, '/about');
+
+  const title = await page.locator('h1').first().textContent();
+  const orientation = page.getByRole('group', { name: /Aion orientation instrument/ });
+  const field = page.getByRole('img', { name: /Aion learning orientation field/ });
+  const modeButtons = page.locator('.about-orientation-node');
+  const routeCards = page.locator('.about-route-card');
+  const detail = page.locator('#about-orientation-detail');
+  const routeCardHrefs = await routeCards.evaluateAll((links) => links.map((link) => link.getAttribute('href')));
+  const scrollYBeforeSelect = await page.evaluate(() => window.scrollY);
+
+  if (!title?.includes('Aion visual atlas')) failures.push(`/about title mismatch: ${title}`);
+  if (!await orientation.isVisible()) failures.push('/about orientation group is not visible');
+  if (!await field.isVisible()) failures.push('/about orientation field is missing an accessible image role');
+  if (await modeButtons.count() !== 4) failures.push(`/about mode button count mismatch: ${await modeButtons.count()}`);
+  if (await routeCards.count() !== 4) failures.push(`/about route card count mismatch: ${await routeCards.count()}`);
+  if (await detail.getAttribute('data-active-mode') !== 'study') failures.push(`/about initial detail mode mismatch: ${await detail.getAttribute('data-active-mode')}`);
+  if (await page.locator('.about-orientation-node[aria-pressed="true"]').count() !== 1) failures.push('/about initial pressed mode count is not one');
+  for (const expectedHref of ['/chapters', '/atlas', '/symbols', '/timeline']) {
+    if (!routeCardHrefs.includes(expectedHref)) failures.push(`/about route cards missing href: ${expectedHref}`);
+  }
+
+  const nodeHitTargets = await modeButtons.evaluateAll((buttons) => buttons.map((button) => {
+    const box = button.getBoundingClientRect();
+    const target = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+    return {
+      name: button.getAttribute('aria-label') || button.textContent?.trim() || 'unknown',
+      hit: button === target || button.contains(target),
+    };
+  }));
+  for (const target of nodeHitTargets) {
+    if (!target.hit) failures.push(`/about orientation node center is obstructed: ${target.name}`);
+  }
+
+  const mapButton = page.getByRole('button', { name: /Map: See concepts as relations/ });
+  await mapButton.click();
+  await page.waitForTimeout(100);
+  const mapPressed = await mapButton.getAttribute('aria-pressed');
+  const mapDetailMode = await detail.getAttribute('data-active-mode');
+  const mapDetailTitle = await page.locator('#about-orientation-detail h2').textContent();
+  const mapLinkHref = await page.locator('.about-orientation__link').getAttribute('href');
+  if (mapPressed !== 'true') failures.push(`/about Map mode did not become pressed: ${mapPressed}`);
+  if (mapDetailMode !== 'map') failures.push(`/about Map detail mode mismatch: ${mapDetailMode}`);
+  if (!mapDetailTitle?.includes('See concepts as relations')) failures.push(`/about Map detail title mismatch: ${mapDetailTitle}`);
+  if (mapLinkHref !== '/atlas') failures.push(`/about Map link href mismatch: ${mapLinkHref}`);
+
+  const symbolizeButton = page.getByRole('button', { name: /Symbolize: Read images as carriers/ });
+  await symbolizeButton.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+  const symbolizePressed = await symbolizeButton.getAttribute('aria-pressed');
+  const symbolizeDetailMode = await detail.getAttribute('data-active-mode');
+  const symbolizeDetailTitle = await page.locator('#about-orientation-detail h2').textContent();
+  if (symbolizePressed !== 'true') failures.push(`/about Symbolize mode did not become pressed: ${symbolizePressed}`);
+  if (symbolizeDetailMode !== 'symbolize') failures.push(`/about Symbolize detail mode mismatch: ${symbolizeDetailMode}`);
+  if (!symbolizeDetailTitle?.includes('Read images as carriers')) failures.push(`/about Symbolize detail title mismatch: ${symbolizeDetailTitle}`);
+
+  const verifyButton = page.getByRole('button', { name: /Verify: Keep the orientation honest/ });
+  await verifyButton.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+  const verifyPressed = await verifyButton.getAttribute('aria-pressed');
+  const verifyDetailText = await detail.textContent();
+  const scrollYAfterSelect = await page.evaluate(() => window.scrollY);
+  if (verifyPressed !== 'true') failures.push(`/about Verify mode did not become pressed: ${verifyPressed}`);
+  if (!verifyDetailText?.includes('Quality gate') || !verifyDetailText?.includes('Smoke, accessibility')) failures.push(`/about Verify evidence mismatch: ${verifyDetailText}`);
+  if (scrollYAfterSelect > scrollYBeforeSelect + 10) failures.push(`/about mode selection unexpectedly scrolled page: ${scrollYAfterSelect}`);
+  if (await page.locator('.about-orientation-node[aria-pressed="true"]').count() !== 1) failures.push('/about pressed mode count after interaction is not one');
+}
+
 async function smokeChapterRoutes(page, failures) {
   const browser = page.context().browser();
 
@@ -3380,6 +3451,7 @@ async function runSmoke() {
     await smokeAtlasVisualSearch(page, failures);
     await smokeTimelineVisualField(page, failures);
     await smokeSymbolsVisualField(page, failures);
+    await smokeAboutOrientation(page, failures);
     await smokeChapterRoutes(page, failures);
     await smokeKeyboard(page, failures);
     await smokeLegacyRedirect(page, failures);

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -190,6 +190,38 @@ async function checkChaptersArtifact(page, failures) {
   if (pressedCount !== 1) failures.push(`/chapters artifact pressed orbit count mismatch: ${pressedCount}`);
 }
 
+async function checkAboutArtifact(page, failures) {
+  await checkShellRoute(page, '/about', failures);
+
+  const title = await page.locator('h1').first().textContent();
+  const fieldVisible = await page.getByRole('img', { name: /Aion learning orientation field/ }).isVisible();
+  const modeCount = await page.locator('.about-orientation-node').count();
+  const routeCardCount = await page.locator('.about-route-card').count();
+  const routeCardHrefs = await page.locator('.about-route-card').evaluateAll((links) => links.map((link) => link.getAttribute('href')));
+  const initialMode = await page.locator('#about-orientation-detail').getAttribute('data-active-mode');
+
+  if (!title?.includes('Aion visual atlas')) failures.push(`/about artifact title mismatch: ${title}`);
+  if (!fieldVisible) failures.push('/about artifact orientation field is not visible');
+  if (modeCount !== 4) failures.push(`/about artifact mode count mismatch: ${modeCount}`);
+  if (routeCardCount !== 4) failures.push(`/about artifact route card count mismatch: ${routeCardCount}`);
+  if (initialMode !== 'study') failures.push(`/about artifact initial detail mode mismatch: ${initialMode}`);
+
+  for (const expectedHref of [`${basePath}/chapters`, `${basePath}/atlas`, `${basePath}/symbols`, `${basePath}/timeline`]) {
+    if (!routeCardHrefs.includes(expectedHref)) failures.push(`/about artifact route cards missing href: ${expectedHref}`);
+  }
+
+  await page.getByRole('button', { name: /Map: See concepts as relations/ }).click();
+  await page.waitForTimeout(100);
+  const selectedMode = await page.locator('#about-orientation-detail').getAttribute('data-active-mode');
+  const selectedTitle = await page.locator('#about-orientation-detail h2').textContent();
+  const selectedLink = await page.locator('.about-orientation__link').getAttribute('href');
+  const pressedCount = await page.locator('.about-orientation-node[aria-pressed="true"]').count();
+  if (selectedMode !== 'map') failures.push(`/about artifact selected mode mismatch: ${selectedMode}`);
+  if (!selectedTitle?.includes('See concepts as relations')) failures.push(`/about artifact selected detail mismatch: ${selectedTitle}`);
+  if (selectedLink !== `${basePath}/atlas`) failures.push(`/about artifact selected link mismatch: ${selectedLink}`);
+  if (pressedCount !== 1) failures.push(`/about artifact pressed mode count mismatch: ${pressedCount}`);
+}
+
 async function runSmoke() {
   const server = createArtifactServer();
   await new Promise((resolve) => server.listen(port, '127.0.0.1', resolve));
@@ -210,6 +242,7 @@ async function runSmoke() {
       }
     }
     await checkChaptersArtifact(desktop, failures);
+    await checkAboutArtifact(desktop, failures);
     await checkTimelineArtifact(desktop, failures);
 
     const legacyChapter = await desktop.goto(`${baseUrl}/chapters/chapter-7.html`, {

--- a/scripts/testing/visual-control-tower.mjs
+++ b/scripts/testing/visual-control-tower.mjs
@@ -28,7 +28,7 @@ const supportRoutes = [
   { route: '/atlas', label: 'Atlas', kind: 'map' },
   { route: '/timeline', label: 'Timeline', kind: 'support' },
   { route: '/symbols', label: 'Symbols', kind: 'support' },
-  { route: '/about', label: 'About', kind: 'support' },
+  { route: '/about', label: 'About', kind: 'orientation' },
 ];
 
 const chapterRoutes = [...chaptersJson.chapters]

--- a/src/app/pages/AboutPage.tsx
+++ b/src/app/pages/AboutPage.tsx
@@ -4,13 +4,16 @@ import { Link } from 'react-router';
 import { getChapters, getConcepts, getSymbols } from '../data/aionData';
 
 import './AboutPage.css';
+import './AboutPageInstrument.css';
 
 const ORIENTATION_MODES = [
   {
     id: 'study',
     label: 'Study',
+    glyph: 'I',
     title: 'Follow the chapter argument',
     body: 'Begin with a guided sequence: each chapter becomes a visual instrument for one movement in Aion.',
+    proof: 'Chapter arc',
     route: '/chapters',
     routeLabel: 'Chapters',
     statLabel: 'visual chapters',
@@ -19,8 +22,10 @@ const ORIENTATION_MODES = [
   {
     id: 'map',
     label: 'Map',
+    glyph: 'II',
     title: 'See concepts as relations',
     body: 'Use the atlas when a term, symbol, or chapter needs to be understood through its neighbors.',
+    proof: 'Concept graph',
     route: '/atlas',
     routeLabel: 'Atlas',
     statLabel: 'linked concepts',
@@ -29,8 +34,10 @@ const ORIENTATION_MODES = [
   {
     id: 'symbolize',
     label: 'Symbolize',
+    glyph: 'III',
     title: 'Read images as carriers',
     body: 'Symbols are treated as recurring objects that carry meaning across the book without replacing the text.',
+    proof: 'Symbol field',
     route: '/symbols',
     routeLabel: 'Symbols',
     statLabel: 'recurring symbols',
@@ -39,8 +46,10 @@ const ORIENTATION_MODES = [
   {
     id: 'verify',
     label: 'Verify',
+    glyph: 'IV',
     title: 'Keep the orientation honest',
     body: "Context, restraint, accessibility, and route checks keep the visual layer in service of Jung's argument.",
+    proof: 'Quality gate',
     route: '/timeline',
     routeLabel: 'Timeline',
     statLabel: 'context path',
@@ -56,11 +65,21 @@ export default function AboutPage() {
   const symbols = getSymbols();
   const [activeModeId, setActiveModeId] = useState<OrientationMode['id']>('study');
   const activeMode = ORIENTATION_MODES.find((mode) => mode.id === activeModeId) || ORIENTATION_MODES[0];
+  const chapterClusters = [...new Set(chapters.map((chapter) => chapter.cluster))];
+  const conceptDifficulties = [...new Set(concepts.map((concept) => concept.difficulty))];
+  const symbolPeriods = [...new Set(symbols.map((symbol) => symbol.historicPeriod))];
+  const finalChapter = chapters.at(-1);
   const statValueByMode: Record<OrientationMode['id'], string> = {
     study: String(chapters.length).padStart(2, '0'),
     map: String(concepts.length).padStart(2, '0'),
     symbolize: String(symbols.length).padStart(2, '0'),
     verify: 'AA',
+  };
+  const evidenceByMode: Record<OrientationMode['id'], string> = {
+    study: `${chapterClusters.length} clusters: ${chapterClusters.slice(0, 3).join(', ')}`,
+    map: `${conceptDifficulties.length} difficulty bands: ${conceptDifficulties.join(', ')}`,
+    symbolize: `${symbolPeriods.length} historical periods in view`,
+    verify: 'Smoke, accessibility, Pages, and visual QA gates',
   };
 
   return (
@@ -70,102 +89,112 @@ export default function AboutPage() {
           <p className="eyebrow">About</p>
           <h1>Aion visual atlas</h1>
           <p className="lede">
-            A sparse, interactive map of chapters, concepts, symbols, and checks that keeps visuals in service of Jung's argument.
+            A visual learning instrument for reading Aion through chapters, concepts, symbols, and disciplined verification.
           </p>
-          <div className="about-mode-controls" aria-label="Learning orientation modes">
-            {ORIENTATION_MODES.map((mode) => (
-              <button
-                key={mode.id}
-                type="button"
-                className={mode.id === activeMode.id ? 'about-mode-controls__button about-mode-controls__button--active' : 'about-mode-controls__button'}
-                onClick={() => setActiveModeId(mode.id)}
-                aria-controls="about-orientation-detail about-orientation-field"
-                aria-pressed={mode.id === activeMode.id}
-              >
-                {mode.label}
-              </button>
-            ))}
+          <div className="about-hero__metrics" aria-label="Aion atlas data model">
+            <span>
+              <strong>{chapters.length}</strong>
+              chapters
+            </span>
+            <span>
+              <strong>{concepts.length}</strong>
+              concepts
+            </span>
+            <span>
+              <strong>{symbols.length}</strong>
+              symbols
+            </span>
           </div>
         </div>
 
-        <div className="about-orientation" data-active-mode={activeMode.id}>
-          <svg
-            id="about-orientation-field"
-            className="about-north-star-field"
-            viewBox="0 0 640 640"
-            role="img"
-            aria-labelledby="about-field-title about-field-desc"
-          >
-            <title id="about-field-title">Aion learning orientation field</title>
-            <desc id="about-field-desc">
-              Four routes orbit the Self: study the chapters, map concepts, read symbols, and verify context.
-            </desc>
-            <defs>
-              <radialGradient id="about-field-glow" cx="50%" cy="50%" r="55%">
-                <stop offset="0%" stopColor="rgba(212, 175, 55, 0.58)" />
-                <stop offset="36%" stopColor="rgba(83, 216, 232, 0.14)" />
-                <stop offset="100%" stopColor="rgba(3, 3, 7, 0)" />
-              </radialGradient>
-              <linearGradient id="about-field-axis" x1="0%" x2="100%" y1="50%" y2="50%">
-                <stop offset="0%" stopColor="rgba(244, 240, 232, 0)" />
-                <stop offset="50%" stopColor="rgba(244, 240, 232, 0.46)" />
-                <stop offset="100%" stopColor="rgba(244, 240, 232, 0)" />
-              </linearGradient>
-              <filter id="about-field-blur">
-                <feGaussianBlur stdDeviation="10" />
-              </filter>
-            </defs>
+        <div
+          className="about-orientation"
+          data-active-mode={activeMode.id}
+          role="group"
+          aria-label={`Aion orientation instrument. Active path: ${activeMode.label}. ${activeMode.title}.`}
+        >
+          <div className="about-orientation__stage">
+            <svg
+              id="about-orientation-field"
+              className="about-north-star-field"
+              viewBox="0 0 640 640"
+              role="img"
+              aria-labelledby="about-field-title about-field-desc"
+            >
+              <title id="about-field-title">Aion learning orientation field</title>
+              <desc id="about-field-desc">
+                Four routes orbit the Self: study the chapters, map concepts, read symbols, and verify context.
+              </desc>
+              <defs>
+                <radialGradient id="about-field-glow" cx="50%" cy="50%" r="55%">
+                  <stop offset="0%" stopColor="rgba(212, 175, 55, 0.58)" />
+                  <stop offset="36%" stopColor="rgba(83, 216, 232, 0.14)" />
+                  <stop offset="100%" stopColor="rgba(3, 3, 7, 0)" />
+                </radialGradient>
+                <linearGradient id="about-field-axis" x1="0%" x2="100%" y1="50%" y2="50%">
+                  <stop offset="0%" stopColor="rgba(244, 240, 232, 0)" />
+                  <stop offset="50%" stopColor="rgba(244, 240, 232, 0.46)" />
+                  <stop offset="100%" stopColor="rgba(244, 240, 232, 0)" />
+                </linearGradient>
+                <filter id="about-field-blur">
+                  <feGaussianBlur stdDeviation="10" />
+                </filter>
+              </defs>
 
-            <rect className="about-north-star-field__plate" x="28" y="28" width="584" height="584" rx="22" />
-            <circle className="about-north-star-field__aura" cx="320" cy="320" r="246" />
-            <circle className="about-north-star-field__halo" cx="320" cy="320" r="205" />
-            <circle className="about-north-star-field__halo about-north-star-field__halo--inner" cx="320" cy="320" r="116" />
-            <ellipse className="about-north-star-field__orbit about-north-star-field__orbit--concept" cx="320" cy="320" rx="222" ry="84" />
-            <ellipse className="about-north-star-field__orbit about-north-star-field__orbit--symbol" cx="320" cy="320" rx="132" ry="244" />
-            <path className="about-north-star-field__axis" d="M112 320h416" />
-            <path className="about-north-star-field__axis about-north-star-field__axis--vertical" d="M320 112v416" />
-            <path className="about-north-star-field__diagonal about-north-star-field__diagonal--one" d="M174 174l292 292" />
-            <path className="about-north-star-field__diagonal about-north-star-field__diagonal--two" d="M466 174L174 466" />
-            <circle className="about-north-star-field__glow" cx="320" cy="320" r="138" />
+              <rect className="about-north-star-field__plate" x="28" y="28" width="584" height="584" rx="22" />
+              <circle className="about-north-star-field__aura" cx="320" cy="320" r="246" />
+              <circle className="about-north-star-field__halo" cx="320" cy="320" r="205" />
+              <circle className="about-north-star-field__halo about-north-star-field__halo--inner" cx="320" cy="320" r="116" />
+              <ellipse className="about-north-star-field__orbit about-north-star-field__orbit--concept" cx="320" cy="320" rx="222" ry="84" />
+              <ellipse className="about-north-star-field__orbit about-north-star-field__orbit--symbol" cx="320" cy="320" rx="132" ry="244" />
+              <path className="about-north-star-field__axis" d="M112 320h416" />
+              <path className="about-north-star-field__axis about-north-star-field__axis--vertical" d="M320 112v416" />
+              <path className="about-north-star-field__diagonal about-north-star-field__diagonal--one" d="M174 174l292 292" />
+              <path className="about-north-star-field__diagonal about-north-star-field__diagonal--two" d="M466 174L174 466" />
+              <path className="about-north-star-field__active-beam about-north-star-field__active-beam--study" d="M320 320L320 96" />
+              <path className="about-north-star-field__active-beam about-north-star-field__active-beam--map" d="M320 320L544 320" />
+              <path className="about-north-star-field__active-beam about-north-star-field__active-beam--symbolize" d="M320 320L320 544" />
+              <path className="about-north-star-field__active-beam about-north-star-field__active-beam--verify" d="M320 320L96 320" />
+              <circle className="about-north-star-field__glow" cx="320" cy="320" r="138" />
 
-            {ORIENTATION_MODES.map((mode, index) => {
-              const nodePositions = [
-                { x: 320, y: 96 },
-                { x: 544, y: 320 },
-                { x: 320, y: 544 },
-                { x: 96, y: 320 },
-              ];
-              const { x, y } = nodePositions[index];
-              return (
-                <g key={mode.id} className={`about-north-star-field__node about-north-star-field__node--${mode.id}`}>
-                  <circle cx={x} cy={y} r={32} />
-                  <text x={x} y={y + 5} textAnchor="middle">
-                    {mode.label}
-                  </text>
-                </g>
-              );
-            })}
+              <g className="about-north-star-field__core">
+                <circle cx="320" cy="320" r="58" />
+                <text x="320" y="312" textAnchor="middle">Aion</text>
+                <text x="320" y="338" textAnchor="middle">Self</text>
+              </g>
+            </svg>
 
-            <g className="about-north-star-field__core">
-              <circle cx="320" cy="320" r="58" />
-              <text x="320" y="312" textAnchor="middle">Aion</text>
-              <text x="320" y="338" textAnchor="middle">Self</text>
-            </g>
-            <g className="about-north-star-field__active-readout">
-              <rect x="214" y="40" width="212" height="68" rx="34" />
-              <text x="320" y="68" textAnchor="middle">{activeMode.label}</text>
-              <text x="320" y="91" textAnchor="middle">{activeMode.title}</text>
-            </g>
-          </svg>
+            <div className="about-mode-controls about-orientation__nodes" role="group" aria-label="Learning orientation modes">
+              {ORIENTATION_MODES.map((mode) => (
+                <button
+                  key={mode.id}
+                  type="button"
+                  className={mode.id === activeMode.id ? `about-mode-controls__button about-mode-controls__button--active about-orientation-node about-orientation-node--${mode.id} about-orientation-node--active` : `about-mode-controls__button about-orientation-node about-orientation-node--${mode.id}`}
+                  onClick={() => setActiveModeId(mode.id)}
+                  aria-controls="about-orientation-detail about-orientation-field"
+                  aria-pressed={mode.id === activeMode.id}
+                  aria-label={`${mode.label}: ${mode.title}`}
+                >
+                  <span className="about-orientation-node__glyph" aria-hidden="true">{mode.glyph}</span>
+                  <span>{mode.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
 
-          <div id="about-orientation-detail" className="about-orientation__detail" aria-live="polite">
+          <div id="about-orientation-detail" className="about-orientation__detail" data-active-mode={activeMode.id} aria-live="polite" aria-atomic="true">
             <p className="eyebrow">{activeMode.routeLabel}</p>
             <h2>{activeMode.title}</h2>
             <p>{activeMode.body}</p>
+            <strong className="about-orientation__proof">{activeMode.proof}</strong>
+            <p className="about-orientation__evidence">{evidenceByMode[activeMode.id]}</p>
             <div className="about-orientation__stat" data-tone={activeMode.tone}>
               <strong>{statValueByMode[activeMode.id]}</strong>
               <span>{activeMode.statLabel}</span>
             </div>
+            <Link className="about-orientation__link" to={activeMode.route}>
+              Open {activeMode.routeLabel}
+            </Link>
           </div>
         </div>
       </section>
@@ -177,9 +206,10 @@ export default function AboutPage() {
         </div>
         <div className="about-route-launch__grid">
           {ORIENTATION_MODES.map((mode, index) => (
-            <Link key={mode.id} to={mode.route} className={`about-route-card about-route-card--${mode.id}`}>
+            <Link key={mode.id} to={mode.route} className={`about-route-card about-route-card--${mode.id}`} aria-label={`Open ${mode.routeLabel}: ${mode.title}`}>
               <span>{String(index + 1).padStart(2, '0')}</span>
               <h3>{mode.routeLabel}</h3>
+              <strong>{mode.proof}</strong>
               <p>{mode.body}</p>
             </Link>
           ))}
@@ -190,7 +220,7 @@ export default function AboutPage() {
         <article>
           <span>01</span>
           <h2>Scholarly restraint</h2>
-          <p>Visual invention clarifies Jung's argument; it does not make unsupported claims.</p>
+          <p>Visual invention clarifies the argument; it does not make unsupported claims.</p>
         </article>
         <article>
           <span>02</span>
@@ -200,8 +230,27 @@ export default function AboutPage() {
         <article>
           <span>03</span>
           <h2>Accessible beauty</h2>
-          <p>The same ideas must remain available through keyboard paths, contrast, and reduced motion.</p>
+          <p>The same ideas remain available through keyboard paths, contrast, and reduced motion.</p>
         </article>
+      </section>
+
+      <section className="about-data-ribbon section-band section-band--tight" aria-label="Canonical data model">
+        <div>
+          <span>{chapterClusters.length}</span>
+          <p>chapter clusters</p>
+        </div>
+        <div>
+          <span>{conceptDifficulties.length}</span>
+          <p>concept levels</p>
+        </div>
+        <div>
+          <span>{symbolPeriods.length}</span>
+          <p>symbol periods</p>
+        </div>
+        <div>
+          <span>{finalChapter?.order || 14}</span>
+          <p>final synthesis</p>
+        </div>
       </section>
     </div>
   );

--- a/src/app/pages/AboutPageInstrument.css
+++ b/src/app/pages/AboutPageInstrument.css
@@ -1,0 +1,369 @@
+.about-hero__metrics {
+  display: grid;
+  width: min(100%, 34rem);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin-top: 2rem;
+}
+
+.about-hero__metrics span {
+  border: 1px solid rgba(244, 240, 232, 0.1);
+  border-radius: calc(var(--radius) - 2px);
+  background: rgba(3, 3, 7, 0.44);
+  box-shadow: var(--shadow-inset);
+  color: rgba(244, 240, 232, 0.56);
+  font: 700 0.68rem/1.15 var(--font-ui);
+  letter-spacing: 0.1em;
+  padding: 0.75rem;
+  text-transform: uppercase;
+}
+
+.about-hero__metrics strong {
+  display: block;
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: 2.15rem;
+  font-weight: 380;
+  letter-spacing: 0;
+  line-height: 0.88;
+  text-transform: none;
+}
+
+.about-orientation {
+  gap: 0;
+}
+
+.about-orientation__stage {
+  position: relative;
+  width: min(100%, 42rem);
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+}
+
+.about-orientation__nodes {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  pointer-events: none;
+}
+
+.about-orientation-node {
+  --node-tone: rgba(212, 175, 55, 0.64);
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  min-width: 6.7rem;
+  min-height: 3.55rem;
+  place-items: center;
+  border-color: rgba(244, 240, 232, 0.16);
+  background: rgba(3, 3, 7, 0.76);
+  box-shadow:
+    var(--shadow-inset),
+    0 0 2rem rgba(0, 0, 0, 0.28);
+  line-height: 1.1;
+  padding: 0.55rem 0.85rem;
+  pointer-events: auto;
+}
+
+.about-orientation-node--study {
+  left: 50%;
+  top: 3.5%;
+  transform: translate(-50%, 0);
+}
+
+.about-orientation-node--map {
+  right: 3.2%;
+  top: 50%;
+  --node-tone: var(--about-cyan);
+  transform: translate(0, -50%);
+}
+
+.about-orientation-node--symbolize {
+  left: 50%;
+  bottom: 3.2%;
+  --node-tone: var(--about-rose);
+  transform: translate(-50%, 0);
+}
+
+.about-orientation-node--verify {
+  left: 3.2%;
+  top: 50%;
+  --node-tone: var(--about-green);
+  transform: translate(0, -50%);
+}
+
+.about-orientation-node:hover,
+.about-orientation-node:focus-visible,
+.about-orientation-node--active {
+  border-color: color-mix(in srgb, var(--node-tone), white 16%);
+  background: color-mix(in srgb, var(--node-tone), rgba(3, 3, 7, 0.92) 86%);
+  box-shadow:
+    var(--shadow-inset),
+    0 0 1.8rem color-mix(in srgb, var(--node-tone), transparent 58%);
+  color: var(--text);
+}
+
+.about-orientation-node--study:hover,
+.about-orientation-node--study:focus-visible,
+.about-orientation-node--study.about-orientation-node--active {
+  transform: translate(-50%, -2px);
+}
+
+.about-orientation-node--map:hover,
+.about-orientation-node--map:focus-visible,
+.about-orientation-node--map.about-orientation-node--active {
+  transform: translate(0, calc(-50% - 2px));
+}
+
+.about-orientation-node--symbolize:hover,
+.about-orientation-node--symbolize:focus-visible,
+.about-orientation-node--symbolize.about-orientation-node--active {
+  transform: translate(-50%, -2px);
+}
+
+.about-orientation-node--verify:hover,
+.about-orientation-node--verify:focus-visible,
+.about-orientation-node--verify.about-orientation-node--active {
+  transform: translate(0, calc(-50% - 2px));
+}
+
+.about-orientation-node__glyph {
+  color: var(--node-tone);
+  font-family: var(--font-display);
+  font-size: 1.08rem;
+  font-weight: 420;
+  letter-spacing: 0;
+}
+
+.about-north-star-field__active-beam {
+  fill: none;
+  stroke: rgba(212, 175, 55, 0.72);
+  stroke-linecap: round;
+  stroke-width: 2;
+  opacity: 0;
+  vector-effect: non-scaling-stroke;
+}
+
+.about-orientation[data-active-mode='study'] .about-north-star-field__active-beam--study,
+.about-orientation[data-active-mode='map'] .about-north-star-field__active-beam--map,
+.about-orientation[data-active-mode='symbolize'] .about-north-star-field__active-beam--symbolize,
+.about-orientation[data-active-mode='verify'] .about-north-star-field__active-beam--verify {
+  opacity: 1;
+}
+
+.about-orientation[data-active-mode='map'] .about-north-star-field__active-beam--map {
+  stroke: var(--about-cyan);
+}
+
+.about-orientation[data-active-mode='symbolize'] .about-north-star-field__active-beam--symbolize {
+  stroke: var(--about-rose);
+}
+
+.about-orientation[data-active-mode='verify'] .about-north-star-field__active-beam--verify {
+  stroke: var(--about-green);
+}
+
+.about-orientation__detail {
+  position: relative;
+  z-index: 3;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  column-gap: 1rem;
+  margin-top: 0.8rem;
+}
+
+.about-orientation__detail h2,
+.about-orientation__detail p:not(.eyebrow) {
+  grid-column: 1 / -1;
+}
+
+.about-orientation__evidence {
+  border-left: 1px solid rgba(212, 175, 55, 0.34);
+  color: rgba(244, 240, 232, 0.78) !important;
+  font-family: var(--font-ui);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin-top: 0.78rem;
+  padding-left: 0.75rem;
+  text-transform: uppercase;
+}
+
+.about-orientation__proof {
+  grid-column: 1 / -1;
+  color: var(--gold-soft);
+  font: 700 0.72rem/1 var(--font-ui);
+  letter-spacing: 0.12em;
+  margin-top: 0.5rem;
+  text-transform: uppercase;
+}
+
+.about-orientation__link {
+  align-self: end;
+  justify-self: end;
+  border: 1px solid rgba(212, 175, 55, 0.22);
+  border-radius: 999px;
+  color: var(--gold-soft);
+  font: 700 0.72rem/1 var(--font-ui);
+  letter-spacing: 0.12em;
+  padding: 0.76rem 0.9rem;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.about-orientation__link:hover,
+.about-orientation__link:focus-visible {
+  border-color: rgba(212, 175, 55, 0.58);
+  background: rgba(212, 175, 55, 0.1);
+}
+
+.about-route-card strong {
+  display: inline-block;
+  color: var(--gold-soft);
+  font: 700 0.7rem/1 var(--font-ui);
+  letter-spacing: 0.12em;
+  margin-bottom: 0.65rem;
+  text-transform: uppercase;
+}
+
+.about-principles {
+  grid-template-columns: 1.12fr 1fr 1fr;
+}
+
+.about-principles article {
+  min-height: 13rem;
+  border-radius: calc(var(--radius) - 2px);
+}
+
+.about-data-ribbon {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  padding-top: 1rem;
+}
+
+.about-data-ribbon div {
+  min-height: 8rem;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  background:
+    linear-gradient(135deg, rgba(212, 175, 55, 0.08), transparent 46%),
+    rgba(3, 3, 7, 0.42);
+  box-shadow: var(--shadow-inset);
+  padding: 1rem;
+}
+
+.about-data-ribbon span {
+  display: block;
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: 3.5rem;
+  font-weight: 360;
+  line-height: 0.85;
+}
+
+.about-data-ribbon p {
+  color: rgba(244, 240, 232, 0.56);
+  font: 700 0.72rem/1.25 var(--font-ui);
+  letter-spacing: 0.12em;
+  margin-top: 1rem;
+  text-transform: uppercase;
+}
+
+@media (max-width: 720px) {
+  .about-hero__metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .about-orientation__stage {
+    width: min(100%, 22.25rem);
+  }
+
+  .about-orientation-node {
+    min-width: 5.1rem;
+    min-height: 2.85rem;
+    font-size: 0.64rem;
+    padding: 0.44rem 0.5rem;
+  }
+
+  .about-orientation-node--study {
+    top: 1.3%;
+  }
+
+  .about-orientation-node--symbolize {
+    bottom: 1.3%;
+  }
+
+  .about-orientation-node--map {
+    right: 0;
+  }
+
+  .about-orientation-node--verify {
+    left: 0;
+  }
+
+  .about-orientation__detail {
+    grid-template-columns: 1fr;
+    margin-top: 0.6rem;
+  }
+
+  .about-orientation__link {
+    justify-self: start;
+    margin-top: 0.9rem;
+  }
+
+  .about-principles,
+  .about-data-ribbon {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 360px) {
+  .about-hero__metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .about-orientation__stage {
+    width: min(100%, 18rem);
+  }
+
+  .about-orientation-node {
+    min-width: 4.6rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .about-north-star-field__active-beam,
+  .about-orientation-node,
+  .about-orientation__link {
+    transition: none;
+  }
+
+  .about-orientation-node--study,
+  .about-orientation-node--study:hover,
+  .about-orientation-node--study:focus-visible,
+  .about-orientation-node--study.about-orientation-node--active {
+    transform: translate(-50%, 0);
+  }
+
+  .about-orientation-node--map,
+  .about-orientation-node--map:hover,
+  .about-orientation-node--map:focus-visible,
+  .about-orientation-node--map.about-orientation-node--active {
+    transform: translate(0, -50%);
+  }
+
+  .about-orientation-node--symbolize,
+  .about-orientation-node--symbolize:hover,
+  .about-orientation-node--symbolize:focus-visible,
+  .about-orientation-node--symbolize.about-orientation-node--active {
+    transform: translate(-50%, 0);
+  }
+
+  .about-orientation-node--verify,
+  .about-orientation-node--verify:hover,
+  .about-orientation-node--verify:focus-visible,
+  .about-orientation-node--verify.about-orientation-node--active {
+    transform: translate(0, -50%);
+  }
+}


### PR DESCRIPTION
## Summary

Polishes `/about` into a visual-first Aion orientation instrument instead of a mostly explanatory route.

- turns the hero compass into four interactive visual route nodes: Study, Map, Symbolize, Verify
- anchors the readout in canonical data counts and lightweight evidence: chapter clusters, concept bands, symbol periods, and QA gates
- adds About-specific app-shell, accessibility, and Pages artifact smoke coverage
- reclassifies `/about` as an orientation route in the visual Control Tower

## Batch Record

Skill stack:
- orchestration-autopilot, frontend-design, accessibility-review, webapp-testing, Playwright/Browser evidence, reviewer subagent

Routes changed:
- `/about`

Visual thesis:
- About should be the atlas orientation instrument: sparse text, dominant compass visual, four clear learning vectors, and visible integrity checks.

Browser evidence:
- Desktop, mobile, and narrow screenshots reviewed locally.
- Control Tower regenerated: `test-results/control-tower/route-scores.md`
- `/about`: 100%, 0 technical blockers, 0px overflow on mobile/narrow.

Checks:
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages`
- `PAGES_BASE=/aion-visualization node scripts/testing/pages-artifact-smoke.mjs`
- `npm run test:visual:control-tower`
- `git diff --check`
- `rg -n '^(<<<<<<<|=======|>>>>>>>)' .` returned no matches

Residual debt:
- The old base `AboutPage.css` still contains a few unused selector blocks from the previous SVG node/readout implementation; harmless, but a future cleanup pass can prune them.
