### PR TITLE
[codex] Refine timeline aeon field

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -442,23 +442,37 @@ async function checkTimelineDynamicAccessibility(page, failures) {
   const search = page.getByLabel('Search');
   const category = page.getByLabel('Category');
   const timelineField = page.getByRole('group', { name: /Timeline field:/ });
+  const quickFilters = page.getByRole('group', { name: 'Timeline filter chips' });
+  const detailLens = page.getByRole('group', { name: 'Selected event interpretive lens' });
   const orbitLabel = await page.locator('.timeline-orbit').getAttribute('aria-label');
   const initialFieldLabel = await timelineField.getAttribute('aria-label');
   const searchVisible = await search.isVisible();
   const categoryVisible = await category.isVisible();
   const fieldVisible = await timelineField.isVisible();
+  const quickFiltersVisible = await quickFilters.isVisible();
+  const detailLensVisible = await detailLens.isVisible();
   const initialActiveRailCount = await page.locator('.timeline-rail__item[aria-pressed="true"]').count();
   const initialActiveFieldCount = await page.locator('.timeline-field__node[aria-pressed="true"]').count();
+  const initialChipCount = await page.locator('.timeline-controls__chip').count();
+  const initialPressedChipCount = await page.locator('.timeline-controls__chip[aria-pressed="true"]').count();
+  const initialPhaseCount = await page.locator('.timeline-field__phase').count();
+  const initialLensText = await page.locator('.timeline-detail__lens').textContent();
   const firstOrbitControls = await page.locator('.timeline-orbit__node').first().getAttribute('aria-controls');
   const firstFieldControls = await page.locator('.timeline-field__node').first().getAttribute('aria-controls');
 
   if (!searchVisible) failures.push('/timeline: search input is not visible by label');
   if (!categoryVisible) failures.push('/timeline: category select is not visible by label');
   if (!fieldVisible) failures.push('/timeline: timeline field group is missing an accessible name');
+  if (!quickFiltersVisible) failures.push('/timeline: quick filter group is missing an accessible name');
+  if (!detailLensVisible) failures.push('/timeline: interpretive lens group is missing an accessible name');
   if (!orbitLabel?.includes('12 events in view')) failures.push(`/timeline: initial orbit label mismatch: ${orbitLabel}`);
   if (!initialFieldLabel?.includes('22 of 22 events visible')) failures.push(`/timeline: initial field label mismatch: ${initialFieldLabel}`);
   if (initialActiveRailCount !== 1) failures.push(`/timeline: initial active rail count mismatch: ${initialActiveRailCount}`);
   if (initialActiveFieldCount !== 1) failures.push(`/timeline: initial active field count mismatch: ${initialActiveFieldCount}`);
+  if (initialChipCount !== 5) failures.push(`/timeline: category chip count mismatch: ${initialChipCount}`);
+  if (initialPressedChipCount !== 1) failures.push(`/timeline: pressed category chip count mismatch: ${initialPressedChipCount}`);
+  if (initialPhaseCount !== 4) failures.push(`/timeline: phase count mismatch: ${initialPhaseCount}`);
+  if (!initialLensText?.includes('1875') || !initialLensText?.includes('Clinical roots')) failures.push(`/timeline: initial lens mismatch: ${initialLensText}`);
   if (!firstOrbitControls?.includes('timeline-selected-detail') || !firstOrbitControls?.includes('timeline-field')) failures.push(`/timeline: orbit controls mismatch: ${firstOrbitControls}`);
   if (!firstFieldControls?.includes('timeline-selected-detail') || !firstFieldControls?.includes('timeline-selected-orbit-detail')) failures.push(`/timeline: field controls mismatch: ${firstFieldControls}`);
 
@@ -470,9 +484,11 @@ async function checkTimelineDynamicAccessibility(page, failures) {
   const freudPressed = await freudRail.getAttribute('aria-pressed');
   const freudDetail = await page.locator('#timeline-selected-detail h2').textContent();
   const freudOrbit = await page.locator('#timeline-selected-orbit-detail').textContent();
+  const freudLens = await page.locator('.timeline-detail__lens').textContent();
   if (freudPressed !== 'true') failures.push(`/timeline: Freud rail did not become pressed: ${freudPressed}`);
   if (!freudDetail?.includes('First meeting with Sigmund Freud')) failures.push(`/timeline: Freud detail mismatch: ${freudDetail}`);
   if (!freudOrbit?.includes('1907') || !freudOrbit?.includes('First meeting with Sigmund Freud')) failures.push(`/timeline: Freud orbit mismatch: ${freudOrbit}`);
+  if (!freudLens?.includes('Encounters') || !freudLens?.includes('Rupture / descent')) failures.push(`/timeline: Freud lens mismatch: ${freudLens}`);
 
   await search.fill('not-a-real-term');
   await page.waitForTimeout(100);

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -491,20 +491,37 @@ async function smokeTimelineVisualField(page, failures) {
   const railItems = page.locator('.timeline-rail__item');
   const fieldNodes = page.locator('.timeline-field__node');
   const timelineField = page.getByRole('group', { name: /Timeline field:/ });
+  const categoryChips = page.locator('.timeline-controls__chip');
+  const phaseBands = page.locator('.timeline-field__phase');
+  const activePhaseBand = page.locator('.timeline-field__phase--active');
+  const selectedBeam = page.locator('.timeline-field__selected-beam');
+  const detailLens = page.locator('.timeline-detail__lens');
   const initialDetail = await page.locator('#timeline-selected-detail h2').textContent();
   const initialOrbitLabel = await page.locator('.timeline-orbit').getAttribute('aria-label');
   const initialFieldLabel = await timelineField.getAttribute('aria-label');
   const initialActiveRailCount = await page.locator('.timeline-rail__item[aria-pressed="true"]').count();
   const initialActiveFieldCount = await page.locator('.timeline-field__node[aria-pressed="true"]').count();
+  const initialActiveChipText = await page.locator('.timeline-controls__chip--active').textContent();
+  const initialActivePhaseText = await activePhaseBand.textContent();
+  const initialLensText = await detailLens.textContent();
+  const selectedBeamVisible = await selectedBeam.isVisible();
 
   if (await orbitButtons.count() !== 12) failures.push(`timeline initial orbit button count mismatch: ${await orbitButtons.count()}`);
   if (await railItems.count() !== 22) failures.push(`timeline initial rail count mismatch: ${await railItems.count()}`);
   if (await fieldNodes.count() !== 22) failures.push(`timeline initial field node count mismatch: ${await fieldNodes.count()}`);
+  if (await categoryChips.count() !== 5) failures.push(`timeline category chip count mismatch: ${await categoryChips.count()}`);
+  if (await phaseBands.count() !== 4) failures.push(`timeline phase band count mismatch: ${await phaseBands.count()}`);
   if (!initialDetail?.includes('Born in Kesswil')) failures.push(`timeline initial detail mismatch: ${initialDetail}`);
   if (!initialOrbitLabel?.includes('12 events in view')) failures.push(`timeline initial orbit label mismatch: ${initialOrbitLabel}`);
   if (!initialFieldLabel?.includes('22 of 22 events visible')) failures.push(`timeline initial field label mismatch: ${initialFieldLabel}`);
   if (initialActiveRailCount !== 1) failures.push(`timeline initial active rail count mismatch: ${initialActiveRailCount}`);
   if (initialActiveFieldCount !== 1) failures.push(`timeline initial active field count mismatch: ${initialActiveFieldCount}`);
+  if (!initialActiveChipText?.includes('All')) failures.push(`timeline initial active chip mismatch: ${initialActiveChipText}`);
+  if (!initialActivePhaseText?.includes('Clinical roots')) failures.push(`timeline initial active phase mismatch: ${initialActivePhaseText}`);
+  if (!selectedBeamVisible) failures.push('timeline selected beam is not visible');
+  if (!initialLensText?.includes('1875') || !initialLensText?.includes('Personal') || !initialLensText?.includes('Clinical roots')) {
+    failures.push(`timeline initial lens mismatch: ${initialLensText}`);
+  }
 
   const freudRail = page.getByRole('button', { name: /1907 · Encounters First meeting with Sigmund Freud/ });
   await freudRail.click();
@@ -512,9 +529,11 @@ async function smokeTimelineVisualField(page, failures) {
   const freudPressed = await freudRail.getAttribute('aria-pressed');
   const freudDetail = await page.locator('#timeline-selected-detail h2').textContent();
   const freudOrbitCore = await page.locator('#timeline-selected-orbit-detail').textContent();
+  const freudLens = await detailLens.textContent();
   if (freudPressed !== 'true') failures.push(`timeline Freud rail did not become active: ${freudPressed}`);
   if (!freudDetail?.includes('First meeting with Sigmund Freud')) failures.push(`timeline Freud detail mismatch: ${freudDetail}`);
   if (!freudOrbitCore?.includes('1907') || !freudOrbitCore?.includes('First meeting with Sigmund Freud')) failures.push(`timeline Freud orbit core mismatch: ${freudOrbitCore}`);
+  if (!freudLens?.includes('Encounters') || !freudLens?.includes('Rupture / descent')) failures.push(`timeline Freud lens mismatch: ${freudLens}`);
 
   await search.fill('Aion');
   await page.waitForTimeout(100);
@@ -524,12 +543,16 @@ async function smokeTimelineVisualField(page, failures) {
   const aionDetail = await page.locator('#timeline-selected-detail h2').textContent();
   const aionResult = await page.locator('.timeline-controls__result').textContent();
   const aionFieldLabel = await timelineField.getAttribute('aria-label');
+  const aionActivePhase = await activePhaseBand.textContent();
+  const aionLens = await detailLens.textContent();
   if (aionRailCount !== 1) failures.push(`timeline Aion rail count mismatch: ${aionRailCount}`);
   if (aionOrbitCount !== 1) failures.push(`timeline Aion orbit count mismatch: ${aionOrbitCount}`);
   if (aionFieldCount !== 1) failures.push(`timeline Aion field count mismatch: ${aionFieldCount}`);
   if (!aionDetail?.includes('Publishes "Aion"')) failures.push(`timeline Aion detail mismatch: ${aionDetail}`);
   if (!aionResult?.includes('1 of 22 events visible')) failures.push(`timeline Aion result mismatch: ${aionResult}`);
   if (!aionFieldLabel?.includes('1 of 22 events visible')) failures.push(`timeline Aion field label mismatch: ${aionFieldLabel}`);
+  if (!aionActivePhase?.includes('Alchemy / Aion')) failures.push(`timeline Aion phase mismatch: ${aionActivePhase}`);
+  if (!aionLens?.includes('Publications') || !aionLens?.includes('Alchemy / Aion')) failures.push(`timeline Aion lens mismatch: ${aionLens}`);
 
   await search.fill('');
   await category.selectOption('concepts');
@@ -539,11 +562,25 @@ async function smokeTimelineVisualField(page, failures) {
   const conceptsFieldCount = await fieldNodes.count();
   const conceptsDetail = await page.locator('#timeline-selected-detail h2').textContent();
   const conceptsActiveRailCount = await page.locator('.timeline-rail__item[aria-pressed="true"]').count();
+  const conceptsActiveChipText = await page.locator('.timeline-controls__chip--active').textContent();
   if (conceptsRailCount !== 4) failures.push(`timeline concepts rail count mismatch: ${conceptsRailCount}`);
   if (conceptsOrbitCount !== 4) failures.push(`timeline concepts orbit count mismatch: ${conceptsOrbitCount}`);
   if (conceptsFieldCount !== 4) failures.push(`timeline concepts field count mismatch: ${conceptsFieldCount}`);
   if (!conceptsDetail?.includes('Seven Sermons to the Dead')) failures.push(`timeline concepts detail mismatch: ${conceptsDetail}`);
   if (conceptsActiveRailCount !== 1) failures.push(`timeline concepts active rail count mismatch: ${conceptsActiveRailCount}`);
+  if (!conceptsActiveChipText?.includes('Concepts')) failures.push(`timeline concepts active chip mismatch: ${conceptsActiveChipText}`);
+
+  const encountersChip = page.getByRole('button', { name: 'Encounters' });
+  await encountersChip.click();
+  await page.waitForTimeout(100);
+  const encountersSelectValue = await category.inputValue();
+  const encountersResult = await page.locator('.timeline-controls__result').textContent();
+  const encountersActiveChipText = await page.locator('.timeline-controls__chip--active').textContent();
+  const encountersRailCount = await railItems.count();
+  if (encountersSelectValue !== 'encounters') failures.push(`timeline chip did not update select value: ${encountersSelectValue}`);
+  if (!encountersResult?.includes('4 of 22 events visible')) failures.push(`timeline encounters chip result mismatch: ${encountersResult}`);
+  if (!encountersActiveChipText?.includes('Encounters')) failures.push(`timeline encounters active chip mismatch: ${encountersActiveChipText}`);
+  if (encountersRailCount !== 4) failures.push(`timeline encounters rail count mismatch: ${encountersRailCount}`);
 
   await search.fill('not-a-real-term');
   await page.waitForTimeout(100);
@@ -554,6 +591,7 @@ async function smokeTimelineVisualField(page, failures) {
   const emptyMessageVisible = await page.locator('.timeline-field__empty').isVisible();
   const emptyResult = await page.locator('.timeline-controls__result').textContent();
   const emptyOrbitCore = await page.locator('#timeline-selected-orbit-detail').textContent();
+  const emptyBeamCount = await selectedBeam.count();
   if (emptyRailCount !== 0) failures.push(`timeline empty rail still rendered items: ${emptyRailCount}`);
   if (emptyOrbitCount !== 0) failures.push(`timeline empty orbit still rendered buttons: ${emptyOrbitCount}`);
   if (emptyFieldCount !== 0) failures.push(`timeline empty field still rendered nodes: ${emptyFieldCount}`);
@@ -561,6 +599,7 @@ async function smokeTimelineVisualField(page, failures) {
   if (!emptyMessageVisible) failures.push('timeline empty field message is not visible');
   if (!emptyResult?.includes('0 of 22 events visible')) failures.push(`timeline empty result mismatch: ${emptyResult}`);
   if (!emptyOrbitCore?.includes('No match') || !emptyOrbitCore?.includes('Adjust the field')) failures.push(`timeline empty orbit core mismatch: ${emptyOrbitCore}`);
+  if (emptyBeamCount !== 0) failures.push(`timeline empty state still rendered selected beam: ${emptyBeamCount}`);
 }
 
 async function smokeSymbolsVisualField(page, failures) {

--- a/scripts/testing/pages-artifact-smoke.mjs
+++ b/scripts/testing/pages-artifact-smoke.mjs
@@ -153,13 +153,21 @@ async function checkTimelineArtifact(page, failures) {
   const title = await page.locator('h1').first().textContent();
   const railCount = await page.locator('.timeline-rail__item').count();
   const fieldNodeCount = await page.locator('.timeline-field__node').count();
+  const chipCount = await page.locator('.timeline-controls__chip').count();
+  const phaseCount = await page.locator('.timeline-field__phase').count();
+  const beamVisible = await page.locator('.timeline-field__selected-beam').isVisible();
   const detailVisible = await page.locator('#timeline-selected-detail').isVisible();
+  const lensText = await page.locator('.timeline-detail__lens').textContent();
   const fieldLabel = await page.getByRole('group', { name: /Timeline field:/ }).getAttribute('aria-label');
 
   if (!title?.includes('Jung in symbolic time')) failures.push(`/timeline artifact title mismatch: ${title}`);
   if (railCount !== 22) failures.push(`/timeline artifact rail count mismatch: ${railCount}`);
   if (fieldNodeCount !== 22) failures.push(`/timeline artifact field count mismatch: ${fieldNodeCount}`);
+  if (chipCount !== 5) failures.push(`/timeline artifact chip count mismatch: ${chipCount}`);
+  if (phaseCount !== 4) failures.push(`/timeline artifact phase count mismatch: ${phaseCount}`);
+  if (!beamVisible) failures.push('/timeline artifact selected beam is not visible');
   if (!detailVisible) failures.push('/timeline artifact detail is not visible');
+  if (!lensText?.includes('1875') || !lensText?.includes('Clinical roots')) failures.push(`/timeline artifact lens mismatch: ${lensText}`);
   if (!fieldLabel?.includes('22 of 22 events visible')) failures.push(`/timeline artifact field label mismatch: ${fieldLabel}`);
 }
 

--- a/src/app/pages/TimelinePage.css
+++ b/src/app/pages/TimelinePage.css
@@ -1,5 +1,6 @@
 .timeline-hero {
   position: relative;
+  grid-template-columns: minmax(0, 0.78fr) minmax(26rem, 1.22fr);
 }
 
 .timeline-hero::before {
@@ -55,22 +56,44 @@
 
 .timeline-orbit {
   isolation: isolate;
+  --timeline-tone: rgba(212, 175, 55, 0.72);
+  --timeline-tone-soft: rgba(212, 175, 55, 0.16);
+}
+
+.timeline-orbit[data-selected-tone='cyan'] {
+  --timeline-tone: rgba(83, 216, 232, 0.76);
+  --timeline-tone-soft: rgba(83, 216, 232, 0.15);
+}
+
+.timeline-orbit[data-selected-tone='green'] {
+  --timeline-tone: rgba(136, 214, 167, 0.7);
+  --timeline-tone-soft: rgba(136, 214, 167, 0.14);
+}
+
+.timeline-orbit[data-selected-tone='rose'] {
+  --timeline-tone: rgba(218, 112, 139, 0.74);
+  --timeline-tone-soft: rgba(218, 112, 139, 0.14);
 }
 
 .timeline-orbit::before {
   background:
-    radial-gradient(circle at 50% 50%, rgba(212, 175, 55, 0.08), transparent 48%),
+    radial-gradient(circle at 50% 50%, var(--timeline-tone-soft), transparent 48%),
     rgba(3, 3, 7, 0.2);
 }
 
 .timeline-orbit::after {
+  border-color: color-mix(in srgb, var(--timeline-tone), transparent 62%);
   box-shadow:
     inset 0 0 0 1.6rem rgba(83, 216, 232, 0.018),
-    0 0 4rem rgba(83, 216, 232, 0.045);
+    0 0 4rem var(--timeline-tone-soft);
 }
 
 .timeline-orbit__core {
+  align-content: center;
   gap: 0.18rem;
+  background:
+    radial-gradient(circle at 50% 42%, var(--timeline-tone-soft), transparent 62%),
+    rgba(3, 3, 7, 0.82);
 }
 
 .timeline-orbit__core span {
@@ -88,6 +111,16 @@
   max-width: 8.5rem;
 }
 
+.timeline-orbit__core em {
+  color: var(--timeline-tone);
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-style: normal;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
 .timeline-orbit__node {
   font-family: var(--font-ui);
   font-size: 0.72rem;
@@ -102,14 +135,14 @@
 }
 
 .timeline-orbit__node--active {
-  border-color: var(--gold);
+  border-color: var(--timeline-tone);
   background:
-    radial-gradient(circle at 50% 42%, rgba(212, 175, 55, 0.24), transparent 62%),
+    radial-gradient(circle at 50% 42%, var(--timeline-tone-soft), transparent 62%),
     rgba(3, 3, 7, 0.88);
   color: var(--text);
   box-shadow:
-    0 0 0 0.24rem rgba(212, 175, 55, 0.07),
-    0 0 1.8rem rgba(212, 175, 55, 0.32);
+    0 0 0 0.24rem color-mix(in srgb, var(--timeline-tone), transparent 88%),
+    0 0 1.8rem var(--timeline-tone-soft);
   transform: rotate(var(--angle)) translateX(min(15vw, 13.2rem)) rotate(calc(-1 * var(--angle))) scale(1.12);
 }
 
@@ -166,6 +199,57 @@
   text-transform: uppercase;
 }
 
+.timeline-controls__chips {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.timeline-controls__chip {
+  min-height: 2.35rem;
+  border: 1px solid rgba(244, 240, 232, 0.1);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.5);
+  color: rgba(244, 240, 232, 0.66);
+  cursor: pointer;
+  font: 800 0.64rem/1 var(--font-ui);
+  letter-spacing: 0.12em;
+  text-align: left;
+  text-transform: uppercase;
+  padding: 0.62rem 0.78rem;
+  transition:
+    border-color 0.32s var(--motion-spring),
+    background 0.32s var(--motion-spring),
+    color 0.32s var(--motion-spring),
+    transform 0.32s var(--motion-spring);
+}
+
+.timeline-controls__chip[data-tone='cyan'] {
+  --chip-tone: rgba(83, 216, 232, 0.7);
+}
+
+.timeline-controls__chip[data-tone='green'] {
+  --chip-tone: rgba(136, 214, 167, 0.68);
+}
+
+.timeline-controls__chip[data-tone='rose'] {
+  --chip-tone: rgba(218, 112, 139, 0.68);
+}
+
+.timeline-controls__chip:not([data-tone]),
+.timeline-controls__chip[data-tone='gold'] {
+  --chip-tone: rgba(212, 175, 55, 0.72);
+}
+
+.timeline-controls__chip:hover,
+.timeline-controls__chip:focus-visible,
+.timeline-controls__chip--active {
+  border-color: color-mix(in srgb, var(--chip-tone), white 10%);
+  background: color-mix(in srgb, var(--chip-tone), rgba(3, 3, 7, 0.95) 88%);
+  color: var(--text);
+  transform: translateX(0.12rem);
+}
+
 .timeline-field-stack {
   display: grid;
   gap: 1rem;
@@ -174,6 +258,8 @@
 
 .timeline-field {
   position: relative;
+  --timeline-tone: rgba(212, 175, 55, 0.72);
+  --timeline-tone-soft: rgba(212, 175, 55, 0.13);
   min-height: clamp(28rem, 44vw, 36rem);
   overflow: hidden;
   border: 1px solid var(--line);
@@ -187,6 +273,21 @@
   isolation: isolate;
 }
 
+.timeline-field[data-selected-tone='cyan'] {
+  --timeline-tone: rgba(83, 216, 232, 0.76);
+  --timeline-tone-soft: rgba(83, 216, 232, 0.12);
+}
+
+.timeline-field[data-selected-tone='green'] {
+  --timeline-tone: rgba(136, 214, 167, 0.7);
+  --timeline-tone-soft: rgba(136, 214, 167, 0.12);
+}
+
+.timeline-field[data-selected-tone='rose'] {
+  --timeline-tone: rgba(218, 112, 139, 0.72);
+  --timeline-tone-soft: rgba(218, 112, 139, 0.12);
+}
+
 .timeline-field::before {
   content: '';
   position: absolute;
@@ -198,6 +299,7 @@
 
 .timeline-field__axis {
   position: absolute;
+  z-index: 3;
   left: 1.35rem;
   right: 1.35rem;
   top: 50%;
@@ -214,12 +316,88 @@
   transform: translateY(-50%);
 }
 
+.timeline-field__phase {
+  position: absolute;
+  left: var(--phase-left);
+  top: 1rem;
+  bottom: 1rem;
+  z-index: 0;
+  display: flex;
+  width: var(--phase-width);
+  min-width: 2.6rem;
+  border-left: 1px solid rgba(244, 240, 232, 0.075);
+  background:
+    linear-gradient(180deg, rgba(244, 240, 232, 0.035), transparent 54%),
+    linear-gradient(90deg, rgba(212, 175, 55, 0.05), transparent);
+  color: rgba(244, 240, 232, 0.45);
+  pointer-events: none;
+}
+
+.timeline-field__phase--active {
+  background:
+    linear-gradient(180deg, var(--timeline-tone-soft), transparent 62%),
+    linear-gradient(90deg, color-mix(in srgb, var(--timeline-tone), transparent 86%), transparent);
+}
+
+.timeline-field__phase strong {
+  position: absolute;
+  left: 0.52rem;
+  top: 0.58rem;
+  max-width: 9rem;
+  color: rgba(244, 240, 232, 0.62);
+  font: 900 0.58rem/1.1 var(--font-ui);
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.timeline-field__phase em {
+  position: absolute;
+  left: 0.52rem;
+  bottom: 0.58rem;
+  color: rgba(244, 240, 232, 0.34);
+  font: 800 0.52rem/1 var(--font-ui);
+  font-style: normal;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+
+.timeline-field__phase--active strong,
+.timeline-field__phase--active em {
+  color: var(--timeline-tone);
+}
+
+.timeline-field__selected-beam {
+  position: absolute;
+  left: var(--selected-x);
+  top: 0.85rem;
+  bottom: 0.85rem;
+  z-index: 1;
+  width: 1px;
+  background: linear-gradient(180deg, transparent, var(--timeline-tone), transparent);
+  box-shadow: 0 0 1.2rem var(--timeline-tone-soft);
+  pointer-events: none;
+}
+
+.timeline-field__selected-beam::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 0.62rem;
+  aspect-ratio: 1;
+  border: 1px solid var(--timeline-tone);
+  border-radius: 50%;
+  background: rgba(3, 3, 7, 0.9);
+  transform: translate(-50%, -50%);
+}
+
 .timeline-field__row {
   --row-top: calc(17% + (var(--row-index) * 20%));
   position: absolute;
   left: 1.35rem;
   right: 1.35rem;
   top: var(--row-top);
+  z-index: 2;
   border-top: 1px solid rgba(212, 175, 55, 0.11);
   pointer-events: none;
 }
@@ -266,6 +444,7 @@
   position: absolute;
   left: var(--event-x);
   top: calc(17% + (var(--row-index) * 20%));
+  z-index: 4;
   display: grid;
   place-items: center;
   width: 2.15rem;
@@ -315,6 +494,7 @@
 .timeline-field__empty {
   position: absolute;
   inset: 0;
+  z-index: 4;
   display: grid;
   align-content: center;
   justify-items: center;
@@ -368,11 +548,65 @@
   line-height: 1.6;
 }
 
+.timeline-detail__lens {
+  display: grid;
+  gap: 1px;
+  margin-top: 1rem;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  background: rgba(244, 240, 232, 0.045);
+}
+
+.timeline-detail__lens[data-tone='cyan'] {
+  --lens-tone: rgba(83, 216, 232, 0.76);
+}
+
+.timeline-detail__lens[data-tone='green'] {
+  --lens-tone: rgba(136, 214, 167, 0.7);
+}
+
+.timeline-detail__lens[data-tone='rose'] {
+  --lens-tone: rgba(218, 112, 139, 0.72);
+}
+
+.timeline-detail__lens:not([data-tone]),
+.timeline-detail__lens[data-tone='gold'] {
+  --lens-tone: rgba(212, 175, 55, 0.72);
+}
+
+.timeline-detail__lens span {
+  display: grid;
+  gap: 0.22rem;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--lens-tone), transparent 90%), transparent),
+    rgba(3, 3, 7, 0.64);
+  padding: 0.75rem 0.82rem;
+}
+
+.timeline-detail__lens strong {
+  color: var(--gold-soft);
+  font-family: var(--font-display);
+  font-size: 1.28rem;
+  font-weight: 400;
+  line-height: 1;
+}
+
+.timeline-detail__lens em {
+  color: rgba(244, 240, 232, 0.54);
+  font: 800 0.58rem/1.25 var(--font-ui);
+  font-style: normal;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
 .timeline-detail--empty {
   border-color: rgba(218, 112, 139, 0.2);
 }
 
 @media (max-width: 1120px) {
+  .timeline-hero {
+    grid-template-columns: 1fr;
+  }
+
   .timeline-layout {
     grid-template-columns: 1fr;
   }
@@ -383,6 +617,11 @@
 }
 
 @media (max-width: 860px) {
+  .timeline-hero {
+    gap: 1.25rem;
+    padding-bottom: 2rem;
+  }
+
   .timeline-hero__metrics {
     grid-template-columns: 1fr;
     max-width: 18rem;
@@ -407,6 +646,11 @@
     min-height: 24rem;
   }
 
+  .timeline-field__phase strong {
+    max-width: 6rem;
+    font-size: 0.5rem;
+  }
+
   .timeline-field__row {
     left: 0.95rem;
     right: 0.95rem;
@@ -424,12 +668,51 @@
 }
 
 @media (max-width: 420px) {
+  .timeline-hero {
+    gap: 0.75rem;
+    padding-top: 9.35rem;
+    padding-bottom: 1.45rem;
+  }
+
+  .timeline-hero h1 {
+    max-width: 9.5ch;
+    font-size: clamp(2.45rem, 12.5vw, 3rem);
+    line-height: 0.95;
+  }
+
+  .timeline-hero .lede {
+    max-width: 21rem;
+    margin-top: 0.95rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+
   .timeline-hero__metrics {
     display: none;
   }
 
+  .timeline-controls__chips {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .timeline-controls__chip {
+    min-height: 2.15rem;
+    text-align: center;
+    padding: 0.56rem 0.45rem;
+  }
+
   .timeline-field {
     min-height: 22rem;
+  }
+
+  .timeline-field__phase {
+    top: 0.75rem;
+    bottom: 0.75rem;
+  }
+
+  .timeline-field__phase strong,
+  .timeline-field__phase em {
+    display: none;
   }
 
   .timeline-field__axis {
@@ -468,10 +751,23 @@
   }
 }
 
+@media (max-width: 360px) {
+  .timeline-hero .lede {
+    display: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
+  .timeline-controls__chip,
   .timeline-orbit__node,
   .timeline-field__node,
   .timeline-rail__item {
     transition: none;
+  }
+
+  .timeline-controls__chip:hover,
+  .timeline-controls__chip:focus-visible,
+  .timeline-controls__chip--active {
+    transform: none;
   }
 }

--- a/src/app/pages/TimelinePage.tsx
+++ b/src/app/pages/TimelinePage.tsx
@@ -31,6 +31,60 @@ function categoryTone(categoryId: string) {
   return tones[categoryId] || 'gold';
 }
 
+const CATEGORY_PROFILES: Record<string, { axis: string; force: string; movement: string }> = {
+  personal: {
+    axis: 'life root',
+    force: 'biography',
+    movement: 'experience becomes symbolic material',
+  },
+  publications: {
+    axis: 'text vessel',
+    force: 'publication',
+    movement: 'inner work crystallizes as argument',
+  },
+  encounters: {
+    axis: 'world contact',
+    force: 'encounter',
+    movement: 'outside relation changes the field',
+  },
+  concepts: {
+    axis: 'idea seed',
+    force: 'concept',
+    movement: 'terms gather into a psychic map',
+  },
+};
+
+const TIMELINE_PHASES = [
+  {
+    id: 'roots',
+    label: 'Clinical roots',
+    startYear: 1875,
+    endYear: 1906,
+  },
+  {
+    id: 'rupture',
+    label: 'Rupture / descent',
+    startYear: 1907,
+    endYear: 1919,
+  },
+  {
+    id: 'widening',
+    label: 'Comparative widening',
+    startYear: 1921,
+    endYear: 1938,
+  },
+  {
+    id: 'aeon',
+    label: 'Alchemy / Aion',
+    startYear: 1944,
+    endYear: 1961,
+  },
+];
+
+function phaseForYear(eventYear: number) {
+  return TIMELINE_PHASES.find((phase) => eventYear >= phase.startYear && eventYear <= phase.endYear) || null;
+}
+
 function buildOrbitEvents(events: TimelineEvent[], selectedId: string | null) {
   if (events.length <= 12) return events;
   const selectedIndex = events.findIndex((event) => event.id === selectedId);
@@ -62,6 +116,12 @@ export default function TimelinePage() {
   const selected = filtered.find((event) => event.id === selectedId) || filtered[0] || null;
   const orbitEvents = buildOrbitEvents(filtered, selected?.id || selectedId);
   const resultSummary = `${filtered.length} of ${events.length} events visible`;
+  const selectedYear = selected ? Number(year(selected.date)) : null;
+  const selectedTone = selected ? categoryTone(selected.category) : 'gold';
+  const selectedProfile = selected ? CATEGORY_PROFILES[selected.category] : null;
+  const selectedPhase = selectedYear ? phaseForYear(selectedYear) : null;
+  const selectedPhaseLabel = selectedPhase?.label || 'Transitional interval';
+  const selectedX = selectedYear == null ? 50 : 10 + ((selectedYear - firstYear) / Math.max(lastYear - firstYear, 1)) * 80;
 
   return (
     <div className="page">
@@ -76,12 +136,13 @@ export default function TimelinePage() {
             <span><strong>{lastYear - firstYear}</strong> year field</span>
           </div>
         </div>
-        <div className="timeline-orbit" aria-label={`Timeline orbit, ${orbitEvents.length} events in view`}>
+        <div className="timeline-orbit" data-selected-tone={selectedTone} aria-label={`Timeline orbit, ${orbitEvents.length} events in view`}>
           <div id="timeline-selected-orbit-detail" className="timeline-orbit__core" aria-live="polite">
             {selected ? (
               <>
                 <span>{year(selected.date)}</span>
                 <strong>{selected.title}</strong>
+                <em>{selectedProfile?.axis}</em>
               </>
             ) : (
               <>
@@ -125,18 +186,53 @@ export default function TimelinePage() {
           <output className="timeline-controls__result" htmlFor="timeline-search timeline-category" aria-live="polite">
             {resultSummary}
           </output>
+          <div className="timeline-controls__chips" role="group" aria-label="Timeline filter chips">
+            {categories.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={item.id === category ? 'timeline-controls__chip timeline-controls__chip--active' : 'timeline-controls__chip'}
+                data-tone={categoryTone(item.id)}
+                onClick={() => setCategory(item.id)}
+                aria-pressed={item.id === category}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
         </div>
         <div className="timeline-field-stack">
           <div
             id="timeline-field"
             className={filtered.length > 0 ? 'timeline-field' : 'timeline-field timeline-field--empty'}
+            data-selected-tone={selectedTone}
             role="group"
             aria-label={`Timeline field: ${resultSummary}. Years ${firstYear} to ${lastYear}.`}
+            style={{ ['--selected-x' as string]: `${selectedX}%` }}
           >
             <div className="timeline-field__axis" aria-hidden="true">
               <span>{firstYear}</span>
               <span>{lastYear}</span>
             </div>
+            {TIMELINE_PHASES.map((phase) => {
+              const left = 10 + ((phase.startYear - firstYear) / Math.max(lastYear - firstYear, 1)) * 80;
+              const right = 10 + ((phase.endYear - firstYear) / Math.max(lastYear - firstYear, 1)) * 80;
+              return (
+                <span
+                  key={phase.id}
+                  className={phase.id === selectedPhase?.id ? 'timeline-field__phase timeline-field__phase--active' : 'timeline-field__phase'}
+                  style={{
+                    ['--phase-left' as string]: `${left}%`,
+                    ['--phase-width' as string]: `${Math.max(right - left, 6)}%`,
+                  }}
+                  aria-hidden="true"
+                >
+                  <strong>{phase.label}</strong>
+                  <em>{phase.startYear}-{phase.endYear}</em>
+                </span>
+              );
+            })}
+            {selected ? <span className="timeline-field__selected-beam" aria-hidden="true" /> : null}
             {categoryRows.map((item, index) => (
               <div
                 key={item.id}
@@ -199,6 +295,20 @@ export default function TimelinePage() {
               <p className="eyebrow">{categoryLabels[selected.category] || selected.category}</p>
               <h2>{selected.title}</h2>
               <p>{selected.summary}</p>
+              <div className="timeline-detail__lens" data-tone={selectedTone} role="group" aria-label="Selected event interpretive lens">
+                <span>
+                  <strong>{year(selected.date)}</strong>
+                  <em>year</em>
+                </span>
+                <span>
+                  <strong>{categoryLabels[selected.category] || selected.category}</strong>
+                  <em>{selectedProfile?.force}</em>
+                </span>
+                <span>
+                  <strong>{selectedPhaseLabel}</strong>
+                  <em>{selectedProfile?.movement}</em>
+                </span>
+              </div>
             </>
           ) : (
             <>


### PR DESCRIPTION
## Summary

- Adds phase bands, selected-event beam, tone-aware orbit styling, and an interpretive lens to make `/timeline` read as a visual learning instrument.
- Adds category filter chips with accessible pressed state and direct smoke coverage.
- Tightens narrow-mobile Timeline hero behavior so the orbit enters the first viewport sooner while preserving the serif visual language.
- Extends app shell, accessibility, and Pages artifact smoke checks for the new Timeline phase/chip/lens behavior.

## Verification

- `git diff --check`
- `node --check scripts/testing/app-shell-smoke.mjs && node --check scripts/testing/app-accessibility-smoke.mjs && node --check scripts/testing/pages-artifact-smoke.mjs`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `AION_SMOKE_PORT=4174 node scripts/testing/app-shell-smoke.mjs --shard=foundation`
- `AION_SMOKE_PORT=4175 node scripts/testing/app-shell-smoke.mjs --shard=chapter-routes`
- `AION_SMOKE_PORT=4176 node scripts/testing/app-shell-smoke.mjs --shard=scene-controls`
- `AION_SMOKE_PORT=4177 node scripts/testing/app-shell-smoke.mjs --shard=mobile`
- `AION_A11Y_PORT=4175 node scripts/testing/app-accessibility-smoke.mjs`
- `npm run build:pages && node scripts/testing/pages-artifact-smoke.mjs`
- `AION_VISUAL_QA_PORT=4177 npm run test:visual:control-tower` - 20 routes, desktop/mobile/narrow, 0 blockers; `/timeline` 100%

## Notes

- Direct `stylelint src/app/pages/TimelinePage.css` is not part of current repo CI and reports baseline/config noise for this page family; existing `npm run lint` remains green.