### PR TITLE
[codex] Refine Chapter 1 reference instrument

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -184,6 +184,67 @@ async function checkRoute(page, route, failures) {
   }
 }
 
+async function checkChapterOneDynamicAccessibility(page, failures) {
+  await page.goto(`${baseUrl}/journey/chapter/ch1`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+  const instrumentGroup = page.getByRole('group', { name: /The Ego calibration instrument/ });
+  const instrument = page.getByRole('img', { name: /Ego depth model/ });
+  const readout = page.locator('.chapter-one-reference__readout');
+  const thesisControls = page.locator('.chapter-stage__thesis-node[aria-controls^="ch1-"]');
+  const referenceControls = page.locator('.chapter-stage__reference-node[aria-controls^="ch1-"]');
+  const instrumentVisible = await instrument.isVisible();
+  const groupPanel = await instrumentGroup.getAttribute('data-active-panel');
+  const initialLabel = await instrument.getAttribute('aria-label');
+  const readoutLive = await readout.getAttribute('aria-live');
+  const readoutAtomic = await readout.getAttribute('aria-atomic');
+  const thesisControlCount = await thesisControls.count();
+  const referenceControlCount = await referenceControls.count();
+  const initialDescription = await page.locator('#scene-host-description-ch1').textContent();
+
+  if (!instrumentVisible) failures.push('/journey/chapter/ch1: ego calibration instrument is missing an accessible image role');
+  if (groupPanel !== 'ego-light') failures.push(`/journey/chapter/ch1: initial instrument panel mismatch: ${groupPanel}`);
+  if (!initialLabel?.includes('Current emphasis: Orientation') || !initialLabel?.includes('The ego is necessary, but not total')) failures.push(`/journey/chapter/ch1: initial instrument label mismatch: ${initialLabel}`);
+  if (!initialDescription?.includes('Orientation: A point of consciousness')) failures.push(`/journey/chapter/ch1: initial scene description mismatch: ${initialDescription}`);
+  if (readoutLive !== 'polite') failures.push(`/journey/chapter/ch1: readout aria-live mismatch: ${readoutLive}`);
+  if (readoutAtomic !== 'true') failures.push(`/journey/chapter/ch1: readout aria-atomic mismatch: ${readoutAtomic}`);
+  if (thesisControlCount !== 3) failures.push(`/journey/chapter/ch1: thesis control count mismatch: ${thesisControlCount}`);
+  if (referenceControlCount !== 3) failures.push(`/journey/chapter/ch1: reference control count mismatch: ${referenceControlCount}`);
+
+  const depth = page.getByRole('button', { name: /02\s+Depth/ });
+  await depth.focus();
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(100);
+
+  const depthPressed = await depth.getAttribute('aria-pressed');
+  const depthPanel = await instrumentGroup.getAttribute('data-active-panel');
+  const depthLabel = await instrument.getAttribute('aria-label');
+  const depthDescription = await page.locator('#scene-host-description-ch1').textContent();
+  if (depthPressed !== 'true') failures.push(`/journey/chapter/ch1: depth button did not become pressed: ${depthPressed}`);
+  if (depthPanel !== 'roots') failures.push(`/journey/chapter/ch1: depth instrument panel mismatch: ${depthPanel}`);
+  if (!depthLabel?.includes('Current emphasis: Depth') || !depthLabel?.includes('Consciousness rests on what it cannot fully command')) failures.push(`/journey/chapter/ch1: depth instrument label mismatch: ${depthLabel}`);
+  if (!depthDescription?.includes('Depth: Two roots feed the I')) failures.push(`/journey/chapter/ch1: depth scene description mismatch: ${depthDescription}`);
+
+  const wholeness = page.getByRole('button', { name: /03\s+Wholeness/ });
+  await wholeness.focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(100);
+
+  const wholenessPressed = await wholeness.getAttribute('aria-pressed');
+  const wholenessPanel = await instrumentGroup.getAttribute('data-active-panel');
+  const wholenessLabel = await instrument.getAttribute('aria-label');
+  const wholenessDescription = await page.locator('#scene-host-description-ch1').textContent();
+  const pressedThesisCount = await page.locator('.chapter-stage__thesis-node[aria-pressed="true"]').count();
+  const ariaCurrentStepCount = await page.locator('.chapter-one-reference__step[aria-current="step"]').count();
+  if (wholenessPressed !== 'true') failures.push(`/journey/chapter/ch1: wholeness button did not become pressed: ${wholenessPressed}`);
+  if (wholenessPanel !== 'self-depth') failures.push(`/journey/chapter/ch1: wholeness instrument panel mismatch: ${wholenessPanel}`);
+  if (!wholenessLabel?.includes('Current emphasis: Wholeness') || !wholenessLabel?.includes('The journey starts by scaling the I correctly')) failures.push(`/journey/chapter/ch1: wholeness instrument label mismatch: ${wholenessLabel}`);
+  if (!wholenessDescription?.includes('Wholeness: The Self holds the field')) failures.push(`/journey/chapter/ch1: wholeness scene description mismatch: ${wholenessDescription}`);
+  if (pressedThesisCount !== 1) failures.push(`/journey/chapter/ch1: pressed thesis control count mismatch: ${pressedThesisCount}`);
+  if (ariaCurrentStepCount !== 1) failures.push(`/journey/chapter/ch1: aria-current calibration step count mismatch: ${ariaCurrentStepCount}`);
+}
+
 async function checkChaptersDynamicAccessibility(page, failures) {
   await page.goto(`${baseUrl}/chapters`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
   await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
@@ -769,6 +830,7 @@ async function runAccessibilitySmoke() {
     await checkTimelineDynamicAccessibility(desktop, failures);
     await checkSymbolsDynamicAccessibility(desktop, failures);
     await checkAboutDynamicAccessibility(desktop, failures);
+    await checkChapterOneDynamicAccessibility(desktop, failures);
     await checkChapterSixDynamicAccessibility(desktop, failures);
     await checkChapterSevenDynamicAccessibility(desktop, failures);
     await checkChapterEightDynamicAccessibility(desktop, failures);

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -738,11 +738,27 @@ async function smokeReducedMotion(browser, failures) {
   const chapterReferenceVisible = await page.locator('.chapter-stage__reference-map').isVisible();
   const chapterPauseControlCount = await page.locator('.scene-host__pause').count();
   const fallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterOneInstrumentCount = await page.locator('.chapter-one-reference').count();
+  const chapterOneCanvasCount = await page.locator('.scene-host canvas').count();
+  const chapterOneAnimationParts = await page.locator('.chapter-one-reference *').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      className: node.className,
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterOneAnimatedParts = chapterOneAnimationParts.filter((motion) => motion.animationName !== 'none');
+  const chapterOneTransitioningParts = chapterOneAnimationParts.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
 
   if (!fallbackVisible) failures.push('reduced-motion fallback is not visible for chapter scene');
   if (reducedMotionAttribute !== 'true') failures.push('chapter did not record reduced-motion state');
   if (!chapterReferenceVisible) failures.push('reduced-motion chapter reference map is not visible');
   if (chapterPauseControlCount !== 0) failures.push(`reduced-motion chapter rendered pause controls: ${chapterPauseControlCount}`);
+  if (chapterOneCanvasCount !== 0) failures.push(`reduced-motion Chapter 1 rendered canvas: ${chapterOneCanvasCount}`);
+  if (chapterOneInstrumentCount !== 1) failures.push(`reduced-motion Chapter 1 calibration instrument count mismatch: ${chapterOneInstrumentCount}`);
+  if (chapterOneAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 1 calibration instrument still animates: ${JSON.stringify(chapterOneAnimatedParts)}`);
+  if (chapterOneTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 1 calibration instrument still transitions: ${JSON.stringify(chapterOneTransitioningParts)}`);
   if (!fallbackText?.includes('small surface light')) failures.push('reduced-motion chapter fallback lost Chapter 1 teaching summary');
 
   await gotoAppRoute(page, '/journey/chapter/ch2');
@@ -1417,10 +1433,48 @@ async function scrollSceneControlIntoView(locator) {
   });
 }
 
+async function assertChapterOneInstrumentState(page, failures, expected) {
+  const instrumentGroup = page.getByRole('group', { name: /The Ego calibration instrument/ });
+  const instrumentImage = page.getByRole('img', { name: /Ego depth model/ });
+  const readout = page.locator('.chapter-one-reference__readout');
+  const groupPanel = await instrumentGroup.getAttribute('data-active-panel');
+  const imageLabel = await instrumentImage.getAttribute('aria-label');
+  const readoutText = await readout.textContent();
+  const activeStepCount = await page.locator('.chapter-one-reference__step--active').count();
+  const ariaCurrentStepCount = await page.locator('.chapter-one-reference__step[aria-current="step"]').count();
+
+  if (groupPanel !== expected.panelId) failures.push(`chapter 1 calibration instrument panel mismatch: ${groupPanel}`);
+  if (activeStepCount !== 1) failures.push(`chapter 1 calibration active step count mismatch: ${activeStepCount}`);
+  if (ariaCurrentStepCount !== 1) failures.push(`chapter 1 calibration aria-current count mismatch: ${ariaCurrentStepCount}`);
+  if (!imageLabel?.includes(`Current emphasis: ${expected.emphasis}`)) {
+    failures.push(`chapter 1 calibration image label did not follow ${expected.emphasis}: ${imageLabel}`);
+  }
+  if (!imageLabel?.includes(expected.insight)) {
+    failures.push(`chapter 1 calibration image label lost insight for ${expected.emphasis}: ${imageLabel}`);
+  }
+  if (!readoutText?.includes(expected.insight)) {
+    failures.push(`chapter 1 calibration readout did not follow ${expected.emphasis}: ${readoutText}`);
+  }
+}
+
 async function smokeChapterSceneControls(page, failures) {
   await gotoAppRoute(page, '/journey/chapter/ch1');
-  const chapterOneReferenceCount = await page.locator('.chapter-stage__reference-node').count();
+  await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const chapterOneReferenceNodes = page.locator('.chapter-stage__reference-node');
+  const chapterOneReferenceCount = await chapterOneReferenceNodes.count();
+  const chapterOnePanelIds = await chapterOneReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterOneInstrumentVisible = await page.getByRole('group', { name: /The Ego calibration instrument/ }).isVisible();
+  const chapterOneModelVisible = await page.getByRole('img', { name: /Ego depth model/ }).isVisible();
+
   if (chapterOneReferenceCount !== 3) failures.push(`chapter 1 reference node count mismatch: ${chapterOneReferenceCount}`);
+  if (chapterOnePanelIds.join(',') !== 'ego-light,roots,self-depth') failures.push(`chapter 1 reference nodes out of order: ${chapterOnePanelIds.join(',')}`);
+  if (!chapterOneInstrumentVisible) failures.push('chapter 1 calibration instrument group is not visible');
+  if (!chapterOneModelVisible) failures.push('chapter 1 ego depth model image is not visible');
+  await assertChapterOneInstrumentState(page, failures, {
+    panelId: 'ego-light',
+    emphasis: 'Orientation',
+    insight: 'The ego is necessary, but not total.',
+  });
 
   const pauseAnimation = page.getByRole('button', { name: /Pause animation/ });
   await activateSceneButton(pauseAnimation);
@@ -1439,6 +1493,11 @@ async function smokeChapterSceneControls(page, failures) {
     egoVisible: document.querySelector('.ch1-a--ego')?.classList.contains('vis') || false,
     rootsPanelVisible: document.querySelector('.ch1-a--unconscious')?.classList.contains('panel-vis') || false,
   }));
+  await assertChapterOneInstrumentState(page, failures, {
+    panelId: 'roots',
+    emphasis: 'Depth',
+    insight: 'Consciousness rests on what it cannot fully command.',
+  });
   if (rootsReferencePressed !== 'true') failures.push(`chapter 1 reference node did not become active: ${rootsReferencePressed}`);
   if (rootsAnnotationState.egoVisible) failures.push('chapter 1 timed ego annotation stayed visible after selecting roots');
   if (!rootsAnnotationState.rootsPanelVisible) failures.push('chapter 1 roots annotation did not follow selected panel');
@@ -1450,7 +1509,14 @@ async function smokeChapterSceneControls(page, failures) {
   const pressed = await wholeness.getAttribute('aria-pressed');
   const scrollY = await page.evaluate(() => window.scrollY);
   const sceneDescription = await page.locator('#scene-host-description-ch1').textContent();
+  const wholenessPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="self-depth"]').count();
+  await assertChapterOneInstrumentState(page, failures, {
+    panelId: 'self-depth',
+    emphasis: 'Wholeness',
+    insight: 'The journey starts by scaling the I correctly.',
+  });
   if (pressed !== 'true') failures.push(`chapter scene control did not become active: ${pressed}`);
+  if (wholenessPanelActive !== 1) failures.push(`chapter 1 Wholeness panel did not become active: ${wholenessPanelActive}`);
   if (scrollY > 10) failures.push(`chapter scene control unexpectedly scrolled page: ${scrollY}`);
   if (!sceneDescription?.includes('The Self holds the field')) failures.push(`chapter 1 scene description did not follow active panel: ${sceneDescription}`);
 
@@ -2854,7 +2920,12 @@ async function smokeMobile(page, failures) {
     await gotoAppRoute(page, '/journey/chapter/ch1');
     const chapterNavBox = await page.locator('.app-nav').boundingBox();
     const chapterHeadingBox = await page.locator('.chapter-stage__intro h1').boundingBox();
-    const referenceCount = await page.locator('.chapter-stage__reference-node').count();
+    const referenceNodes = page.locator('.chapter-stage__reference-node');
+    const referenceCount = await referenceNodes.count();
+    const panelIds = await referenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+    const chapterScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const referenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const instrumentBox = await page.locator('.chapter-one-reference').boundingBox();
     if (!chapterNavBox || !chapterHeadingBox) {
       failures.push(`mobile chapter 1 geometry missing at ${viewport.width}x${viewport.height}`);
       continue;
@@ -2865,6 +2936,15 @@ async function smokeMobile(page, failures) {
       failures.push(`mobile nav overlaps chapter 1 heading at ${viewport.width}x${viewport.height}: nav bottom ${Math.round(chapterNavBottom)}, heading top ${Math.round(chapterHeadingBox.y)}`);
     }
     if (referenceCount !== 3) failures.push(`mobile chapter 1 reference node count mismatch at ${viewport.width}x${viewport.height}: ${referenceCount}`);
+    if (panelIds.join(',') !== 'ego-light,roots,self-depth') failures.push(`mobile chapter 1 reference nodes out of order at ${viewport.width}x${viewport.height}: ${panelIds.join(',')}`);
+    if (chapterScrollWidth > viewport.width + 2) failures.push(`mobile chapter 1 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterScrollWidth}`);
+    if (referenceMapBox && referenceMapBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 1 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(referenceMapBox.width)}`);
+    }
+    if (!instrumentBox) failures.push(`mobile chapter 1 calibration instrument missing at ${viewport.width}x${viewport.height}`);
+    if (instrumentBox && instrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 1 calibration instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(instrumentBox.width)}`);
+    }
 
     await gotoAppRoute(page, '/journey/chapter/ch2');
     await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -19,7 +19,7 @@ const canonicalRoutes = [
   ...Array.from({ length: 14 }, (_, index) => `/journey/chapter/ch${index + 1}`),
 ];
 
-const mobileRoutes = ['/', '/chapters', '/atlas', '/timeline', '/symbols', '/about', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch12', '/journey/chapter/ch13', '/journey/chapter/ch14'];
+const mobileRoutes = ['/', '/chapters', '/atlas', '/timeline', '/symbols', '/about', '/journey/chapter/ch1', '/journey/chapter/ch2', '/journey/chapter/ch3', '/journey/chapter/ch4', '/journey/chapter/ch5', '/journey/chapter/ch6', '/journey/chapter/ch8', '/journey/chapter/ch9', '/journey/chapter/ch10', '/journey/chapter/ch11', '/journey/chapter/ch12', '/journey/chapter/ch13', '/journey/chapter/ch14'];
 
 const mimeTypes = new Map([
   ['.html', 'text/html; charset=utf-8'],

--- a/src/app/components/ChapterOneReferenceInstrument.css
+++ b/src/app/components/ChapterOneReferenceInstrument.css
@@ -1,0 +1,217 @@
+.chapter-one-reference {
+  position: relative;
+  width: min(30rem, 100%);
+  margin-top: 0.95rem;
+  overflow: hidden;
+  border: 1px solid rgba(244, 240, 232, 0.13);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(145deg, rgba(244, 240, 232, 0.08), transparent 28%),
+    radial-gradient(circle at 50% 18%, rgba(244, 240, 232, 0.16), transparent 5.6rem),
+    radial-gradient(circle at 24% 74%, rgba(204, 109, 134, 0.12), transparent 6.2rem),
+    radial-gradient(circle at 76% 74%, rgba(83, 216, 232, 0.13), transparent 6.2rem),
+    rgba(3, 3, 7, 0.48);
+  box-shadow:
+    var(--shadow-inset),
+    0 1.6rem 4.2rem rgba(0, 0, 0, 0.28);
+}
+
+.chapter-one-reference::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.09), transparent),
+    repeating-linear-gradient(90deg, transparent 0 3.2rem, rgba(244, 240, 232, 0.035) 3.22rem 3.26rem);
+  opacity: 0.62;
+  mask-image: linear-gradient(180deg, #000, transparent 78%);
+}
+
+.chapter-one-reference__header {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.65rem;
+  align-items: center;
+  padding: 0.52rem 0.72rem 0.28rem;
+  color: rgba(244, 240, 232, 0.7);
+  font-family: var(--font-ui);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.chapter-one-reference__header span,
+.chapter-one-reference__header em {
+  color: rgba(244, 240, 232, 0.54);
+  font-style: normal;
+  text-transform: uppercase;
+}
+
+.chapter-one-reference__header strong {
+  color: rgba(255, 227, 156, 0.92);
+  text-align: center;
+}
+
+.chapter-one-reference .chapter-one-reference__field {
+  width: 100%;
+  min-height: clamp(5.8rem, 10vh, 6.6rem);
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background:
+    radial-gradient(circle at 50% 24%, rgba(244, 240, 232, 0.15), transparent 3.5rem),
+    radial-gradient(circle at 36% 72%, rgba(204, 109, 134, 0.12), transparent 5.6rem),
+    radial-gradient(circle at 64% 72%, rgba(83, 216, 232, 0.14), transparent 5.6rem),
+    linear-gradient(180deg, rgba(3, 3, 7, 0.32), rgba(3, 3, 7, 0.1));
+  box-shadow: none;
+}
+
+.chapter-one-reference .chapter-one-reference__field::before {
+  inset: 0.62rem 0.82rem;
+  border-color: rgba(212, 175, 55, 0.11);
+}
+
+.chapter-one-reference .chapter-one-reference__field::after {
+  inset: 0;
+  background:
+    linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.07), transparent),
+    repeating-linear-gradient(180deg, transparent 0 2.2rem, rgba(244, 240, 232, 0.052) 2.24rem, transparent 2.3rem);
+}
+
+.chapter-one-reference__calibration-line {
+  position: absolute;
+  left: 50%;
+  top: 27%;
+  width: 38%;
+  height: 1px;
+  pointer-events: none;
+  opacity: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.7), transparent);
+  transform: translateX(-50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    top 0.55s var(--motion-spring),
+    width 0.55s var(--motion-spring);
+}
+
+.chapter-one-reference__calibration-line--depth {
+  top: 74%;
+  width: 54%;
+  background: linear-gradient(90deg, transparent, rgba(83, 216, 232, 0.55), rgba(255, 227, 156, 0.5), transparent);
+}
+
+.chapter-one-reference[data-active-panel="ego-light"] .chapter-one-reference__calibration-line--surface,
+.chapter-one-reference[data-active-panel="roots"] .chapter-one-reference__calibration-line--surface,
+.chapter-one-reference[data-active-panel="self-depth"] .chapter-one-reference__calibration-line--depth {
+  opacity: 0.95;
+}
+
+.chapter-one-reference[data-active-panel="roots"] .chapter-one-reference__calibration-line--depth {
+  top: 57%;
+  opacity: 0.78;
+}
+
+.chapter-one-reference__scale {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.28rem;
+  margin: 0;
+  padding: 0 0.62rem 0.48rem;
+  list-style: none;
+}
+
+.chapter-one-reference__step {
+  display: grid;
+  gap: 0.08rem;
+  min-width: 0;
+  padding: 0.34rem 0.42rem;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  border-radius: calc(var(--radius) - 2px);
+  background: rgba(244, 240, 232, 0.035);
+  color: rgba(244, 240, 232, 0.5);
+  font-family: var(--font-ui);
+}
+
+.chapter-one-reference__step span,
+.chapter-one-reference__step em {
+  overflow: hidden;
+  font-size: 0.5rem;
+  font-style: normal;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.chapter-one-reference__step strong {
+  overflow: hidden;
+  color: rgba(244, 240, 232, 0.76);
+  font-size: 0.68rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chapter-one-reference__step--active {
+  border-color: rgba(212, 175, 55, 0.38);
+  background:
+    linear-gradient(180deg, rgba(212, 175, 55, 0.14), rgba(244, 240, 232, 0.035));
+  color: rgba(255, 227, 156, 0.86);
+  box-shadow: 0 0 1.35rem rgba(212, 175, 55, 0.14);
+}
+
+.chapter-one-reference__readout {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .chapter-one-reference {
+    width: min(100%, 25rem);
+    margin-inline: auto;
+  }
+
+  .chapter-one-reference .chapter-one-reference__field {
+    min-height: 5.8rem;
+  }
+
+  .chapter-one-reference__scale {
+    gap: 0.28rem;
+    padding-inline: 0.58rem;
+  }
+
+  .chapter-one-reference__step {
+    padding-inline: 0.38rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .chapter-one-reference__header {
+    grid-template-columns: 1fr;
+    gap: 0.12rem;
+    text-align: center;
+  }
+
+  .chapter-one-reference__scale {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chapter-one-reference *,
+  .chapter-one-reference *::before,
+  .chapter-one-reference *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/app/components/ChapterOneReferenceInstrument.tsx
+++ b/src/app/components/ChapterOneReferenceInstrument.tsx
@@ -1,0 +1,87 @@
+import type { LearningPanel } from '../types';
+import './ChapterOneReferenceInstrument.css';
+
+const referenceSteps = [
+  {
+    id: 'ego-light',
+    label: 'Ego',
+    measure: 'surface light',
+    note: 'necessary center',
+  },
+  {
+    id: 'roots',
+    label: 'Roots',
+    measure: 'somatic / psychic',
+    note: 'two bases',
+  },
+  {
+    id: 'self-depth',
+    label: 'Self',
+    measure: 'total field',
+    note: 'larger whole',
+  },
+];
+
+export default function ChapterOneReferenceInstrument({
+  activePanel,
+  activePanelId,
+}: {
+  activePanel?: LearningPanel;
+  activePanelId: string;
+}) {
+  const currentStep = referenceSteps.find((step) => step.id === activePanelId) || referenceSteps[0];
+  const emphasis = activePanel
+    ? `${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`
+    : `${currentStep.label}: ${currentStep.note}.`;
+
+  return (
+    <section
+      className="chapter-one-reference"
+      data-active-panel={currentStep.id}
+      role="group"
+      aria-label={`The Ego calibration instrument. Active focus: ${emphasis}`}
+    >
+      <div className="chapter-one-reference__header">
+        <span>Calibration</span>
+        <strong>{currentStep.label}</strong>
+        <em>{currentStep.measure}</em>
+      </div>
+      <div
+        className="ego-depth-instrument chapter-one-reference__field"
+        data-active-panel={currentStep.id}
+        role="img"
+        aria-label={`Ego depth model: the conscious ego shines at the surface, somatic and psychic roots descend, and the Self holds the wider field below. Current emphasis: ${emphasis}`}
+      >
+        <span className="ego-depth-instrument__axis" aria-hidden="true" />
+        <span className="ego-depth-instrument__surface" aria-hidden="true" />
+        <span className="ego-depth-instrument__ego" aria-hidden="true" />
+        <span className="ego-depth-instrument__root ego-depth-instrument__root--somatic" aria-hidden="true" />
+        <span className="ego-depth-instrument__root ego-depth-instrument__root--psychic" aria-hidden="true" />
+        <span className="ego-depth-instrument__wake ego-depth-instrument__wake--one" aria-hidden="true" />
+        <span className="ego-depth-instrument__wake ego-depth-instrument__wake--two" aria-hidden="true" />
+        <span className="ego-depth-instrument__self" aria-hidden="true" />
+        <span className="ego-depth-instrument__label ego-depth-instrument__label--ego" aria-hidden="true">ego</span>
+        <span className="ego-depth-instrument__label ego-depth-instrument__label--roots" aria-hidden="true">roots</span>
+        <span className="ego-depth-instrument__label ego-depth-instrument__label--self" aria-hidden="true">Self</span>
+        <span className="chapter-one-reference__calibration-line chapter-one-reference__calibration-line--surface" aria-hidden="true" />
+        <span className="chapter-one-reference__calibration-line chapter-one-reference__calibration-line--depth" aria-hidden="true" />
+      </div>
+      <ol className="chapter-one-reference__scale" aria-label="Ego depth scale">
+        {referenceSteps.map((step, index) => (
+          <li
+            key={step.id}
+            className={step.id === currentStep.id ? 'chapter-one-reference__step chapter-one-reference__step--active' : 'chapter-one-reference__step'}
+            aria-current={step.id === currentStep.id ? 'step' : undefined}
+          >
+            <span>{String(index + 1).padStart(2, '0')}</span>
+            <strong>{step.label}</strong>
+            <em>{step.note}</em>
+          </li>
+        ))}
+      </ol>
+      <p className="chapter-one-reference__readout" aria-live="polite" aria-atomic="true">
+        {activePanel?.insight || currentStep.note}
+      </p>
+    </section>
+  );
+}

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 
 import Chapter14FinalSynthesisInstrument from '../components/Chapter14FinalSynthesisInstrument';
+import ChapterOneReferenceInstrument from '../components/ChapterOneReferenceInstrument';
 import ChapterSigil from '../components/ChapterSigil';
 import SceneHost from '../components/SceneHost';
 import {
@@ -497,24 +498,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
             ))}
           </div>
           {chapter.id === 'ch1' && (
-            <div
-              className="ego-depth-instrument"
-              data-active-panel={activePanelId}
-              role="img"
-              aria-label="Ego depth model: the conscious ego shines at the surface, somatic and psychic roots descend, and the Self holds the wider field below."
-            >
-              <span className="ego-depth-instrument__axis" aria-hidden="true" />
-              <span className="ego-depth-instrument__surface" aria-hidden="true" />
-              <span className="ego-depth-instrument__ego" aria-hidden="true" />
-              <span className="ego-depth-instrument__root ego-depth-instrument__root--somatic" aria-hidden="true" />
-              <span className="ego-depth-instrument__root ego-depth-instrument__root--psychic" aria-hidden="true" />
-              <span className="ego-depth-instrument__wake ego-depth-instrument__wake--one" aria-hidden="true" />
-              <span className="ego-depth-instrument__wake ego-depth-instrument__wake--two" aria-hidden="true" />
-              <span className="ego-depth-instrument__self" aria-hidden="true" />
-              <span className="ego-depth-instrument__label ego-depth-instrument__label--ego" aria-hidden="true">ego</span>
-              <span className="ego-depth-instrument__label ego-depth-instrument__label--roots" aria-hidden="true">roots</span>
-              <span className="ego-depth-instrument__label ego-depth-instrument__label--self" aria-hidden="true">Self</span>
-            </div>
+            <ChapterOneReferenceInstrument activePanel={activePanel} activePanelId={activePanelId} />
           )}
           {activePanel && (
             <p className="sr-only" role="status" aria-live="polite">

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -69,6 +69,30 @@ describe('Aion framework data contract', () => {
     }
   });
 
+  test('keeps Chapter 1 Ego panels tied to the reference calibration model', () => {
+    expect(CHAPTER_SCENES.ch1.panels.map((panel) => panel.id)).toEqual([
+      'ego-light',
+      'roots',
+      'self-depth',
+    ]);
+    expect(CHAPTER_SCENES.ch1.panels.map((panel) => panel.kicker)).toEqual([
+      'Orientation',
+      'Depth',
+      'Wholeness',
+    ]);
+    expect(CHAPTER_SCENES.ch1.motionGrammar).toBe('cyclical-return');
+    expect(CHAPTER_SCENES.ch1.visualTheme).toContain('Ego/Self depth field');
+    expect(CHAPTER_SCENES.ch1.sceneModule).toBe('../visualizations/chapters/ch1/ThreeEgoViz.js');
+    expect(CHAPTER_SCENES.ch1.fallbackSummary).toContain('small surface light');
+    expect(CHAPTER_SCENES.ch1.fallbackSummary).toContain('somatic and psychic roots');
+    expect(CHAPTER_SCENES.ch1.fallbackSummary).toContain('deeper Self');
+
+    expect(getConceptsForChapter('ch1').map((concept) => concept.id)).toEqual([
+      'ego',
+      'self',
+    ]);
+  });
+
   test('keeps Chapter 2 shadow panels in the canonical learning sequence', () => {
     expect(CHAPTER_SCENES.ch2.panels.map((panel) => panel.id)).toEqual([
       'mirror',


### PR DESCRIPTION
## Summary

Refines Chapter 1 as the Ego reference surface without replacing the loved Three.js scene.

- extracts the Chapter 1 ego/Self depth companion into `ChapterOneReferenceInstrument`
- makes the calibration tool visual-first, compact, and accessible-only for the live readout
- keeps the first viewport anchored so pause/reference controls do not force scroll jumps
- adds Chapter 1-specific app shell, accessibility, Pages mobile, and data-contract coverage

## Skill stack

- orchestration-autopilot subagent lanes: explorer, architect planner, test verifier, devil advocate
- Aion skill-routing playbook
- frontend/accessibility/webapp-testing guidance
- Playwright/Control Tower browser evidence
- github:yeet publish flow

## Routes changed

- `/journey/chapter/ch1`

## Visual thesis

Chapter 1 should remain an ego/Self depth field: the live canvas carries atmosphere and depth, while the companion instrument makes the three learning states legible as Orientation, Depth, and Wholeness with minimal visible text.

## Browser evidence

- `AION_VISUAL_MIN_SCORE=85 npm run test:visual:control-tower`
- Control Tower route score for `/journey/chapter/ch1`: 100% desktop, no mobile/narrow blockers
- Screenshot evidence generated under `test-results/control-tower/latest/screenshots/`

## Checks

- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages`
- `npm run test:pages:artifact`
- `AION_VISUAL_MIN_SCORE=85 npm run test:visual:control-tower`
- `git diff --check`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .` returned no matches

## Residual debt

- The shared `src/app/styles.css` still contains older Chapter 1 `.ego-depth-instrument` rules. This PR scopes the new component CSS strongly enough to avoid growing the global file, but a future visual-system cleanup should consolidate chapter instrument primitives.
- Vite still warns that the shared Three chunk exceeds 500 kB; this predates this PR and belongs to the later performance/lazy-loading batch.
