### PR TITLE
[codex] Align Vercel config with Vite app

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,59 +1,17 @@
 {
-  "buildCommand": null,
-  "outputDirectory": ".",
-  "framework": null,
-  "installCommand": null,
-  "devCommand": null,
-  "public": true,
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "installCommand": "npm ci",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
   "github": {
     "enabled": true,
     "silent": true
   },
-  "trailingSlash": false,
-  "cleanUrls": false,
   "rewrites": [
     {
-      "source": "/journey/chapter-:n(\\d+)",
-      "destination": "/journey/chapter/index.html"
-    },
-    {
-      "source": "/journey/chapter/:id",
-      "destination": "/journey/chapter/index.html?id=:id"
-    },
-    {
-      "source": "/journey/chapter",
-      "destination": "/journey/chapter/index.html"
-    },
-    {
-      "source": "/journey/:path*",
-      "destination": "/chapters/:path*"
-    },
-    {
-      "source": "/atlas",
-      "destination": "/src/atlas/index.html"
-    },
-    {
-      "source": "/atlas/:path*",
-      "destination": "/src/atlas/:path*"
-    }
-  ],
-  "headers": [
-    {
       "source": "/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "no-cache, no-store, must-revalidate, max-age=0, s-maxage=0"
-        },
-        {
-          "key": "Pragma",
-          "value": "no-cache"
-        },
-        {
-          "key": "Expires",
-          "value": "0"
-        }
-      ]
+      "destination": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Updates `vercel.json` from the old static-route deployment shape to the current React/Vite SPA deployment shape.

- uses Vercel's `vite` framework preset
- installs with `npm ci` and builds with `npm run build`
- serves the generated `dist` directory
- rewrites all deep links to `/index.html` for SPA routing
- removes stale rewrites to old static files such as `/src/atlas/index.html` and `/journey/chapter/index.html`
- removes deprecated/unsupported top-level config fields from the current schema surface

## Why

The repo-owned GitHub Pages gates are green, but Vercel has been posting an external red deployment status on PRs. The old config disabled normal build detection and served the repository root, which no longer matches the Vite app.

## Verification

- `node -e "JSON.parse(require('fs').readFileSync('vercel.json','utf8')); console.log('vercel.json parses')"`
- fetched `https://openapi.vercel.sh/vercel.json` and checked: `vite` is an allowed framework, no unknown top-level keys, `npm ci`, `npm run build`, `dist`, and SPA rewrite are present
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npm run build:pages && PAGES_BASE=/aion-visualization node scripts/testing/pages-artifact-smoke.mjs`
- `git diff --check`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .` returned no matches

## Note

`vercel build --yes` could not run locally because Vercel CLI reports invalid local token/auth state. I did not mutate credentials; this PR fixes the repo-side config and lets the GitHub integration re-run it with its own configured Vercel credentials.

Docs used:
- https://vercel.com/docs/frameworks/frontend/vite
- https://vercel.com/docs/project-configuration/vercel-json