### PR TITLE
[codex] Refine psyche arc instruments

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -245,6 +245,115 @@ async function checkChapterOneDynamicAccessibility(page, failures) {
   if (ariaCurrentStepCount !== 1) failures.push(`/journey/chapter/ch1: aria-current calibration step count mismatch: ${ariaCurrentStepCount}`);
 }
 
+async function checkPsycheArcDynamicAccessibility(page, failures) {
+  const configs = [
+    {
+      route: '/journey/chapter/ch2',
+      arc: 'Shadow',
+      model: 'Shadow projection model',
+      steps: [
+        { panelId: 'mirror', kicker: 'Opposition', title: 'The refused likeness', insight: 'Recognition begins when the image becomes personal.' },
+        { panelId: 'projection', kicker: 'Projection', title: 'Thrown outward', insight: 'Projection makes inner conflict look external.' },
+        { panelId: 'integration', kicker: 'Integration', title: 'Return without collapse', insight: 'The ego grows by admitting what it excludes.' },
+      ],
+    },
+    {
+      route: '/journey/chapter/ch3',
+      arc: 'Syzygy',
+      model: 'Syzygy relation model',
+      steps: [
+        { panelId: 'pair', kicker: 'Syzygy', title: 'Two poles, one psyche', insight: 'The psyche thinks in living opposites.' },
+        { panelId: 'orbit', kicker: 'Relation', title: 'Projection becomes orbit', insight: 'Wholeness needs tension, not sameness.' },
+        { panelId: 'union', kicker: 'Conjunction', title: 'Union flashes, then moves', insight: 'Integration is rhythmic, not static.' },
+      ],
+    },
+    {
+      route: '/journey/chapter/ch4',
+      arc: 'Self',
+      model: 'Self mandala model',
+      steps: [
+        { panelId: 'seed', kicker: 'Center', title: 'The small center opens', insight: 'The deepest center is not the loudest form.' },
+        { panelId: 'quaternity', kicker: 'Fourfold', title: 'Wholeness takes four directions', insight: 'A totality image must include more than perfection.' },
+        { panelId: 'mandala', kicker: 'Mandala', title: 'Chaos receives a form', insight: 'The Self orders by holding difference.' },
+      ],
+    },
+  ];
+
+  for (const config of configs) {
+    await page.goto(`${baseUrl}${config.route}`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
+    await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+
+    const group = page.getByRole('group', { name: new RegExp(`Psyche arc instrument for ${config.arc}`, 'i') });
+    const image = page.getByRole('img', { name: new RegExp(config.model, 'i') });
+    const readout = page.locator('.psyche-arc-instrument__readout');
+    const referenceControls = page.locator('.chapter-stage__reference-node');
+    const initial = config.steps[0];
+
+    const groupVisible = await group.isVisible();
+    const imageVisible = await image.isVisible();
+    const initialGroupPanel = await group.getAttribute('data-active-panel');
+    const initialImagePanel = await image.getAttribute('data-active-panel');
+    const initialLabel = await image.getAttribute('aria-label');
+    const readoutLive = await readout.getAttribute('aria-live');
+    const readoutAtomic = await readout.getAttribute('aria-atomic');
+    const referenceCount = await referenceControls.count();
+    const railLinkCount = await page.locator('.psyche-arc-instrument__rail-link').count();
+    const currentRailLinkCount = await page.locator('.psyche-arc-instrument__rail-link[aria-current="page"]').count();
+    const stepCount = await page.locator('.psyche-arc-instrument__step').count();
+    const currentStepCount = await page.locator('.psyche-arc-instrument__step[aria-current="step"]').count();
+    const initialDescription = await page.locator(`#scene-host-description-${config.route.split('/').at(-1)}`).textContent();
+
+    if (!groupVisible) failures.push(`${config.route}: psyche arc group is not visible`);
+    if (!imageVisible) failures.push(`${config.route}: ${config.model} is missing an accessible image role`);
+    if (initialGroupPanel !== initial.panelId) failures.push(`${config.route}: initial psyche arc group panel mismatch: ${initialGroupPanel}`);
+    if (initialImagePanel !== initial.panelId) failures.push(`${config.route}: initial psyche arc image panel mismatch: ${initialImagePanel}`);
+    if (!initialLabel?.includes(`Current emphasis: ${initial.kicker}`) || !initialLabel?.includes(initial.insight)) failures.push(`${config.route}: initial psyche arc label mismatch: ${initialLabel}`);
+    if (!initialDescription?.includes(`${initial.kicker}: ${initial.title}`)) failures.push(`${config.route}: initial scene description mismatch: ${initialDescription}`);
+    if (readoutLive !== 'polite') failures.push(`${config.route}: psyche arc readout aria-live mismatch: ${readoutLive}`);
+    if (readoutAtomic !== 'true') failures.push(`${config.route}: psyche arc readout aria-atomic mismatch: ${readoutAtomic}`);
+    if (referenceCount !== 3) failures.push(`${config.route}: reference control count mismatch: ${referenceCount}`);
+    if (railLinkCount !== 3) failures.push(`${config.route}: psyche arc rail link count mismatch: ${railLinkCount}`);
+    if (currentRailLinkCount !== 1) failures.push(`${config.route}: current psyche arc rail count mismatch: ${currentRailLinkCount}`);
+    if (stepCount !== 3) failures.push(`${config.route}: psyche arc step count mismatch: ${stepCount}`);
+    if (currentStepCount !== 1) failures.push(`${config.route}: initial psyche arc current step count mismatch: ${currentStepCount}`);
+
+    const second = config.steps[1];
+    const secondControl = page.locator(`.chapter-stage__reference-node[data-panel-id="${second.panelId}"]`);
+    await secondControl.focus();
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(100);
+
+    const secondPressed = await secondControl.getAttribute('aria-pressed');
+    const secondGroupPanel = await group.getAttribute('data-active-panel');
+    const secondImageLabel = await image.getAttribute('aria-label');
+    const secondDescription = await page.locator(`#scene-host-description-${config.route.split('/').at(-1)}`).textContent();
+    if (secondPressed !== 'true') failures.push(`${config.route}: second psyche arc control did not become pressed: ${secondPressed}`);
+    if (secondGroupPanel !== second.panelId) failures.push(`${config.route}: second psyche arc panel mismatch: ${secondGroupPanel}`);
+    if (!secondImageLabel?.includes(`Current emphasis: ${second.kicker}`) || !secondImageLabel?.includes(second.insight)) failures.push(`${config.route}: second psyche arc label mismatch: ${secondImageLabel}`);
+    if (!secondDescription?.includes(`${second.kicker}: ${second.title}`)) failures.push(`${config.route}: second scene description mismatch: ${secondDescription}`);
+
+    const third = config.steps[2];
+    const thirdControl = page.locator(`.chapter-stage__reference-node[data-panel-id="${third.panelId}"]`);
+    await thirdControl.focus();
+    await page.keyboard.press('Space');
+    await page.waitForTimeout(100);
+
+    const thirdPressed = await thirdControl.getAttribute('aria-pressed');
+    const thirdGroupPanel = await group.getAttribute('data-active-panel');
+    const thirdImageLabel = await image.getAttribute('aria-label');
+    const thirdDescription = await page.locator(`#scene-host-description-${config.route.split('/').at(-1)}`).textContent();
+    const pressedReferenceCount = await page.locator('.chapter-stage__reference-node[aria-pressed="true"]').count();
+    const finalCurrentStepCount = await page.locator('.psyche-arc-instrument__step[aria-current="step"]').count();
+    if (thirdPressed !== 'true') failures.push(`${config.route}: third psyche arc control did not become pressed: ${thirdPressed}`);
+    if (thirdGroupPanel !== third.panelId) failures.push(`${config.route}: third psyche arc panel mismatch: ${thirdGroupPanel}`);
+    if (!thirdImageLabel?.includes(`Current emphasis: ${third.kicker}`) || !thirdImageLabel?.includes(third.insight)) failures.push(`${config.route}: third psyche arc label mismatch: ${thirdImageLabel}`);
+    if (!thirdDescription?.includes(`${third.kicker}: ${third.title}`)) failures.push(`${config.route}: third scene description mismatch: ${thirdDescription}`);
+    if (pressedReferenceCount !== 1) failures.push(`${config.route}: pressed reference control count mismatch: ${pressedReferenceCount}`);
+    if (finalCurrentStepCount !== 1) failures.push(`${config.route}: final psyche arc current step count mismatch: ${finalCurrentStepCount}`);
+  }
+}
+
 async function checkChaptersDynamicAccessibility(page, failures) {
   await page.goto(`${baseUrl}/chapters`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
   await page.locator('main#main-content').waitFor({ state: 'visible', timeout: 10_000 });
@@ -831,6 +940,7 @@ async function runAccessibilitySmoke() {
     await checkSymbolsDynamicAccessibility(desktop, failures);
     await checkAboutDynamicAccessibility(desktop, failures);
     await checkChapterOneDynamicAccessibility(desktop, failures);
+    await checkPsycheArcDynamicAccessibility(desktop, failures);
     await checkChapterSixDynamicAccessibility(desktop, failures);
     await checkChapterSevenDynamicAccessibility(desktop, failures);
     await checkChapterEightDynamicAccessibility(desktop, failures);

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -770,6 +770,17 @@ async function smokeReducedMotion(browser, failures) {
   const chapterTwoCanvasCount = await page.locator('.scene-host canvas').count();
   const chapterTwoAnnotationCount = await page.locator('.ch2-annotations').count();
   const chapterTwoFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterTwoPsycheArcCount = await page.locator('.psyche-arc-instrument').count();
+  const chapterTwoPsycheArcMotion = await page.locator('.psyche-arc-instrument *').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      className: node.className,
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterTwoAnimatedParts = chapterTwoPsycheArcMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterTwoTransitioningParts = chapterTwoPsycheArcMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
 
   if (!chapterTwoFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 2 scene');
   if (chapterTwoReducedMotionAttribute !== 'true') failures.push('Chapter 2 did not record reduced-motion state');
@@ -777,6 +788,9 @@ async function smokeReducedMotion(browser, failures) {
   if (chapterTwoPauseControlCount !== 0) failures.push(`reduced-motion Chapter 2 rendered pause controls: ${chapterTwoPauseControlCount}`);
   if (chapterTwoCanvasCount !== 0) failures.push(`reduced-motion Chapter 2 rendered canvas: ${chapterTwoCanvasCount}`);
   if (chapterTwoAnnotationCount !== 0) failures.push(`reduced-motion Chapter 2 rendered annotation overlay: ${chapterTwoAnnotationCount}`);
+  if (chapterTwoPsycheArcCount !== 1) failures.push(`reduced-motion Chapter 2 psyche arc instrument count mismatch: ${chapterTwoPsycheArcCount}`);
+  if (chapterTwoAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 2 psyche arc still animates: ${JSON.stringify(chapterTwoAnimatedParts)}`);
+  if (chapterTwoTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 2 psyche arc still transitions: ${JSON.stringify(chapterTwoTransitioningParts)}`);
   if (!chapterTwoFallbackText?.includes('split mirror') || !chapterTwoFallbackText?.includes('projection arcs')) {
     failures.push('reduced-motion chapter fallback lost Chapter 2 shadow teaching summary');
   }
@@ -792,6 +806,17 @@ async function smokeReducedMotion(browser, failures) {
   const chapterThreeCanvasCount = await page.locator('.scene-host canvas').count();
   const chapterThreeAnnotationCount = await page.locator('.ch3-annotations').count();
   const chapterThreeFallbackText = await page.locator('.scene-host__fallback').textContent();
+  const chapterThreePsycheArcCount = await page.locator('.psyche-arc-instrument').count();
+  const chapterThreePsycheArcMotion = await page.locator('.psyche-arc-instrument *').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      className: node.className,
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
+  const chapterThreeAnimatedParts = chapterThreePsycheArcMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterThreeTransitioningParts = chapterThreePsycheArcMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
 
   if (!chapterThreeFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 3 scene');
   if (chapterThreeReducedMotionAttribute !== 'true') failures.push('Chapter 3 did not record reduced-motion state');
@@ -800,6 +825,9 @@ async function smokeReducedMotion(browser, failures) {
   if (chapterThreePauseControlCount !== 0) failures.push(`reduced-motion Chapter 3 rendered pause controls: ${chapterThreePauseControlCount}`);
   if (chapterThreeCanvasCount !== 0) failures.push(`reduced-motion Chapter 3 rendered canvas: ${chapterThreeCanvasCount}`);
   if (chapterThreeAnnotationCount !== 0) failures.push(`reduced-motion Chapter 3 rendered annotation overlay: ${chapterThreeAnnotationCount}`);
+  if (chapterThreePsycheArcCount !== 1) failures.push(`reduced-motion Chapter 3 psyche arc instrument count mismatch: ${chapterThreePsycheArcCount}`);
+  if (chapterThreeAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 3 psyche arc still animates: ${JSON.stringify(chapterThreeAnimatedParts)}`);
+  if (chapterThreeTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 3 psyche arc still transitions: ${JSON.stringify(chapterThreeTransitioningParts)}`);
   if (!chapterThreeFallbackText?.includes('projection makes the inner image appear outside') || !chapterThreeFallbackText?.includes('brief symbolic union')) {
     failures.push('reduced-motion chapter fallback lost Chapter 3 syzygy teaching summary');
   }
@@ -815,6 +843,15 @@ async function smokeReducedMotion(browser, failures) {
   const chapterFourCanvasCount = await page.locator('.scene-host canvas').count();
   const chapterFourFallbackText = await page.locator('.scene-host__fallback').textContent();
   const chapterFourInstrumentCount = await page.locator('.self-mandala-instrument').count();
+  const chapterFourPsycheArcCount = await page.locator('.psyche-arc-instrument').count();
+  const chapterFourPsycheArcMotion = await page.locator('.psyche-arc-instrument *').evaluateAll((nodes) => nodes.map((node) => {
+    const styles = window.getComputedStyle(node);
+    return {
+      className: node.className,
+      animationName: styles.animationName,
+      transitionDuration: styles.transitionDuration,
+    };
+  }));
   const chapterFourInstrumentMotion = await page.locator('.self-mandala-instrument__center').evaluate((node) => {
     const styles = window.getComputedStyle(node);
     return {
@@ -822,6 +859,8 @@ async function smokeReducedMotion(browser, failures) {
       transitionDuration: styles.transitionDuration,
     };
   });
+  const chapterFourAnimatedParts = chapterFourPsycheArcMotion.filter((motion) => motion.animationName !== 'none');
+  const chapterFourTransitioningParts = chapterFourPsycheArcMotion.filter((motion) => !motion.transitionDuration.split(',').every((duration) => duration.trim() === '0s'));
 
   if (!chapterFourFallbackVisible) failures.push('reduced-motion fallback is not visible for Chapter 4 scene');
   if (chapterFourReducedMotionAttribute !== 'true') failures.push('Chapter 4 did not record reduced-motion state');
@@ -830,8 +869,11 @@ async function smokeReducedMotion(browser, failures) {
   if (chapterFourPauseControlCount !== 0) failures.push(`reduced-motion Chapter 4 rendered pause controls: ${chapterFourPauseControlCount}`);
   if (chapterFourCanvasCount !== 0) failures.push(`reduced-motion Chapter 4 rendered canvas: ${chapterFourCanvasCount}`);
   if (chapterFourInstrumentCount !== 1) failures.push(`reduced-motion Chapter 4 Self mandala instrument count mismatch: ${chapterFourInstrumentCount}`);
+  if (chapterFourPsycheArcCount !== 1) failures.push(`reduced-motion Chapter 4 psyche arc instrument count mismatch: ${chapterFourPsycheArcCount}`);
   if (chapterFourInstrumentMotion.animationName !== 'none') failures.push(`reduced-motion Chapter 4 Self mandala center still animates: ${chapterFourInstrumentMotion.animationName}`);
   if (chapterFourInstrumentMotion.transitionDuration !== '0s') failures.push(`reduced-motion Chapter 4 Self mandala center still transitions: ${chapterFourInstrumentMotion.transitionDuration}`);
+  if (chapterFourAnimatedParts.length > 0) failures.push(`reduced-motion Chapter 4 psyche arc still animates: ${JSON.stringify(chapterFourAnimatedParts)}`);
+  if (chapterFourTransitioningParts.length > 0) failures.push(`reduced-motion Chapter 4 psyche arc still transitions: ${JSON.stringify(chapterFourTransitioningParts)}`);
   if (!chapterFourFallbackText?.includes('Concentric mandala rings') || !chapterFourFallbackText?.includes('fourfold ordering image')) {
     failures.push('reduced-motion chapter fallback lost Chapter 4 Self teaching summary');
   }
@@ -1457,6 +1499,36 @@ async function assertChapterOneInstrumentState(page, failures, expected) {
   }
 }
 
+async function assertPsycheArcInstrumentState(page, failures, expected) {
+  const instrumentGroup = page.getByRole('group', { name: new RegExp(`Psyche arc instrument for ${expected.arcLabel}`, 'i') });
+  const instrumentImage = page.getByRole('img', { name: new RegExp(`${expected.modelLabel}.*Current emphasis`, 'i') });
+  const readout = page.locator('.psyche-arc-instrument__readout');
+  const groupPanel = await instrumentGroup.getAttribute('data-active-panel');
+  const imagePanel = await instrumentImage.getAttribute('data-active-panel');
+  const imageLabel = await instrumentImage.getAttribute('aria-label');
+  const readoutText = await readout.textContent();
+  const activeStepCount = await page.locator('.psyche-arc-instrument__step--active').count();
+  const ariaCurrentStepCount = await page.locator('.psyche-arc-instrument__step[aria-current="step"]').count();
+  const arcCurrentLinkCount = await page.locator('.psyche-arc-instrument__rail-link[aria-current="page"]').count();
+  const arcRailLinkCount = await page.locator('.psyche-arc-instrument__rail-link').count();
+
+  if (groupPanel !== expected.panelId) failures.push(`${expected.chapterLabel} psyche arc group panel mismatch: ${groupPanel}`);
+  if (imagePanel !== expected.panelId) failures.push(`${expected.chapterLabel} psyche arc image panel mismatch: ${imagePanel}`);
+  if (activeStepCount !== 1) failures.push(`${expected.chapterLabel} psyche arc active step count mismatch: ${activeStepCount}`);
+  if (ariaCurrentStepCount !== 1) failures.push(`${expected.chapterLabel} psyche arc aria-current count mismatch: ${ariaCurrentStepCount}`);
+  if (arcCurrentLinkCount !== 1) failures.push(`${expected.chapterLabel} psyche arc current link count mismatch: ${arcCurrentLinkCount}`);
+  if (arcRailLinkCount !== 3) failures.push(`${expected.chapterLabel} psyche arc rail link count mismatch: ${arcRailLinkCount}`);
+  if (!imageLabel?.includes(`Current emphasis: ${expected.emphasis}`)) {
+    failures.push(`${expected.chapterLabel} psyche arc image label did not follow ${expected.emphasis}: ${imageLabel}`);
+  }
+  if (!imageLabel?.includes(expected.insight)) {
+    failures.push(`${expected.chapterLabel} psyche arc image label lost insight for ${expected.emphasis}: ${imageLabel}`);
+  }
+  if (!readoutText?.includes(expected.insight)) {
+    failures.push(`${expected.chapterLabel} psyche arc readout did not follow ${expected.emphasis}: ${readoutText}`);
+  }
+}
+
 async function smokeChapterSceneControls(page, failures) {
   await gotoAppRoute(page, '/journey/chapter/ch1');
   await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
@@ -1526,8 +1598,18 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterTwoReferenceNodes = page.locator('.chapter-stage__reference-node');
   const chapterTwoReferenceCount = await chapterTwoReferenceNodes.count();
   const chapterTwoPanelIds = await chapterTwoReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterTwoModelVisible = await page.getByRole('img', { name: /Shadow projection model/ }).isVisible();
   if (chapterTwoReferenceCount !== 3) failures.push(`chapter 2 reference node count mismatch: ${chapterTwoReferenceCount}`);
   if (chapterTwoPanelIds.join(',') !== 'mirror,projection,integration') failures.push(`chapter 2 reference nodes out of order: ${chapterTwoPanelIds.join(',')}`);
+  if (!chapterTwoModelVisible) failures.push('chapter 2 shadow projection model image is not visible');
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Shadow',
+    chapterLabel: 'chapter 2',
+    modelLabel: 'Shadow projection model',
+    panelId: 'mirror',
+    emphasis: 'Opposition',
+    insight: 'Recognition begins when the image becomes personal.',
+  });
 
   const chapterTwoPause = page.getByRole('button', { name: /Pause animation/ });
   await activateSceneButton(chapterTwoPause);
@@ -1547,6 +1629,14 @@ async function smokeChapterSceneControls(page, failures) {
   const projectionPanelAnnotationVisible = await page.locator('.ch2-a--projection.panel-vis').count();
   const chapterTwoScrollY = await page.evaluate(() => window.scrollY);
   const chapterTwoSceneDescription = await page.locator('#scene-host-description-ch2').textContent();
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Shadow',
+    chapterLabel: 'chapter 2',
+    modelLabel: 'Shadow projection model',
+    panelId: 'projection',
+    emphasis: 'Projection',
+    insight: 'Projection makes inner conflict look external.',
+  });
   if (projectionPressed !== 'true') failures.push(`chapter 2 scene control did not become active: ${projectionPressed}`);
   if (projectionPanelActive !== 1) failures.push(`chapter 2 projection panel did not become active: ${projectionPanelActive}`);
   if (projectionPanelAnnotationVisible !== 1) failures.push(`chapter 2 projection annotation did not follow selected panel: ${projectionPanelAnnotationVisible}`);
@@ -1558,6 +1648,14 @@ async function smokeChapterSceneControls(page, failures) {
   await page.waitForFunction(() => document.querySelector('.ch2-a--integration')?.classList.contains('vis'), null, { timeout: 2_000 }).catch(() => {});
   const integrationPressed = await integration.getAttribute('aria-pressed');
   const integrationAnnotationVisible = await page.locator('.ch2-a--integration.vis').count();
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Shadow',
+    chapterLabel: 'chapter 2',
+    modelLabel: 'Shadow projection model',
+    panelId: 'integration',
+    emphasis: 'Integration',
+    insight: 'The ego grows by admitting what it excludes.',
+  });
   if (integrationPressed !== 'true') failures.push(`chapter 2 integration reference did not become active: ${integrationPressed}`);
   if (integrationAnnotationVisible !== 1) failures.push(`chapter 2 integration annotation did not follow selected panel: ${integrationAnnotationVisible}`);
 
@@ -1585,8 +1683,18 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterThreeReferenceNodes = page.locator('.chapter-stage__reference-node');
   const chapterThreeReferenceCount = await chapterThreeReferenceNodes.count();
   const chapterThreePanelIds = await chapterThreeReferenceNodes.evaluateAll((nodes) => nodes.map((node) => node.getAttribute('data-panel-id')));
+  const chapterThreeModelVisible = await page.getByRole('img', { name: /Syzygy relation model/ }).isVisible();
   if (chapterThreeReferenceCount !== 3) failures.push(`chapter 3 reference node count mismatch: ${chapterThreeReferenceCount}`);
   if (chapterThreePanelIds.join(',') !== 'pair,orbit,union') failures.push(`chapter 3 reference nodes out of order: ${chapterThreePanelIds.join(',')}`);
+  if (!chapterThreeModelVisible) failures.push('chapter 3 syzygy relation model image is not visible');
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Syzygy',
+    chapterLabel: 'chapter 3',
+    modelLabel: 'Syzygy relation model',
+    panelId: 'pair',
+    emphasis: 'Syzygy',
+    insight: 'The psyche thinks in living opposites.',
+  });
 
   const chapterThreePause = page.getByRole('button', { name: /Pause animation/ });
   await activateSceneButton(chapterThreePause);
@@ -1607,6 +1715,14 @@ async function smokeChapterSceneControls(page, failures) {
   const orbitAnnotationDisplay = await page.locator('.ch3-panel-note--orbit.panel-vis').evaluate((node) => window.getComputedStyle(node).display).catch(() => 'missing');
   const chapterThreeOrbitScrollY = await page.evaluate(() => window.scrollY);
   const chapterThreeOrbitDescription = await page.locator('#scene-host-description-ch3').textContent();
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Syzygy',
+    chapterLabel: 'chapter 3',
+    modelLabel: 'Syzygy relation model',
+    panelId: 'orbit',
+    emphasis: 'Relation',
+    insight: 'Wholeness needs tension, not sameness.',
+  });
   if (orbitPressed !== 'true') failures.push(`chapter 3 orbit reference did not become active: ${orbitPressed}`);
   if (orbitPanelActive !== 1) failures.push(`chapter 3 orbit panel did not become active: ${orbitPanelActive}`);
   if (orbitPanelAnnotationVisible !== 1) failures.push(`chapter 3 orbit annotation did not follow selected panel: ${orbitPanelAnnotationVisible}`);
@@ -1633,6 +1749,14 @@ async function smokeChapterSceneControls(page, failures) {
   });
   const chapterThreeUnionScrollY = await page.evaluate(() => window.scrollY);
   const chapterThreeUnionDescription = await page.locator('#scene-host-description-ch3').textContent();
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Syzygy',
+    chapterLabel: 'chapter 3',
+    modelLabel: 'Syzygy relation model',
+    panelId: 'union',
+    emphasis: 'Conjunction',
+    insight: 'Integration is rhythmic, not static.',
+  });
   if (conjunctionPressed !== 'true') failures.push(`chapter 3 union reference did not become active: ${conjunctionPressed}`);
   if (conjunctionPanelActive !== 1) failures.push(`chapter 3 union panel did not become active: ${conjunctionPanelActive}`);
   if (!conjunctionAnnotationState.visible) failures.push('chapter 3 conjunction annotation did not follow selected panel');
@@ -1695,6 +1819,14 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterFourInstrumentCount !== 1) failures.push(`chapter 4 Self mandala instrument count mismatch: ${chapterFourInstrumentCount}`);
   if (!chapterFourInstrumentLabel?.includes('Self mandala model')) failures.push(`chapter 4 Self mandala instrument label missing teaching text: ${chapterFourInstrumentLabel}`);
   if (chapterFourInstrumentPanel !== 'seed') failures.push(`chapter 4 Self mandala instrument did not start on seed panel: ${chapterFourInstrumentPanel}`);
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Self',
+    chapterLabel: 'chapter 4',
+    modelLabel: 'Self mandala model',
+    panelId: 'seed',
+    emphasis: 'Center',
+    insight: 'The deepest center is not the loudest form.',
+  });
   if (!chapterFourInstrumentMarksVisible) failures.push('chapter 4 Self mandala instrument marks are not visibly rendered');
   if (!chapterFourQuaternityGlyphsVisible) failures.push('chapter 4 reference quaternity glyphs are not visibly rendered');
   if (!chapterFourPanelGlyphsVisible) failures.push('chapter 4 panel quaternity/mandala glyphs are not visibly rendered');
@@ -1707,6 +1839,14 @@ async function smokeChapterSceneControls(page, failures) {
   const quaternityPanelActive = await page.locator('.chapter-panel.chapter-panel--active[data-panel-id="quaternity"]').count();
   const chapterFourQuaternityDescription = await page.locator('#scene-host-description-ch4').textContent();
   const chapterFourInstrumentQuaternityPanel = await chapterFourInstrument.getAttribute('data-active-panel');
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Self',
+    chapterLabel: 'chapter 4',
+    modelLabel: 'Self mandala model',
+    panelId: 'quaternity',
+    emphasis: 'Fourfold',
+    insight: 'A totality image must include more than perfection.',
+  });
   if (quaternityPressed !== 'true') failures.push(`chapter 4 quaternity reference did not become active: ${quaternityPressed}`);
   if (quaternityPanelActive !== 1) failures.push(`chapter 4 quaternity panel did not become active: ${quaternityPanelActive}`);
   if (chapterFourInstrumentQuaternityPanel !== 'quaternity') failures.push(`chapter 4 Self mandala instrument did not follow quaternity panel: ${chapterFourInstrumentQuaternityPanel}`);
@@ -1723,6 +1863,14 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterFourMandalaDescription = await page.locator('#scene-host-description-ch4').textContent();
   const chapterFourScrollY = await page.evaluate(() => window.scrollY);
   const chapterFourInstrumentMandalaPanel = await chapterFourInstrument.getAttribute('data-active-panel');
+  await assertPsycheArcInstrumentState(page, failures, {
+    arcLabel: 'Self',
+    chapterLabel: 'chapter 4',
+    modelLabel: 'Self mandala model',
+    panelId: 'mandala',
+    emphasis: 'Mandala',
+    insight: 'The Self orders by holding difference.',
+  });
   if (mandalaPressed !== 'true') failures.push(`chapter 4 scene control did not become active: ${mandalaPressed}`);
   if (mandalaPanelActive !== 1) failures.push(`chapter 4 mandala panel did not become active: ${mandalaPanelActive}`);
   if (chapterFourInstrumentMandalaPanel !== 'mandala') failures.push(`chapter 4 Self mandala instrument did not follow mandala panel: ${chapterFourInstrumentMandalaPanel}`);
@@ -2953,6 +3101,7 @@ async function smokeMobile(page, failures) {
     const chapterTwoReferenceCount = await page.locator('.chapter-stage__reference-node').count();
     const chapterTwoAnnotationDisplay = await page.locator('.ch2-annotations').evaluate((node) => window.getComputedStyle(node).display).catch(() => 'missing');
     const chapterTwoScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const chapterTwoInstrumentBox = await page.locator('.psyche-arc-instrument').boundingBox();
     if (!chapterTwoNavBox || !chapterTwoHeadingBox) {
       failures.push(`mobile chapter 2 geometry missing at ${viewport.width}x${viewport.height}`);
       continue;
@@ -2965,6 +3114,10 @@ async function smokeMobile(page, failures) {
     if (chapterTwoReferenceCount !== 3) failures.push(`mobile chapter 2 reference node count mismatch at ${viewport.width}x${viewport.height}: ${chapterTwoReferenceCount}`);
     if (chapterTwoAnnotationDisplay !== 'none') failures.push(`mobile chapter 2 annotation overlay remains visible at ${viewport.width}x${viewport.height}: ${chapterTwoAnnotationDisplay}`);
     if (chapterTwoScrollWidth > viewport.width + 2) failures.push(`mobile chapter 2 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterTwoScrollWidth}`);
+    if (!chapterTwoInstrumentBox) failures.push(`mobile chapter 2 psyche arc instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterTwoInstrumentBox && chapterTwoInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 2 psyche arc instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterTwoInstrumentBox.width)}`);
+    }
 
     await gotoAppRoute(page, '/journey/chapter/ch3');
     await page.locator('.scene-host__mount[data-state="ready"], .scene-host__fallback').first().waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
@@ -2976,6 +3129,7 @@ async function smokeMobile(page, failures) {
     const chapterThreeAnnotationDisplay = await page.locator('.ch3-annotations').evaluate((node) => window.getComputedStyle(node).display).catch(() => 'missing');
     const chapterThreeScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
     const chapterThreeReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
+    const chapterThreeInstrumentBox = await page.locator('.psyche-arc-instrument').boundingBox();
     if (!chapterThreeNavBox || !chapterThreeHeadingBox) {
       failures.push(`mobile chapter 3 geometry missing at ${viewport.width}x${viewport.height}`);
       continue;
@@ -2991,6 +3145,10 @@ async function smokeMobile(page, failures) {
     if (chapterThreeScrollWidth > viewport.width + 2) failures.push(`mobile chapter 3 horizontal overflow at ${viewport.width}x${viewport.height}: ${chapterThreeScrollWidth}`);
     if (chapterThreeReferenceMapBox && chapterThreeReferenceMapBox.width > viewport.width + 2) {
       failures.push(`mobile chapter 3 reference map exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterThreeReferenceMapBox.width)}`);
+    }
+    if (!chapterThreeInstrumentBox) failures.push(`mobile chapter 3 psyche arc instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterThreeInstrumentBox && chapterThreeInstrumentBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 3 psyche arc instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterThreeInstrumentBox.width)}`);
     }
 
     if (viewport.width === mobileViewport.width) {
@@ -3012,6 +3170,7 @@ async function smokeMobile(page, failures) {
     const chapterFourScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
     const chapterFourReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
     const chapterFourInstrumentBox = await page.locator('.self-mandala-instrument').boundingBox();
+    const chapterFourPsycheArcBox = await page.locator('.psyche-arc-instrument').boundingBox();
     if (!chapterFourNavBox || !chapterFourHeadingBox) {
       failures.push(`mobile chapter 4 geometry missing at ${viewport.width}x${viewport.height}`);
       continue;
@@ -3030,6 +3189,10 @@ async function smokeMobile(page, failures) {
     if (!chapterFourInstrumentBox) failures.push(`mobile chapter 4 Self mandala instrument missing at ${viewport.width}x${viewport.height}`);
     if (chapterFourInstrumentBox && chapterFourInstrumentBox.width > viewport.width + 2) {
       failures.push(`mobile chapter 4 Self mandala instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterFourInstrumentBox.width)}`);
+    }
+    if (!chapterFourPsycheArcBox) failures.push(`mobile chapter 4 psyche arc instrument missing at ${viewport.width}x${viewport.height}`);
+    if (chapterFourPsycheArcBox && chapterFourPsycheArcBox.width > viewport.width + 2) {
+      failures.push(`mobile chapter 4 psyche arc instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterFourPsycheArcBox.width)}`);
     }
 
     await gotoAppRoute(page, '/journey/chapter/ch5');

--- a/src/app/components/PsycheArcInstrument.css
+++ b/src/app/components/PsycheArcInstrument.css
@@ -1,0 +1,255 @@
+.psyche-arc-instrument {
+  --psyche-accent: var(--gold-soft);
+  --psyche-secondary: var(--cyan);
+  --psyche-shadow: rgba(0, 0, 0, 0.2);
+  position: relative;
+  width: min(30rem, 100%);
+  margin-top: 0.5rem;
+  padding: 0.28rem;
+  overflow: hidden;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: calc(var(--radius) + 0.18rem);
+  background:
+    radial-gradient(circle at 18% 0%, color-mix(in srgb, var(--psyche-secondary) 18%, transparent), transparent 5.8rem),
+    radial-gradient(circle at 92% 20%, color-mix(in srgb, var(--psyche-accent) 16%, transparent), transparent 6rem),
+    linear-gradient(180deg, rgba(244, 240, 232, 0.055), rgba(244, 240, 232, 0.018));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 1.8rem 4rem var(--psyche-shadow);
+}
+
+.psyche-arc-instrument--ch2 {
+  --psyche-accent: #c4a6f6;
+  --psyche-secondary: #d4af37;
+}
+
+.psyche-arc-instrument--ch3 {
+  --psyche-accent: #ffd060;
+  --psyche-secondary: #53d8e8;
+}
+
+.psyche-arc-instrument--ch4 {
+  --psyche-accent: #d4af37;
+  --psyche-secondary: #53d8e8;
+}
+
+.psyche-arc-instrument__header,
+.psyche-arc-instrument__rail,
+.psyche-arc-instrument__scale {
+  position: relative;
+  z-index: 2;
+}
+
+.psyche-arc-instrument__header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.03rem 0.6rem;
+  padding: 0.08rem 0.18rem 0.18rem;
+  text-align: left;
+}
+
+.psyche-arc-instrument__header span,
+.psyche-arc-instrument__header em,
+.psyche-arc-instrument__step em {
+  color: rgba(244, 240, 232, 0.52);
+  font-family: var(--font-ui);
+  font-size: 0.55rem;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.psyche-arc-instrument__header strong {
+  color: rgba(244, 240, 232, 0.94);
+  font-family: var(--font-display);
+  font-size: 0.92rem;
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 0.92;
+}
+
+.psyche-arc-instrument__header em {
+  align-self: end;
+  color: color-mix(in srgb, var(--psyche-accent) 88%, rgba(244, 240, 232, 0.82));
+  text-align: right;
+}
+
+.psyche-arc-instrument .psyche-arc-instrument__field {
+  width: 100%;
+  min-height: clamp(5.9rem, 10vh, 7.2rem);
+  margin-top: 0;
+  border-radius: calc(var(--radius) - 0.05rem);
+}
+
+.psyche-arc-instrument--ch3 .psyche-arc-instrument__field,
+.psyche-arc-instrument--ch4 .psyche-arc-instrument__field {
+  min-height: clamp(4.45rem, 7vh, 5.1rem);
+}
+
+.psyche-arc-instrument__rail {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.24rem;
+  margin-top: 0.2rem;
+}
+
+.psyche-arc-instrument__rail-link {
+  display: grid;
+  min-height: 1.55rem;
+  padding: 0.15rem 0.22rem;
+  color: rgba(244, 240, 232, 0.54);
+  text-decoration: none;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  border-radius: 0.58rem;
+  background: rgba(3, 3, 7, 0.35);
+  transition:
+    color 0.42s var(--motion-spring),
+    border-color 0.42s var(--motion-spring),
+    background 0.42s var(--motion-spring),
+    transform 0.42s var(--motion-spring);
+}
+
+.psyche-arc-instrument__rail-link:hover,
+.psyche-arc-instrument__rail-link:focus-visible {
+  color: rgba(244, 240, 232, 0.88);
+  border-color: rgba(244, 240, 232, 0.18);
+  background: rgba(244, 240, 232, 0.06);
+  transform: translateY(-1px);
+}
+
+.psyche-arc-instrument__rail-link--active {
+  color: rgba(244, 240, 232, 0.95);
+  border-color: color-mix(in srgb, var(--psyche-accent) 44%, transparent);
+  background:
+    radial-gradient(circle at 20% 20%, color-mix(in srgb, var(--psyche-accent) 20%, transparent), transparent 2rem),
+    rgba(244, 240, 232, 0.07);
+}
+
+.psyche-arc-instrument__rail-link span {
+  color: color-mix(in srgb, var(--psyche-accent) 84%, rgba(244, 240, 232, 0.72));
+  font-family: var(--font-ui);
+  font-size: 0.44rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.psyche-arc-instrument__rail-link strong {
+  margin-top: 0.03rem;
+  font-family: var(--font-ui);
+  font-size: 0.52rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.psyche-arc-instrument__scale {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  list-style: none;
+  white-space: nowrap;
+}
+
+.psyche-arc-instrument__step {
+  display: grid;
+  gap: 0.12rem;
+  min-height: 2.55rem;
+  padding: 0.32rem 0.36rem;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  border-radius: 0.62rem;
+  background: rgba(3, 3, 7, 0.36);
+}
+
+.psyche-arc-instrument__step--active {
+  border-color: color-mix(in srgb, var(--psyche-accent) 40%, transparent);
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--psyche-accent) 12%, transparent), transparent),
+    rgba(3, 3, 7, 0.42);
+}
+
+.psyche-arc-instrument__step span {
+  color: color-mix(in srgb, var(--psyche-accent) 88%, rgba(244, 240, 232, 0.84));
+  font-family: var(--font-ui);
+  font-size: 0.52rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.psyche-arc-instrument__step strong {
+  color: rgba(244, 240, 232, 0.88);
+  font-family: var(--font-ui);
+  font-size: 0.64rem;
+  font-weight: 850;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.psyche-arc-instrument__step em {
+  overflow: hidden;
+  font-size: 0.5rem;
+  letter-spacing: 0.02em;
+  line-height: 1.08;
+  text-overflow: ellipsis;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+.psyche-arc-instrument__readout {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .psyche-arc-instrument,
+  .psyche-arc-instrument *,
+  .psyche-arc-instrument *::before,
+  .psyche-arc-instrument *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+@media (max-width: 680px) {
+  .psyche-arc-instrument {
+    width: min(25.5rem, 100%);
+    padding: 0.36rem;
+  }
+
+  .psyche-arc-instrument .psyche-arc-instrument__field,
+  .psyche-arc-instrument--ch3 .psyche-arc-instrument__field,
+  .psyche-arc-instrument--ch4 .psyche-arc-instrument__field {
+    min-height: 6.65rem;
+  }
+
+  .psyche-arc-instrument__rail-link {
+    min-height: 1.84rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .psyche-arc-instrument {
+    margin-top: 0.72rem;
+  }
+
+  .psyche-arc-instrument__scale {
+    gap: 0.2rem;
+  }
+
+  .psyche-arc-instrument__step {
+    padding: 0.3rem 0.26rem;
+  }
+
+  .psyche-arc-instrument__step em {
+    display: none;
+  }
+}

--- a/src/app/components/PsycheArcInstrument.tsx
+++ b/src/app/components/PsycheArcInstrument.tsx
@@ -1,0 +1,189 @@
+import { Link } from 'react-router';
+
+import type { LearningPanel } from '../types';
+import './PsycheArcInstrument.css';
+
+type PsycheArcChapterId = 'ch2' | 'ch3' | 'ch4';
+
+const quaternityDirections = ['north', 'east', 'south', 'west'] as const;
+
+const psycheArcChapters = [
+  { id: 'ch2', label: 'Shadow', route: '/journey/chapter/ch2' },
+  { id: 'ch3', label: 'Syzygy', route: '/journey/chapter/ch3' },
+  { id: 'ch4', label: 'Self', route: '/journey/chapter/ch4' },
+] as const;
+
+const psycheArcSteps: Record<PsycheArcChapterId, Array<{
+  id: string;
+  label: string;
+  measure: string;
+  note: string;
+}>> = {
+  ch2: [
+    { id: 'mirror', label: 'Mirror', measure: 'refused likeness', note: 'make it personal' },
+    { id: 'projection', label: 'Projection', measure: 'outward arc', note: 'see the throw' },
+    { id: 'integration', label: 'Return', measure: 'held tension', note: 'relate the dark' },
+  ],
+  ch3: [
+    { id: 'pair', label: 'Pair', measure: 'living poles', note: 'do not fix them' },
+    { id: 'orbit', label: 'Orbit', measure: 'relation field', note: 'keep tension moving' },
+    { id: 'union', label: 'Conjunction', measure: 'brief mandorla', note: 'flash then release' },
+  ],
+  ch4: [
+    { id: 'seed', label: 'Seed', measure: 'small center', note: 'quiet origin' },
+    { id: 'quaternity', label: 'Fourfold', measure: 'ordered directions', note: 'structure appears' },
+    { id: 'mandala', label: 'Mandala', measure: 'total image', note: 'hold difference' },
+  ],
+};
+
+const psycheArcFieldLabels: Record<PsycheArcChapterId, string> = {
+  ch2: 'Shadow projection model: the ego stands before a mirror, casts refused material outward as a shadow, and begins returning it through integration.',
+  ch3: 'Syzygy relation model: anima and animus appear as symbolic poles, projection arcs outward and returns into orbit, and conjunction forms a brief shared field without erasing the pair.',
+  ch4: 'Self mandala model: a small center opens into a wider totality, four directions make wholeness readable, and concentric mandala rings order conflict without flattening difference.',
+};
+
+export default function PsycheArcInstrument({
+  activePanel,
+  activePanelId,
+  chapterId,
+}: {
+  activePanel?: LearningPanel;
+  activePanelId: string;
+  chapterId: PsycheArcChapterId;
+}) {
+  const steps = psycheArcSteps[chapterId];
+  const currentStep = steps.find((step) => step.id === activePanelId) || steps[0];
+  const activeChapter = psycheArcChapters.find((chapter) => chapter.id === chapterId);
+  const emphasis = activePanel
+    ? `${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`
+    : `${currentStep.label}: ${currentStep.note}.`;
+  const fieldLabel = `${psycheArcFieldLabels[chapterId]} Current emphasis: ${emphasis}`;
+
+  return (
+    <section
+      className={`psyche-arc-instrument psyche-arc-instrument--${chapterId}`}
+      data-active-panel={currentStep.id}
+      data-arc-chapter={chapterId}
+      role="group"
+      aria-label={`Psyche arc instrument for ${activeChapter?.label}. Active focus: ${emphasis}`}
+    >
+      <div className="psyche-arc-instrument__header">
+        <span>Psyche arc</span>
+        <strong>{currentStep.label}</strong>
+        <em>{currentStep.measure}</em>
+      </div>
+
+      {chapterId === 'ch2' && <ShadowProjectionField activePanelId={currentStep.id} label={fieldLabel} />}
+      {chapterId === 'ch3' && <SyzygyRelationField activePanelId={currentStep.id} label={fieldLabel} />}
+      {chapterId === 'ch4' && <SelfMandalaField activePanelId={currentStep.id} label={fieldLabel} />}
+
+      <nav className="psyche-arc-instrument__rail" aria-label="Psyche arc chapter sequence">
+        {psycheArcChapters.map((chapter, index) => (
+          <Link
+            key={chapter.id}
+            className={chapter.id === chapterId ? 'psyche-arc-instrument__rail-link psyche-arc-instrument__rail-link--active' : 'psyche-arc-instrument__rail-link'}
+            to={chapter.route}
+            aria-current={chapter.id === chapterId ? 'page' : undefined}
+            aria-label={`Open Chapter ${index + 2}: ${chapter.label}`}
+          >
+            <span>{String(index + 2).padStart(2, '0')}</span>
+            <strong>{chapter.label}</strong>
+          </Link>
+        ))}
+      </nav>
+
+      <ol className="psyche-arc-instrument__scale" aria-label={`${activeChapter?.label} visual sequence`}>
+        {steps.map((step, index) => (
+          <li
+            key={step.id}
+            className={step.id === currentStep.id ? 'psyche-arc-instrument__step psyche-arc-instrument__step--active' : 'psyche-arc-instrument__step'}
+            aria-current={step.id === currentStep.id ? 'step' : undefined}
+          >
+            <span>{String(index + 1).padStart(2, '0')}</span>
+            <strong>{step.label}</strong>
+            <em>{step.note}</em>
+          </li>
+        ))}
+      </ol>
+
+      <p className="psyche-arc-instrument__readout" aria-live="polite" aria-atomic="true">
+        {activePanel?.insight || currentStep.note}
+      </p>
+    </section>
+  );
+}
+
+function ShadowProjectionField({ activePanelId, label }: { activePanelId: string; label: string }) {
+  return (
+    <div
+      className="shadow-projection-instrument psyche-arc-instrument__field"
+      data-active-panel={activePanelId}
+      role="img"
+      aria-label={label}
+    >
+      <span className="shadow-projection-instrument__vessel" aria-hidden="true" />
+      <span className="shadow-projection-instrument__mirror" aria-hidden="true" />
+      <span className="shadow-projection-instrument__ego" aria-hidden="true" />
+      <span className="shadow-projection-instrument__shadow" aria-hidden="true" />
+      <span className="shadow-projection-instrument__arc shadow-projection-instrument__arc--projection" aria-hidden="true" />
+      <span className="shadow-projection-instrument__arc shadow-projection-instrument__arc--return" aria-hidden="true" />
+      <span className="shadow-projection-instrument__bridge" aria-hidden="true" />
+      <span className="shadow-projection-instrument__label shadow-projection-instrument__label--ego" aria-hidden="true">ego</span>
+      <span className="shadow-projection-instrument__label shadow-projection-instrument__label--mirror" aria-hidden="true">mirror</span>
+      <span className="shadow-projection-instrument__label shadow-projection-instrument__label--shadow" aria-hidden="true">shadow</span>
+      <span className="shadow-projection-instrument__label shadow-projection-instrument__label--projection" aria-hidden="true">projection</span>
+      <span className="shadow-projection-instrument__label shadow-projection-instrument__label--return" aria-hidden="true">return</span>
+    </div>
+  );
+}
+
+function SyzygyRelationField({ activePanelId, label }: { activePanelId: string; label: string }) {
+  return (
+    <div
+      className="syzygy-relation-instrument psyche-arc-instrument__field"
+      data-active-panel={activePanelId}
+      role="img"
+      aria-label={label}
+    >
+      <span className="syzygy-relation-instrument__axis" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__orbit syzygy-relation-instrument__orbit--outer" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__orbit syzygy-relation-instrument__orbit--inner" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__field syzygy-relation-instrument__field--upper" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__field syzygy-relation-instrument__field--lower" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__projection syzygy-relation-instrument__projection--outward" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__projection syzygy-relation-instrument__projection--return" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__mandorla" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__conjunction-core" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__pole syzygy-relation-instrument__pole--anima" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__pole syzygy-relation-instrument__pole--animus" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--anima" aria-hidden="true">anima</span>
+      <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--animus" aria-hidden="true">animus</span>
+      <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--orbit" aria-hidden="true">orbit</span>
+      <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--conjunction" aria-hidden="true">conjunction</span>
+    </div>
+  );
+}
+
+function SelfMandalaField({ activePanelId, label }: { activePanelId: string; label: string }) {
+  return (
+    <div
+      className="self-mandala-instrument psyche-arc-instrument__field"
+      data-active-panel={activePanelId}
+      role="img"
+      aria-label={label}
+    >
+      <span className="self-mandala-instrument__ring self-mandala-instrument__ring--outer" aria-hidden="true" />
+      <span className="self-mandala-instrument__ring self-mandala-instrument__ring--middle" aria-hidden="true" />
+      <span className="self-mandala-instrument__ring self-mandala-instrument__ring--inner" aria-hidden="true" />
+      <span className="self-mandala-instrument__axis self-mandala-instrument__axis--vertical" aria-hidden="true" />
+      <span className="self-mandala-instrument__axis self-mandala-instrument__axis--horizontal" aria-hidden="true" />
+      {quaternityDirections.map((direction) => (
+        <span key={direction} className={`self-mandala-instrument__point self-mandala-instrument__point--${direction}`} aria-hidden="true" />
+      ))}
+      <span className="self-mandala-instrument__center" aria-hidden="true" />
+      <span className="self-mandala-instrument__label self-mandala-instrument__label--center" aria-hidden="true">center</span>
+      <span className="self-mandala-instrument__label self-mandala-instrument__label--fourfold" aria-hidden="true">fourfold</span>
+      <span className="self-mandala-instrument__label self-mandala-instrument__label--mandala" aria-hidden="true">mandala</span>
+    </div>
+  );
+}

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import Chapter14FinalSynthesisInstrument from '../components/Chapter14FinalSynthesisInstrument';
 import ChapterOneReferenceInstrument from '../components/ChapterOneReferenceInstrument';
 import ChapterSigil from '../components/ChapterSigil';
+import PsycheArcInstrument from '../components/PsycheArcInstrument';
 import SceneHost from '../components/SceneHost';
 import {
   getAdjacentChapters,
@@ -124,71 +125,12 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
           <p className="eyebrow">Chapter {chapter.order} · {chapter.cluster}</p>
           <h1>{chapter.title}</h1>
           <p>{chapter.summary}</p>
-          {chapter.id === 'ch2' && (
-            <div
-              className="shadow-projection-instrument"
-              data-active-panel={activePanelId}
-              role="img"
-              aria-label="Shadow projection model: the ego stands before a mirror, casts refused material outward as a shadow, and begins returning it through integration."
-            >
-              <span className="shadow-projection-instrument__vessel" aria-hidden="true" />
-              <span className="shadow-projection-instrument__mirror" aria-hidden="true" />
-              <span className="shadow-projection-instrument__ego" aria-hidden="true" />
-              <span className="shadow-projection-instrument__shadow" aria-hidden="true" />
-              <span className="shadow-projection-instrument__arc shadow-projection-instrument__arc--projection" aria-hidden="true" />
-              <span className="shadow-projection-instrument__arc shadow-projection-instrument__arc--return" aria-hidden="true" />
-              <span className="shadow-projection-instrument__bridge" aria-hidden="true" />
-              <span className="shadow-projection-instrument__label shadow-projection-instrument__label--ego" aria-hidden="true">ego</span>
-              <span className="shadow-projection-instrument__label shadow-projection-instrument__label--mirror" aria-hidden="true">mirror</span>
-              <span className="shadow-projection-instrument__label shadow-projection-instrument__label--shadow" aria-hidden="true">shadow</span>
-              <span className="shadow-projection-instrument__label shadow-projection-instrument__label--projection" aria-hidden="true">projection</span>
-              <span className="shadow-projection-instrument__label shadow-projection-instrument__label--return" aria-hidden="true">return</span>
-            </div>
-          )}
-          {chapter.id === 'ch3' && (
-            <div
-              className="syzygy-relation-instrument"
-              data-active-panel={activePanelId}
-              role="img"
-              aria-label="Syzygy relation model: anima and animus appear as symbolic poles, projection arcs outward and returns into orbit, and conjunction forms a brief shared field without erasing the pair."
-            >
-              <span className="syzygy-relation-instrument__axis" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__orbit syzygy-relation-instrument__orbit--outer" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__orbit syzygy-relation-instrument__orbit--inner" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__field syzygy-relation-instrument__field--upper" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__field syzygy-relation-instrument__field--lower" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__projection syzygy-relation-instrument__projection--outward" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__projection syzygy-relation-instrument__projection--return" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__mandorla" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__conjunction-core" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__pole syzygy-relation-instrument__pole--anima" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__pole syzygy-relation-instrument__pole--animus" aria-hidden="true" />
-              <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--anima" aria-hidden="true">anima</span>
-              <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--animus" aria-hidden="true">animus</span>
-              <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--orbit" aria-hidden="true">orbit</span>
-              <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--conjunction" aria-hidden="true">conjunction</span>
-            </div>
-          )}
-          {chapter.id === 'ch4' && (
-            <div
-              className="self-mandala-instrument"
-              data-active-panel={activePanelId}
-              role="img"
-              aria-label="Self mandala model: a small center opens into a wider totality, four directions make wholeness readable, and concentric mandala rings order conflict without flattening difference."
-            >
-              <span className="self-mandala-instrument__ring self-mandala-instrument__ring--outer" aria-hidden="true" />
-              <span className="self-mandala-instrument__ring self-mandala-instrument__ring--middle" aria-hidden="true" />
-              <span className="self-mandala-instrument__ring self-mandala-instrument__ring--inner" aria-hidden="true" />
-              <span className="self-mandala-instrument__axis self-mandala-instrument__axis--vertical" aria-hidden="true" />
-              <span className="self-mandala-instrument__axis self-mandala-instrument__axis--horizontal" aria-hidden="true" />
-              {quaternityDirections.map((direction) => (
-                <span key={direction} className={`self-mandala-instrument__point self-mandala-instrument__point--${direction}`} aria-hidden="true" />
-              ))}
-              <span className="self-mandala-instrument__center" aria-hidden="true" />
-              <span className="self-mandala-instrument__label self-mandala-instrument__label--center" aria-hidden="true">center</span>
-              <span className="self-mandala-instrument__label self-mandala-instrument__label--fourfold" aria-hidden="true">fourfold</span>
-              <span className="self-mandala-instrument__label self-mandala-instrument__label--mandala" aria-hidden="true">mandala</span>
-            </div>
+          {(chapter.id === 'ch2' || chapter.id === 'ch3' || chapter.id === 'ch4') && (
+            <PsycheArcInstrument
+              activePanel={activePanel}
+              activePanelId={activePanelId}
+              chapterId={chapter.id}
+            />
           )}
           {chapter.id === 'ch5' && (
             <div

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2370,6 +2370,11 @@ h3 {
   font-size: clamp(1rem, 1.35vw, 1.08rem);
 }
 
+.chapter-experience[data-chapter-id="ch3"] .scene-host__controls {
+  top: 7.25rem;
+  bottom: auto;
+}
+
 .chapter-experience[data-chapter-id="ch3"] .chapter-stage__thesis-map {
   max-width: 28rem;
   margin-top: 1.25rem;
@@ -11167,6 +11172,11 @@ h3 {
     max-width: 26ch;
     font-size: 0.98rem;
     line-height: 1.56;
+  }
+
+  .chapter-experience[data-chapter-id="ch3"] .scene-host__controls {
+    top: 7.25rem;
+    bottom: auto;
   }
 
   .syzygy-relation-instrument {


### PR DESCRIPTION
## Summary

- Extract the Chapter 2-4 psyche arc visuals into a shared React instrument that preserves the existing Shadow, Syzygy, and Self visual language while adding an arc rail and live panel readout.
- Make the Ch2-4 visual model labels follow the active scrollytelling panel for screen readers and keyboard users.
- Fix Chapter 3 control placement so the pause control no longer sits below the smoke-test viewport and triggers page scroll during scene interaction.
- Extend app shell and accessibility smoke coverage for psyche-arc state, reduced motion, mobile width, keyboard activation, and touch-target size.

## Root Cause

The current local e2e failure was layout-driven: Chapter 3's stage content made the stage taller than the first viewport, while the pause control was anchored to the stage bottom. The smoke helper scrolled that control into view before pausing, leaving the page scrolled when later orbit/union controls were checked.

## Verification

- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages`
- `npm run test:pages:artifact`
- `AION_VISUAL_MIN_SCORE=85 npm run test:visual:control-tower`
- `git diff --check`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .`