### PR TITLE
[codex] Refine symbols concordance

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -493,10 +493,13 @@ async function checkSymbolsDynamicAccessibility(page, failures) {
   const fishField = page.getByRole('img', { name: /Fish symbol field/ });
   const initialFieldVisible = await fishField.isVisible();
   const initialFieldLabel = initialFieldVisible ? await fishField.getAttribute('aria-label') : null;
+  const detailRegion = page.locator('#symbol-selected-detail');
+  const detailAtomic = await detailRegion.getAttribute('aria-atomic');
   const initialDetail = await page.locator('#symbol-selected-detail h2').textContent();
 
   if (!initialFieldVisible) failures.push('/symbols: active symbol field is missing an accessible image role');
   if (!initialFieldLabel?.includes('Piscean fish pair') || !initialFieldLabel?.includes('Chapter 6')) failures.push(`/symbols: initial field label mismatch: ${initialFieldLabel}`);
+  if (detailAtomic !== 'true') failures.push(`/symbols: detail live region is not atomic: ${detailAtomic}`);
   if (!initialDetail?.includes('Fish')) failures.push(`/symbols: initial detail mismatch: ${initialDetail}`);
 
   const sophia = page.getByRole('button', { name: /Select Sophia:/ });

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -542,6 +542,10 @@ async function smokeSymbolsVisualField(page, failures) {
   const initialActivePanelCount = await page.locator('.symbol-panel__activate[aria-pressed="true"]').count();
   const initialConceptCount = await page.locator('.symbol-field__concept').count();
   const initialChapterCount = await page.locator('.symbol-field__chapter').count();
+  const initialThreadCount = await page.locator('.symbol-field__thread').count();
+  const initialMarkCount = await page.locator('.symbol-mark').count();
+  const specimenVisible = await page.locator('.symbol-field__specimen').isVisible();
+  const detailSpecimen = await page.locator('.symbol-detail__specimen').textContent();
   const initialChapterLinkCount = await page.locator('.symbol-detail__chapter-links a').count();
   const scrollYBeforeSelect = await page.evaluate(() => window.scrollY);
 
@@ -554,6 +558,10 @@ async function smokeSymbolsVisualField(page, failures) {
   if (initialActivePanelCount !== 1) failures.push(`symbols active panel count mismatch: ${initialActivePanelCount}`);
   if (initialConceptCount < 4) failures.push(`symbols concept node count too low: ${initialConceptCount}`);
   if (initialChapterCount < 2) failures.push(`symbols chapter node count too low: ${initialChapterCount}`);
+  if (initialThreadCount < 2) failures.push(`symbols chapter thread count too low: ${initialThreadCount}`);
+  if (initialMarkCount < 20) failures.push(`symbols mark count too low: ${initialMarkCount}`);
+  if (!specimenVisible) failures.push('symbols active specimen is not visible');
+  if (!detailSpecimen?.includes('Aeon / shadow')) failures.push(`symbols detail specimen mismatch: ${detailSpecimen}`);
   if (initialChapterLinkCount < 2) failures.push(`symbols chapter link count too low: ${initialChapterLinkCount}`);
 
   const sophia = page.getByRole('button', { name: /Select Sophia:/ });
@@ -581,10 +589,14 @@ async function smokeSymbolsVisualField(page, failures) {
   const lapisPanelPressed = await lapisPanelButton.getAttribute('aria-pressed');
   const lapisDetail = await page.locator('#symbol-selected-detail h2').textContent();
   const lapisFieldLabel = await page.getByRole('img', { name: /Lapis symbol field/ }).getAttribute('aria-label');
+  const lapisActiveOrbitCount = await page.locator('.symbol-orbit__node[aria-pressed="true"]').count();
+  const lapisThreadCount = await page.locator('.symbol-field__thread').count();
 
   if (lapisPanelPressed !== 'true') failures.push(`symbols Lapis panel did not become active: ${lapisPanelPressed}`);
   if (!lapisDetail?.includes('Lapis')) failures.push(`symbols detail did not follow Lapis panel selection: ${lapisDetail}`);
   if (!lapisFieldLabel?.includes('Lapis philosophorum') || !lapisFieldLabel?.toLowerCase().includes('individuation')) failures.push(`symbols Lapis field label mismatch: ${lapisFieldLabel}`);
+  if (lapisActiveOrbitCount !== 1) failures.push(`symbols Lapis active orbit count mismatch: ${lapisActiveOrbitCount}`);
+  if (lapisThreadCount < 2) failures.push(`symbols Lapis chapter thread count too low: ${lapisThreadCount}`);
 }
 
 async function smokeAboutOrientation(page, failures) {

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -163,6 +163,59 @@ async function checkTimelineArtifact(page, failures) {
   if (!fieldLabel?.includes('22 of 22 events visible')) failures.push(`/timeline artifact field label mismatch: ${fieldLabel}`);
 }
 
+async function checkSymbolsArtifact(page, failures) {
+  await checkShellRoute(page, '/symbols', failures);
+
+  const title = await page.locator('h1').first().textContent();
+  const orbitCount = await page.locator('.symbol-orbit__node').count();
+  const panelCount = await page.locator('.symbol-panel').count();
+  const markCount = await page.locator('.symbol-mark').count();
+  const specimenVisible = await page.locator('.symbol-field__specimen').isVisible();
+  const threadCount = await page.locator('.symbol-field__thread').count();
+  const fieldLabel = await page.getByRole('img', { name: /Fish symbol field/ }).getAttribute('aria-label');
+  const detailTitle = await page.locator('#symbol-selected-detail h2').textContent();
+  const detailSpecimen = await page.locator('.symbol-detail__specimen').textContent();
+  const chapterHrefs = await page.locator('.symbol-detail__chapter-links a').evaluateAll((links) => links.map((link) => link.getAttribute('href')));
+
+  if (!title?.includes('Lexicon of recurring images')) failures.push(`/symbols artifact title mismatch: ${title}`);
+  if (orbitCount !== 9) failures.push(`/symbols artifact orbit count mismatch: ${orbitCount}`);
+  if (panelCount !== 9) failures.push(`/symbols artifact panel count mismatch: ${panelCount}`);
+  if (markCount < 20) failures.push(`/symbols artifact mark count too low: ${markCount}`);
+  if (!specimenVisible) failures.push('/symbols artifact active specimen is not visible');
+  if (threadCount < 2) failures.push(`/symbols artifact chapter thread count too low: ${threadCount}`);
+  if (!fieldLabel?.includes('Piscean fish pair') || !fieldLabel?.includes('Chapter 6')) failures.push(`/symbols artifact field label mismatch: ${fieldLabel}`);
+  if (!detailTitle?.includes('Fish')) failures.push(`/symbols artifact initial detail mismatch: ${detailTitle}`);
+  if (!detailSpecimen?.includes('Aeon / shadow')) failures.push(`/symbols artifact specimen mismatch: ${detailSpecimen}`);
+  if (!chapterHrefs.length || chapterHrefs.some((href) => !href?.startsWith(`${basePath}/journey/chapter/ch`))) {
+    failures.push(`/symbols artifact chapter hrefs are not base-aware: ${chapterHrefs.join(', ')}`);
+  }
+
+  const sophia = page.getByRole('button', { name: /Select Sophia:/ });
+  await sophia.click();
+  await page.waitForTimeout(100);
+
+  const sophiaPressed = await sophia.getAttribute('aria-pressed');
+  const sophiaFieldLabel = await page.getByRole('img', { name: /Sophia symbol field/ }).getAttribute('aria-label');
+  const sophiaLink = await page.getByRole('link', { name: /03 · The Syzygy/ }).getAttribute('href');
+  const activeOrbitCount = await page.locator('.symbol-orbit__node[aria-pressed="true"]').count();
+
+  if (sophiaPressed !== 'true') failures.push(`/symbols artifact Sophia orbit did not become active: ${sophiaPressed}`);
+  if (!sophiaFieldLabel?.includes('Sophia / wisdom figure') || !sophiaFieldLabel?.includes('The Syzygy')) failures.push(`/symbols artifact Sophia field label mismatch: ${sophiaFieldLabel}`);
+  if (sophiaLink !== `${basePath}/journey/chapter/ch3`) failures.push(`/symbols artifact Sophia link mismatch: ${sophiaLink}`);
+  if (activeOrbitCount !== 1) failures.push(`/symbols artifact active orbit count mismatch: ${activeOrbitCount}`);
+
+  const lapis = page.getByRole('button', { name: /Focus Lapis in the symbol field/ });
+  await lapis.click();
+  await page.waitForTimeout(100);
+
+  const lapisPressed = await lapis.getAttribute('aria-pressed');
+  const lapisDetail = await page.locator('#symbol-selected-detail h2').textContent();
+  const activePanelCount = await page.locator('.symbol-panel__activate[aria-pressed="true"]').count();
+  if (lapisPressed !== 'true') failures.push(`/symbols artifact Lapis panel did not become active: ${lapisPressed}`);
+  if (!lapisDetail?.includes('Lapis')) failures.push(`/symbols artifact Lapis detail mismatch: ${lapisDetail}`);
+  if (activePanelCount !== 1) failures.push(`/symbols artifact active panel count mismatch: ${activePanelCount}`);
+}
+
 async function checkChaptersArtifact(page, failures) {
   await checkShellRoute(page, '/chapters', failures);
 
@@ -244,6 +297,7 @@ async function runSmoke() {
     await checkChaptersArtifact(desktop, failures);
     await checkAboutArtifact(desktop, failures);
     await checkTimelineArtifact(desktop, failures);
+    await checkSymbolsArtifact(desktop, failures);
 
     const legacyChapter = await desktop.goto(`${baseUrl}/chapters/chapter-7.html`, {
       waitUntil: 'domcontentloaded',

--- a/src/app/pages/SymbolsPage.css
+++ b/src/app/pages/SymbolsPage.css
@@ -5,11 +5,12 @@
 .symbols-hero::before {
   content: '';
   position: absolute;
-  inset: 0 50% 0 0;
+  inset: 0;
   pointer-events: none;
   background:
-    radial-gradient(circle at 20% 42%, rgba(83, 216, 232, 0.12), transparent 22rem),
-    linear-gradient(90deg, rgba(5, 5, 8, 0.96), rgba(5, 5, 8, 0));
+    radial-gradient(circle at 17% 44%, rgba(83, 216, 232, 0.13), transparent 24rem),
+    radial-gradient(circle at 70% 48%, rgba(212, 175, 55, 0.08), transparent 26rem),
+    linear-gradient(90deg, rgba(5, 5, 8, 0.98), rgba(5, 5, 8, 0.45) 44%, rgba(5, 5, 8, 0.78));
 }
 
 .symbols-hero > div {
@@ -52,6 +53,286 @@
   line-height: 1;
 }
 
+.symbol-mark {
+  --mark-color: var(--gold-soft);
+  --mark-soft: rgba(212, 175, 55, 0.2);
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 1.5rem;
+  aspect-ratio: 1;
+  color: var(--mark-color);
+  flex: 0 0 auto;
+}
+
+.symbol-mark::before,
+.symbol-mark::after,
+.symbol-mark > span {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  display: block;
+  box-sizing: border-box;
+  transform: translate(-50%, -50%);
+}
+
+.symbol-orbit__node .symbol-mark {
+  --mark-color: rgba(244, 240, 232, 0.8);
+  --mark-soft: rgba(212, 175, 55, 0.24);
+}
+
+.symbol-orbit__node--active .symbol-mark,
+.symbol-panel--active .symbol-mark {
+  --mark-color: var(--gold-soft);
+  --mark-soft: rgba(212, 175, 55, 0.36);
+}
+
+.symbol-mark--core {
+  width: 2.35rem;
+}
+
+.symbol-mark--specimen {
+  width: clamp(3.4rem, 7vw, 4.9rem);
+}
+
+.symbol-mark--detail {
+  width: 2.6rem;
+}
+
+.symbol-panel__glyph {
+  width: 2.05rem;
+}
+
+.symbol-panel__glyph.symbol-mark {
+  height: auto;
+  border: 0;
+  border-radius: 0;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.symbol-mark--fish::before,
+.symbol-mark--fish::after {
+  width: 72%;
+  height: 32%;
+  border: 1px solid currentColor;
+  border-radius: 70% 10% 70% 10%;
+  box-shadow: 0 0 1rem var(--mark-soft);
+}
+
+.symbol-mark--fish::before {
+  transform: translate(-56%, -58%) rotate(-20deg);
+}
+
+.symbol-mark--fish::after {
+  transform: translate(-38%, -28%) rotate(160deg);
+}
+
+.symbol-mark--fish > span {
+  width: 12%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0.82rem 0.42rem 0 currentColor;
+}
+
+.symbol-mark--mandala::before {
+  width: 86%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 0 0.32rem rgba(212, 175, 55, 0.05),
+    0 0 1.1rem var(--mark-soft);
+}
+
+.symbol-mark--mandala::after {
+  width: 62%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.symbol-mark--mandala > span,
+.symbol-mark--zodiac > span {
+  width: 100%;
+  height: 1px;
+  background: currentColor;
+  box-shadow: 0 0 0.8rem var(--mark-soft);
+}
+
+.symbol-mark--mandala > span::after,
+.symbol-mark--zodiac > span::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 1px;
+  height: 100%;
+  background: currentColor;
+  transform: translate(-50%, -50%);
+}
+
+.symbol-mark--dragon::before {
+  width: 78%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  transform: translate(-50%, -50%) rotate(-28deg);
+  box-shadow: 0 0 1rem var(--mark-soft);
+}
+
+.symbol-mark--dragon::after {
+  width: 30%;
+  height: 22%;
+  border-top: 1px solid currentColor;
+  border-right: 1px solid currentColor;
+  transform: translate(6%, -77%) rotate(28deg);
+}
+
+.symbol-mark--dragon > span {
+  width: 14%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: currentColor;
+  transform: translate(128%, -114%);
+}
+
+.symbol-mark--sophia::before {
+  width: 72%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  transform: translate(-50%, -50%) rotate(45deg);
+  box-shadow: 0 0 1rem var(--mark-soft);
+}
+
+.symbol-mark--sophia::after {
+  width: 34%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  transform: translate(-50%, -96%);
+}
+
+.symbol-mark--sophia > span {
+  width: 1px;
+  height: 78%;
+  background: currentColor;
+}
+
+.symbol-mark--sword::before {
+  width: 10%;
+  height: 86%;
+  border-radius: 999px 999px 0 0;
+  background: currentColor;
+  box-shadow: 0 0 1rem var(--mark-soft);
+}
+
+.symbol-mark--sword::after {
+  width: 76%;
+  height: 1px;
+  background: currentColor;
+  transform: translate(-50%, -12%) rotate(-8deg);
+}
+
+.symbol-mark--sword > span {
+  width: 28%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  transform: translate(-50%, 78%);
+}
+
+.symbol-mark--lapis::before {
+  width: 82%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  clip-path: polygon(50% 0, 90% 22%, 90% 74%, 50% 100%, 10% 74%, 10% 22%);
+  background: linear-gradient(145deg, var(--mark-soft), transparent 68%);
+  box-shadow: 0 0 1rem var(--mark-soft);
+}
+
+.symbol-mark--lapis::after {
+  width: 44%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.symbol-mark--lapis > span {
+  width: 16%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.symbol-mark--cross::before {
+  width: 1px;
+  height: 86%;
+  background: currentColor;
+  box-shadow: 0 0 1rem var(--mark-soft);
+}
+
+.symbol-mark--cross::after {
+  width: 76%;
+  height: 1px;
+  background: currentColor;
+}
+
+.symbol-mark--cross > span {
+  width: 68%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  opacity: 0.5;
+}
+
+.symbol-mark--ouroboros::before {
+  width: 82%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  transform: translate(-50%, -50%) rotate(26deg);
+  box-shadow: 0 0 1rem var(--mark-soft);
+}
+
+.symbol-mark--ouroboros::after {
+  width: 24%;
+  height: 16%;
+  border-top: 1px solid currentColor;
+  border-right: 1px solid currentColor;
+  transform: translate(80%, -60%) rotate(38deg);
+}
+
+.symbol-mark--ouroboros > span {
+  width: 12%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: currentColor;
+  transform: translate(142%, -38%);
+}
+
+.symbol-mark--zodiac::before {
+  width: 86%;
+  aspect-ratio: 1;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 0 0.32rem rgba(83, 216, 232, 0.04),
+    0 0 1.1rem var(--mark-soft);
+}
+
+.symbol-mark--zodiac::after {
+  width: 58%;
+  aspect-ratio: 1;
+  border: 1px dotted currentColor;
+  border-radius: 50%;
+}
+
 .symbol-orbit--interactive {
   isolation: isolate;
 }
@@ -70,15 +351,17 @@
 
 .symbol-orbit__center {
   gap: 0.1rem;
+  align-content: center;
 }
 
-.symbol-orbit__center span {
+.symbol-orbit__center em {
   display: block;
   color: var(--cyan);
   font-family: var(--font-ui);
-  font-size: 0.72rem;
+  font-size: 0.58rem;
+  font-style: normal;
   font-weight: 900;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
@@ -127,6 +410,8 @@
 
 .symbol-field,
 .symbol-detail {
+  --symbol-tone: rgba(212, 175, 55, 0.82);
+  --symbol-soft: rgba(212, 175, 55, 0.16);
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background:
@@ -136,25 +421,26 @@
 }
 
 .symbol-field {
-  --symbol-tone: rgba(212, 175, 55, 0.82);
-  --symbol-soft: rgba(212, 175, 55, 0.16);
   position: relative;
   min-height: clamp(28rem, 58vw, 39rem);
   overflow: hidden;
   isolation: isolate;
 }
 
-.symbol-field[data-tone='cyan'] {
+.symbol-field[data-tone='cyan'],
+.symbol-detail[data-tone='cyan'] {
   --symbol-tone: rgba(83, 216, 232, 0.86);
   --symbol-soft: rgba(83, 216, 232, 0.16);
 }
 
-.symbol-field[data-tone='rose'] {
+.symbol-field[data-tone='rose'],
+.symbol-detail[data-tone='rose'] {
   --symbol-tone: rgba(218, 112, 139, 0.82);
   --symbol-soft: rgba(218, 112, 139, 0.16);
 }
 
-.symbol-field[data-tone='green'] {
+.symbol-field[data-tone='green'],
+.symbol-detail[data-tone='green'] {
   --symbol-tone: rgba(136, 214, 167, 0.82);
   --symbol-soft: rgba(136, 214, 167, 0.16);
 }
@@ -165,6 +451,7 @@
 .symbol-field__axis,
 .symbol-field__glyph,
 .symbol-field__index,
+.symbol-field__thread,
 .symbol-field__concept,
 .symbol-field__chapter {
   position: absolute;
@@ -235,9 +522,11 @@
 .symbol-field__glyph {
   left: 50%;
   top: 50%;
-  width: clamp(5.8rem, 13vw, 8.25rem);
+  width: clamp(7rem, 15vw, 10rem);
   aspect-ratio: 1;
   display: grid;
+  align-content: center;
+  gap: 0.25rem;
   place-items: center;
   border: 1px solid color-mix(in srgb, var(--symbol-tone) 58%, transparent);
   border-radius: 50%;
@@ -254,6 +543,27 @@
   transform: translate(-50%, -50%);
 }
 
+.symbol-field__glyph strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: clamp(1.05rem, 2vw, 1.45rem);
+  font-weight: 400;
+  line-height: 1;
+}
+
+.symbol-field__glyph em {
+  max-width: 7.4rem;
+  color: rgba(244, 240, 232, 0.56);
+  font-family: var(--font-ui);
+  font-size: 0.52rem;
+  font-style: normal;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  line-height: 1.15;
+  text-align: center;
+  text-transform: uppercase;
+}
+
 .symbol-field__index {
   left: 1.1rem;
   top: 1rem;
@@ -262,6 +572,31 @@
   font-size: 0.7rem;
   font-weight: 900;
   letter-spacing: 0.18em;
+}
+
+.symbol-field__thread {
+  --angle: calc((360deg / var(--node-count)) * var(--node-index));
+  left: 50%;
+  top: 50%;
+  width: min(18vw, 10.6rem);
+  height: 1px;
+  background: linear-gradient(90deg, color-mix(in srgb, var(--symbol-tone) 62%, transparent), transparent);
+  opacity: 0.54;
+  transform: rotate(calc(var(--angle) + 17deg));
+  transform-origin: left center;
+}
+
+.symbol-field__thread::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: 50%;
+  width: 0.32rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--symbol-tone);
+  box-shadow: 0 0 1rem var(--symbol-soft);
+  transform: translate(50%, -50%);
 }
 
 .symbol-field__concept,
@@ -318,6 +653,41 @@
 .symbol-detail p:not(.eyebrow) {
   color: var(--muted);
   line-height: 1.55;
+}
+
+.symbol-detail__specimen {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.72rem;
+  align-items: center;
+  border: 1px solid rgba(212, 175, 55, 0.16);
+  border-radius: 0.9rem;
+  background:
+    radial-gradient(circle at 14% 48%, var(--symbol-soft), transparent 5.4rem),
+    rgba(3, 3, 7, 0.36);
+  padding: 0.72rem;
+}
+
+.symbol-detail__specimen strong,
+.symbol-detail__specimen > div > span {
+  display: block;
+}
+
+.symbol-detail__specimen strong {
+  color: var(--gold-soft);
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.symbol-detail__specimen > div > span {
+  margin-top: 0.18rem;
+  color: rgba(244, 240, 232, 0.62);
+  font-family: var(--font-serif);
+  font-size: 0.9rem;
+  line-height: 1.35;
 }
 
 .symbol-detail__thread-group,
@@ -432,6 +802,19 @@
     min-height: 23.5rem;
   }
 
+  .symbol-field__glyph {
+    width: clamp(6.2rem, 34vw, 8rem);
+  }
+
+  .symbol-field__glyph em {
+    max-width: 6rem;
+    font-size: 0.46rem;
+  }
+
+  .symbol-field__thread {
+    width: min(29vw, 7.2rem);
+  }
+
   .symbol-field__concept {
     max-width: 6.6rem;
     min-height: 1.95rem;
@@ -453,11 +836,38 @@
 
 @media (max-width: 420px) {
   .symbols-hero__metrics {
+    display: grid;
+    grid-template-columns: 1fr;
+    max-width: 10rem;
+  }
+
+  .symbols-hero__metrics span:not(:first-child) {
     display: none;
+  }
+
+  .symbols-hero__metrics strong {
+    font-size: 1.45rem;
   }
 
   .symbol-field {
     min-height: 22rem;
+  }
+
+  .symbol-field__glyph {
+    width: 6rem;
+  }
+
+  .symbol-field__glyph strong {
+    font-size: 1rem;
+  }
+
+  .symbol-field__glyph em {
+    display: none;
+  }
+
+  .symbol-field__thread {
+    width: min(21vw, 4.75rem);
+    opacity: 0.42;
   }
 
   .symbol-field__concept {
@@ -477,6 +887,22 @@
 
   .symbol-detail__chapter-links a {
     width: 100%;
+  }
+}
+
+@media (max-width: 360px) {
+  .symbols-hero__metrics {
+    display: none;
+  }
+
+  .symbols-hero .lede {
+    max-width: 18rem;
+    font-size: 0.98rem;
+    line-height: 1.48;
+  }
+
+  .symbol-orbit--interactive {
+    margin-top: -0.75rem;
   }
 }
 

--- a/src/app/pages/SymbolsPage.tsx
+++ b/src/app/pages/SymbolsPage.tsx
@@ -5,17 +5,61 @@ import { getChapters, getChapterRoute, getConcepts, getSymbols } from '../data/a
 
 import './SymbolsPage.css';
 
-const glyphs: Record<string, string> = {
-  fish: 'F',
-  mandala: 'M',
-  dragon: 'D',
-  sophia: 'S',
-  sword: 'L',
-  lapis: 'P',
-  cross: 'C',
-  ouroboros: 'O',
-  zodiac: 'Z',
+const symbolProfiles: Record<string, { axis: string; polarity: string; movement: string }> = {
+  fish: {
+    axis: 'Aeon / shadow',
+    polarity: 'paired carriers',
+    movement: 'Opposition held in one image',
+  },
+  mandala: {
+    axis: 'Self / quaternity',
+    polarity: 'fourfold center',
+    movement: 'Totality ordered around a center',
+  },
+  dragon: {
+    axis: 'Shadow / adversary',
+    polarity: 'threatening double',
+    movement: 'Rejected force made visible',
+  },
+  sophia: {
+    axis: 'Anima / wisdom',
+    polarity: 'mediating figure',
+    movement: 'Relation opens toward the unconscious',
+  },
+  sword: {
+    axis: 'Animus / logos',
+    polarity: 'dividing blade',
+    movement: 'Judgment separates and clarifies',
+  },
+  lapis: {
+    axis: 'Alchemy / stone',
+    polarity: 'fixed result',
+    movement: 'Transformation becomes stable form',
+  },
+  cross: {
+    axis: 'Christ / Self',
+    polarity: 'vertical and horizontal',
+    movement: 'A totality organized by tension',
+  },
+  ouroboros: {
+    axis: 'Return / opus',
+    polarity: 'self-consuming circle',
+    movement: 'The end returns to the beginning',
+  },
+  zodiac: {
+    axis: 'Aeon / time',
+    polarity: 'cosmic wheel',
+    movement: 'History read as symbolic rhythm',
+  },
 };
+
+function SymbolMark({ symbolId, className = '' }: { symbolId: string; className?: string }) {
+  return (
+    <span className={`symbol-mark symbol-mark--${symbolId} ${className}`.trim()} aria-hidden="true">
+      <span />
+    </span>
+  );
+}
 
 const toneBySymbol: Record<string, string> = {
   fish: 'cyan',
@@ -44,10 +88,15 @@ export default function SymbolsPage() {
     () => chapters.filter((chapter) => chapter.keyConceptIds.some((conceptId) => activeSymbol.conceptIds.includes(conceptId))),
     [activeSymbol.conceptIds, chapters],
   );
+  const activeProfile = symbolProfiles[activeSymbol.id] || {
+    axis: activeSymbol.historicPeriod,
+    polarity: activeSymbol.motif,
+    movement: 'Trace this image across the atlas',
+  };
   const symbolFieldLabel = `${activeSymbol.label} symbol field: ${activeSymbol.motif}. Linked concepts: ${activeConcepts.map((concept) => concept.label).join(', ') || 'none'}. Related chapters: ${relatedChapters.map((chapter) => `Chapter ${chapter.order}, ${chapter.title}`).join('; ') || 'none'}.`;
 
   return (
-    <div className="page">
+    <div className="page symbols-page">
       <section className="page-header page-header--visual symbols-hero section-band">
         <div>
           <p className="eyebrow">Symbols</p>
@@ -61,8 +110,9 @@ export default function SymbolsPage() {
         </div>
         <div className="symbol-orbit symbol-orbit--interactive" aria-label="Symbol orbit">
           <div id="symbol-selected-orbit-detail" className="symbol-orbit__center" aria-live="polite">
-            <span>{glyphs[activeSymbol.id] || activeSymbol.label[0]}</span>
+            <SymbolMark symbolId={activeSymbol.id} className="symbol-mark--core" />
             <strong>{activeSymbol.label}</strong>
+            <em>{activeProfile.axis}</em>
           </div>
           {symbols.slice(0, 9).map((symbol, index) => (
             <button
@@ -75,7 +125,7 @@ export default function SymbolsPage() {
               aria-label={`Select ${symbol.label}: ${symbol.motif}`}
               aria-pressed={symbol.id === activeSymbol.id}
             >
-              {glyphs[symbol.id] || symbol.label[0]}
+              <SymbolMark symbolId={symbol.id} />
             </button>
           ))}
         </div>
@@ -98,8 +148,20 @@ export default function SymbolsPage() {
             <span className="symbol-field__ring symbol-field__ring--inner" aria-hidden="true" />
             <span className="symbol-field__axis symbol-field__axis--horizontal" aria-hidden="true" />
             <span className="symbol-field__axis symbol-field__axis--vertical" aria-hidden="true" />
-            <span className="symbol-field__glyph" aria-hidden="true">{glyphs[activeSymbol.id] || activeSymbol.label[0]}</span>
+            <span className="symbol-field__glyph symbol-field__specimen" aria-hidden="true">
+              <SymbolMark symbolId={activeSymbol.id} className="symbol-mark--specimen" />
+              <strong>{activeSymbol.label}</strong>
+              <em>{activeProfile.polarity}</em>
+            </span>
             <span className="symbol-field__index" aria-hidden="true">{String(activeSymbolIndex + 1).padStart(2, '0')}</span>
+            {relatedChapters.slice(0, 7).map((chapter, index) => (
+              <span
+                key={`${chapter.id}-thread`}
+                className="symbol-field__thread"
+                style={{ ['--node-index' as string]: index, ['--node-count' as string]: Math.min(relatedChapters.length, 7) }}
+                aria-hidden="true"
+              />
+            ))}
             {activeConcepts.slice(0, 6).map((concept, index) => (
               <span
                 key={concept.id}
@@ -122,10 +184,23 @@ export default function SymbolsPage() {
             ))}
           </div>
 
-          <aside id="symbol-selected-detail" className="symbol-detail" aria-live="polite">
+          <aside
+            id="symbol-selected-detail"
+            className="symbol-detail"
+            data-tone={toneBySymbol[activeSymbol.id] || 'gold'}
+            aria-live="polite"
+            aria-atomic="true"
+          >
             <p className="eyebrow">{activeSymbol.historicPeriod}</p>
             <h2>{activeSymbol.label}</h2>
             <p>{activeSymbol.motif}</p>
+            <div className="symbol-detail__specimen">
+              <SymbolMark symbolId={activeSymbol.id} className="symbol-mark--detail" />
+              <div>
+                <strong>{activeProfile.axis}</strong>
+                <span>{activeProfile.movement}</span>
+              </div>
+            </div>
             <div className="symbol-detail__thread-group" aria-label="Linked concepts">
               {activeConcepts.map((concept) => (
                 <span key={concept.id}>{concept.label}</span>
@@ -156,7 +231,7 @@ export default function SymbolsPage() {
                 aria-label={`Focus ${symbol.label} in the symbol field`}
                 aria-pressed={isActive}
               >
-                <span className="symbol-panel__glyph" aria-hidden="true">{glyphs[symbol.id] || symbol.label[0]}</span>
+                <SymbolMark symbolId={symbol.id} className="symbol-panel__glyph" />
                 <span>{isActive ? 'In field' : 'Focus'}</span>
               </button>
               <p className="eyebrow">{symbol.historicPeriod}</p>


### PR DESCRIPTION
## Summary

- Replaces initial-letter Symbols orbit nodes with CSS-drawn symbolic marks across the hero, active field, detail specimen, and symbol grid.
- Adds an active symbol specimen, tone-aware detail gloss, and chapter trace lines so the route reads more like an illuminated symbolic concordance than a catalog.
- Strengthens app shell, accessibility, and GitHub Pages artifact smoke coverage for the Symbols route.

## Skill stack

orchestration-autopilot, Aion skill-routing playbook, high-end visual review lane, accessibility/test verifier lanes, Browser/Playwright, github:yeet

## Routes changed

- `/symbols`

## Visual thesis

Symbols should behave like navigational images: each mark carries concepts through chapters, with sparse text and a richer visual teaching surface.

## Browser evidence

- Control Tower: 20 routes inspected across desktop, mobile, and narrow viewports.
- `/symbols`: 100% desktop score, 0 technical blockers, 0px mobile/narrow overflow.
- Screenshots regenerated in `test-results/control-tower/latest/screenshots/`.

## Checks

- `node --check scripts/testing/app-shell-smoke.mjs && node --check scripts/testing/app-accessibility-smoke.mjs && node --check scripts/testing/pages-artifact-smoke.mjs`
- `git diff --check && rg -n "^(<<<<<<<|=======|>>>>>>>)" .`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages && npm run test:pages:artifact`
- `npm run test:visual:control-tower`

## Residual debt

- The new `symbolProfiles` presentation metadata should move into canonical symbol data if reused beyond this page.
- The smoke checks intentionally assert a small visual contract for CSS-drawn marks; future refactors may want a more semantic symbol-renderer contract.
