### PR TITLE
[codex] Refine chapter nine ambivalence field

### DIFF
--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -1111,7 +1111,7 @@ async function smokeReducedMotion(browser, failures) {
   const chapterNineCanvasCount = await page.locator('.scene-host canvas').count();
   const chapterNineFallbackText = await page.locator('.scene-host__fallback').textContent();
   const chapterNineInstrumentCount = await page.locator('.ambivalent-fish-instrument').count();
-  const chapterNineInstrumentMotion = await page.locator('.ambivalent-fish-instrument__field, .ambivalent-fish-instrument__mirror, .ambivalent-fish-instrument__ring, .ambivalent-fish-instrument__thread, .ambivalent-fish-instrument__fish, .ambivalent-fish-instrument__junction, .ambivalent-fish-instrument__shadow-core').evaluateAll((nodes) => nodes.map((node) => {
+  const chapterNineInstrumentMotion = await page.locator('.ambivalent-fish-instrument__field, .ambivalent-fish-instrument__axis, .ambivalent-fish-instrument__mirror, .ambivalent-fish-instrument__ring, .ambivalent-fish-instrument__thread, .ambivalent-fish-instrument__fish, .ambivalent-fish-instrument__junction, .ambivalent-fish-instrument__shadow-core, .ambivalent-fish-instrument__charge').evaluateAll((nodes) => nodes.map((node) => {
     const styles = window.getComputedStyle(node);
     return {
       animationName: styles.animationName,
@@ -2455,14 +2455,16 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterNineInstrumentLabel = await chapterNineInstrument.getAttribute('aria-label');
   const chapterNineInstrumentPanel = await chapterNineInstrument.getAttribute('data-active-panel');
   const chapterNineInstrumentFieldCount = await page.locator('.ambivalent-fish-instrument__field').count();
+  const chapterNineInstrumentAxisCount = await page.locator('.ambivalent-fish-instrument__axis').count();
   const chapterNineInstrumentMirrorCount = await page.locator('.ambivalent-fish-instrument__mirror').count();
   const chapterNineInstrumentRingCount = await page.locator('.ambivalent-fish-instrument__ring').count();
   const chapterNineInstrumentFishCount = await page.locator('.ambivalent-fish-instrument__fish').count();
   const chapterNineInstrumentJunctionCount = await page.locator('.ambivalent-fish-instrument__junction').count();
   const chapterNineInstrumentShadowCoreCount = await page.locator('.ambivalent-fish-instrument__shadow-core').count();
+  const chapterNineInstrumentChargeCount = await page.locator('.ambivalent-fish-instrument__charge').count();
   const chapterNineInstrumentLabelCount = await page.locator('.ambivalent-fish-instrument__label').count();
   const chapterNineInitialDescription = await page.locator('#scene-host-description-ch9').textContent();
-  const chapterNineInstrumentMarksVisible = await page.locator('.ambivalent-fish-instrument__field, .ambivalent-fish-instrument__mirror, .ambivalent-fish-instrument__ring, .ambivalent-fish-instrument__thread, .ambivalent-fish-instrument__fish, .ambivalent-fish-instrument__junction, .ambivalent-fish-instrument__shadow-core').evaluateAll((nodes) => nodes.length >= 10 && nodes.every((node) => {
+  const chapterNineInstrumentMarksVisible = await page.locator('.ambivalent-fish-instrument__field, .ambivalent-fish-instrument__axis, .ambivalent-fish-instrument__mirror, .ambivalent-fish-instrument__ring, .ambivalent-fish-instrument__thread, .ambivalent-fish-instrument__fish, .ambivalent-fish-instrument__junction, .ambivalent-fish-instrument__shadow-core, .ambivalent-fish-instrument__charge').evaluateAll((nodes) => nodes.length >= 14 && nodes.every((node) => {
     const styles = window.getComputedStyle(node);
     const box = node.getBoundingClientRect();
     return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
@@ -2477,11 +2479,13 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterNinePanelIds.join(',') !== 'ambivalence,ouroboros,shadow-fish') failures.push(`chapter 9 reference nodes out of order: ${chapterNinePanelIds.join(',')}`);
   if (chapterNineInstrumentCount !== 1) failures.push(`chapter 9 ambivalent fish instrument count mismatch: ${chapterNineInstrumentCount}`);
   if (chapterNineInstrumentFieldCount !== 2) failures.push(`chapter 9 ambivalent fish instrument field count mismatch: ${chapterNineInstrumentFieldCount}`);
+  if (chapterNineInstrumentAxisCount !== 2) failures.push(`chapter 9 ambivalent fish instrument axis count mismatch: ${chapterNineInstrumentAxisCount}`);
   if (chapterNineInstrumentMirrorCount !== 1) failures.push(`chapter 9 ambivalent fish instrument mirror count mismatch: ${chapterNineInstrumentMirrorCount}`);
   if (chapterNineInstrumentRingCount !== 2) failures.push(`chapter 9 ambivalent fish instrument ring count mismatch: ${chapterNineInstrumentRingCount}`);
   if (chapterNineInstrumentFishCount !== 2) failures.push(`chapter 9 ambivalent fish instrument fish count mismatch: ${chapterNineInstrumentFishCount}`);
   if (chapterNineInstrumentJunctionCount !== 1) failures.push(`chapter 9 ambivalent fish instrument junction count mismatch: ${chapterNineInstrumentJunctionCount}`);
   if (chapterNineInstrumentShadowCoreCount !== 1) failures.push(`chapter 9 ambivalent fish instrument shadow core count mismatch: ${chapterNineInstrumentShadowCoreCount}`);
+  if (chapterNineInstrumentChargeCount !== 2) failures.push(`chapter 9 ambivalent fish instrument charge count mismatch: ${chapterNineInstrumentChargeCount}`);
   if (chapterNineInstrumentLabelCount !== 3) failures.push(`chapter 9 ambivalent fish instrument label count mismatch: ${chapterNineInstrumentLabelCount}`);
   if (chapterNineInstrumentRole !== 'img') failures.push(`chapter 9 ambivalent fish instrument role mismatch: ${chapterNineInstrumentRole}`);
   if (!chapterNineInstrumentLabel?.includes('Ambivalent fish model') || !chapterNineInstrumentLabel?.includes('blessing and threat') || !chapterNineInstrumentLabel?.includes('Current emphasis: Paradox')) {
@@ -3442,6 +3446,25 @@ async function smokeMobile(page, failures) {
     const chapterNineScrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
     const chapterNineReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
     const chapterNineInstrumentBox = await page.locator('.ambivalent-fish-instrument').boundingBox();
+    const chapterNineAxisCount = await page.locator('.ambivalent-fish-instrument__axis').count();
+    const chapterNineChargeCount = await page.locator('.ambivalent-fish-instrument__charge').count();
+    const chapterNineChargeLayout = await page.locator('.ambivalent-fish-instrument__charge').evaluateAll((nodes) => {
+      const instrument = document.querySelector('.ambivalent-fish-instrument');
+      const instrumentBox = instrument?.getBoundingClientRect();
+      return nodes.map((node) => {
+        const box = node.getBoundingClientRect();
+        return {
+          text: node.textContent?.trim() || '',
+          inside: Boolean(instrumentBox)
+            && box.left >= instrumentBox.left - 1
+            && box.right <= instrumentBox.right + 1
+            && box.top >= instrumentBox.top - 1
+            && box.bottom <= instrumentBox.bottom + 1,
+          width: box.width,
+          height: box.height,
+        };
+      });
+    });
     if (!chapterNineNavBox || !chapterNineHeadingBox) {
       failures.push(`mobile chapter 9 geometry missing at ${viewport.width}x${viewport.height}`);
       continue;
@@ -3460,6 +3483,13 @@ async function smokeMobile(page, failures) {
     if (!chapterNineInstrumentBox) failures.push(`mobile chapter 9 ambivalent fish instrument missing at ${viewport.width}x${viewport.height}`);
     if (chapterNineInstrumentBox && chapterNineInstrumentBox.width > viewport.width + 2) {
       failures.push(`mobile chapter 9 ambivalent fish instrument exceeds viewport at ${viewport.width}x${viewport.height}: ${Math.round(chapterNineInstrumentBox.width)}`);
+    }
+    if (chapterNineAxisCount !== 2) failures.push(`mobile chapter 9 ambivalent fish axis count mismatch at ${viewport.width}x${viewport.height}: ${chapterNineAxisCount}`);
+    if (chapterNineChargeCount !== 2) failures.push(`mobile chapter 9 ambivalent fish charge count mismatch at ${viewport.width}x${viewport.height}: ${chapterNineChargeCount}`);
+    for (const charge of chapterNineChargeLayout) {
+      if (!charge.inside || charge.width <= 0 || charge.height <= 0) {
+        failures.push(`mobile chapter 9 charge label escapes instrument at ${viewport.width}x${viewport.height}: ${charge.text}`);
+      }
     }
 
     if (viewport.width === mobileViewport.width) {

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -264,6 +264,8 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="ambivalent-fish-instrument__field ambivalent-fish-instrument__field--light" aria-hidden="true" />
               <span className="ambivalent-fish-instrument__field ambivalent-fish-instrument__field--shadow" aria-hidden="true" />
               <span className="ambivalent-fish-instrument__mirror" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__axis ambivalent-fish-instrument__axis--horizontal" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__axis ambivalent-fish-instrument__axis--vertical" aria-hidden="true" />
               <span className="ambivalent-fish-instrument__ring ambivalent-fish-instrument__ring--outer" aria-hidden="true" />
               <span className="ambivalent-fish-instrument__ring ambivalent-fish-instrument__ring--inner" aria-hidden="true" />
               <span className="ambivalent-fish-instrument__thread" aria-hidden="true" />
@@ -271,6 +273,8 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="ambivalent-fish-instrument__fish ambivalent-fish-instrument__fish--shadow" aria-hidden="true" />
               <span className="ambivalent-fish-instrument__junction" aria-hidden="true" />
               <span className="ambivalent-fish-instrument__shadow-core" aria-hidden="true" />
+              <span className="ambivalent-fish-instrument__charge ambivalent-fish-instrument__charge--light" aria-hidden="true">salvific</span>
+              <span className="ambivalent-fish-instrument__charge ambivalent-fish-instrument__charge--shadow" aria-hidden="true">counter</span>
               <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--paradox" aria-hidden="true">double edge</span>
               <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--return" aria-hidden="true">return</span>
               <span className="ambivalent-fish-instrument__label ambivalent-fish-instrument__label--shadow" aria-hidden="true">counter-pole</span>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -5150,10 +5150,11 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch9"] .chapter-stage__scrim {
   background:
-    linear-gradient(180deg, rgba(3, 3, 7, 0.76), rgba(3, 3, 7, 0.4) 48%, rgba(3, 3, 7, 0.82)),
-    linear-gradient(90deg, rgba(3, 3, 7, 0.95), rgba(3, 3, 7, 0.52) 60%, rgba(3, 3, 7, 0.3)),
-    radial-gradient(circle at 31% 47%, rgba(212, 175, 55, 0.14), transparent 32%),
-    radial-gradient(circle at 66% 52%, rgba(83, 216, 232, 0.13), transparent 36%);
+    linear-gradient(180deg, rgba(3, 3, 7, 0.72), rgba(3, 3, 7, 0.32) 46%, rgba(3, 3, 7, 0.78)),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.95), rgba(3, 3, 7, 0.56) 42%, rgba(3, 3, 7, 0.22) 78%),
+    radial-gradient(circle at 30% 47%, rgba(212, 175, 55, 0.18), transparent 31%),
+    radial-gradient(circle at 66% 52%, rgba(83, 216, 232, 0.18), transparent 36%),
+    radial-gradient(ellipse at 63% 50%, rgba(244, 240, 232, 0.08), transparent 34%);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .chapter-stage__reference-node[data-panel-id="ambivalence"] .chapter-stage__reference-mark::before {
@@ -5216,18 +5217,20 @@ h3 {
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument {
   position: relative;
   width: min(31rem, 100%);
-  min-height: clamp(6.75rem, 10.6vh, 8.05rem);
+  min-height: clamp(7.4rem, 11.6vh, 8.8rem);
   overflow: hidden;
   margin-top: 0.82rem;
-  border: 1px solid rgba(244, 240, 232, 0.12);
+  border: 1px solid rgba(244, 240, 232, 0.16);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 30% 45%, rgba(212, 175, 55, 0.18), transparent 4.6rem),
-    radial-gradient(circle at 68% 52%, rgba(83, 216, 232, 0.14), transparent 4.8rem),
-    linear-gradient(90deg, rgba(17, 13, 8, 0.8), rgba(9, 9, 13, 0.66) 50%, rgba(3, 13, 18, 0.66));
+    radial-gradient(circle at 28% 50%, rgba(255, 227, 156, 0.24), transparent 4.4rem),
+    radial-gradient(circle at 71% 52%, rgba(83, 216, 232, 0.2), transparent 4.8rem),
+    radial-gradient(ellipse at 50% 50%, rgba(244, 240, 232, 0.11), transparent 48%),
+    linear-gradient(90deg, rgba(24, 17, 8, 0.86), rgba(8, 8, 12, 0.72) 48%, rgba(3, 17, 22, 0.76));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.22);
+    0 1.5rem 4.4rem rgba(0, 0, 0, 0.28),
+    0 0 2.4rem rgba(83, 216, 232, 0.08);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::before,
@@ -5239,27 +5242,34 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::before {
   inset: 0.58rem;
-  border: 1px solid rgba(255, 227, 156, 0.08);
+  border: 1px solid rgba(255, 227, 156, 0.12);
   border-radius: calc(var(--radius) - 2px);
+  background:
+    linear-gradient(90deg, rgba(255, 227, 156, 0.05), transparent 34%, transparent 66%, rgba(83, 216, 232, 0.05)),
+    repeating-linear-gradient(90deg, transparent 0 18%, rgba(244, 240, 232, 0.035) 18.2% 18.45%, transparent 18.7% 36%);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::after {
   left: 50%;
   top: 50%;
-  width: 0.08rem;
-  height: 5.25rem;
-  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.28), transparent);
-  box-shadow: 0 0 1.35rem rgba(244, 240, 232, 0.12);
+  width: 0.1rem;
+  height: 6rem;
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.42), transparent);
+  box-shadow:
+    0 0 1.35rem rgba(244, 240, 232, 0.18),
+    0 0 2.2rem rgba(83, 216, 232, 0.12);
   transform: translate(-50%, -50%) rotate(4deg);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__axis,
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__mirror,
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring,
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__thread,
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish,
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__junction,
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__charge,
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label {
   position: absolute;
   pointer-events: none;
@@ -5269,7 +5279,7 @@ h3 {
   top: 0;
   bottom: 0;
   width: 50%;
-  opacity: 0.56;
+  opacity: 0.68;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -5278,31 +5288,58 @@ h3 {
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field--light {
   left: 0;
   background:
-    radial-gradient(circle at 42% 48%, rgba(255, 227, 156, 0.18), transparent 4rem),
-    linear-gradient(90deg, rgba(212, 175, 55, 0.09), transparent);
+    radial-gradient(circle at 40% 48%, rgba(255, 227, 156, 0.32), transparent 4.2rem),
+    radial-gradient(ellipse at 68% 50%, rgba(244, 240, 232, 0.12), transparent 3.2rem),
+    linear-gradient(90deg, rgba(212, 175, 55, 0.13), transparent);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field--shadow {
   right: 0;
   background:
-    radial-gradient(circle at 58% 52%, rgba(83, 216, 232, 0.14), transparent 4.2rem),
-    linear-gradient(270deg, rgba(83, 216, 232, 0.08), rgba(181, 130, 255, 0.04), transparent);
+    radial-gradient(circle at 58% 52%, rgba(83, 216, 232, 0.26), transparent 4.4rem),
+    radial-gradient(ellipse at 34% 50%, rgba(181, 130, 255, 0.13), transparent 3.2rem),
+    linear-gradient(270deg, rgba(83, 216, 232, 0.12), rgba(181, 130, 255, 0.06), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__axis {
+  left: 50%;
+  top: 50%;
+  opacity: 0.52;
+  background: linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.36), rgba(244, 240, 232, 0.24), rgba(83, 216, 232, 0.36), transparent);
+  filter: drop-shadow(0 0 0.7rem rgba(244, 240, 232, 0.16));
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__axis--horizontal {
+  width: 82%;
+  height: 1px;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__axis--vertical {
+  width: 1px;
+  height: 74%;
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.34), transparent);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__mirror {
   left: 50%;
   top: 50%;
-  width: 3.1rem;
-  height: 5rem;
-  border: 1px solid rgba(244, 240, 232, 0.16);
+  width: 3.35rem;
+  height: 5.55rem;
+  border: 1px solid rgba(244, 240, 232, 0.22);
   border-radius: 50%;
   background:
-    linear-gradient(92deg, transparent 46%, rgba(244, 240, 232, 0.16) 49%, transparent 52%),
-    radial-gradient(ellipse at 50% 50%, rgba(244, 240, 232, 0.08), transparent 72%);
+    linear-gradient(92deg, transparent 45%, rgba(244, 240, 232, 0.22) 49%, transparent 53%),
+    radial-gradient(ellipse at 50% 50%, rgba(244, 240, 232, 0.13), transparent 72%);
   box-shadow:
-    inset 0 0 1.1rem rgba(244, 240, 232, 0.08),
-    0 0 1.55rem rgba(83, 216, 232, 0.12);
-  opacity: 0.7;
+    inset 0 0 1.25rem rgba(244, 240, 232, 0.1),
+    0 0 1.75rem rgba(83, 216, 232, 0.18),
+    0 0 2.5rem rgba(212, 175, 55, 0.08);
+  opacity: 0.82;
   transform: translate(-50%, -50%) rotate(4deg);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5314,7 +5351,7 @@ h3 {
   left: 50%;
   top: 50%;
   border-radius: 50%;
-  opacity: 0.42;
+  opacity: 0.5;
   transform: translate(-50%, -50%) rotate(-14deg);
   transition:
     border-color 0.55s var(--motion-spring),
@@ -5323,30 +5360,31 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring--outer {
-  width: 9.7rem;
-  height: 4.85rem;
-  border: 1px solid rgba(255, 227, 156, 0.24);
-  border-left-color: rgba(83, 216, 232, 0.28);
+  width: 10.8rem;
+  height: 5.35rem;
+  border: 1px solid rgba(255, 227, 156, 0.34);
+  border-left-color: rgba(83, 216, 232, 0.4);
+  box-shadow: 0 0 1.5rem rgba(83, 216, 232, 0.08);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring--inner {
-  width: 6.7rem;
-  height: 3.12rem;
-  border: 1px solid rgba(83, 216, 232, 0.22);
-  border-right-color: rgba(255, 227, 156, 0.26);
-  opacity: 0.34;
+  width: 7.35rem;
+  height: 3.42rem;
+  border: 1px solid rgba(83, 216, 232, 0.34);
+  border-right-color: rgba(255, 227, 156, 0.36);
+  opacity: 0.42;
   transform: translate(-50%, -50%) rotate(16deg);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__thread {
   left: 50%;
   top: 50%;
-  width: 8.25rem;
-  height: 3.6rem;
-  border-top: 1px solid rgba(255, 227, 156, 0.22);
-  border-bottom: 1px solid rgba(83, 216, 232, 0.24);
+  width: 9.35rem;
+  height: 4.05rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.32);
+  border-bottom: 1px solid rgba(83, 216, 232, 0.34);
   border-radius: 50%;
-  opacity: 0.46;
+  opacity: 0.58;
   transform: translate(-50%, -50%) rotate(-8deg);
   transition:
     border-color 0.55s var(--motion-spring),
@@ -5356,10 +5394,10 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish {
   top: 50%;
-  width: 3.95rem;
-  height: 1.22rem;
+  width: 4.35rem;
+  height: 1.34rem;
   border-radius: 50%;
-  opacity: 0.84;
+  opacity: 0.9;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
@@ -5378,12 +5416,14 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--light {
   left: 25%;
-  border-top: 1px solid rgba(255, 227, 156, 0.58);
-  border-bottom: 1px solid rgba(244, 240, 232, 0.28);
+  border-top: 1px solid rgba(255, 227, 156, 0.7);
+  border-bottom: 1px solid rgba(244, 240, 232, 0.34);
   background:
-    radial-gradient(circle at 32% 50%, rgba(255, 227, 156, 0.72) 0 0.16rem, transparent 0.18rem),
-    radial-gradient(ellipse at 52% 50%, rgba(212, 175, 55, 0.2), transparent 68%);
-  box-shadow: 0 0 1.4rem rgba(212, 175, 55, 0.22);
+    radial-gradient(circle at 32% 50%, rgba(255, 227, 156, 0.9) 0 0.17rem, transparent 0.19rem),
+    radial-gradient(ellipse at 52% 50%, rgba(212, 175, 55, 0.3), transparent 68%);
+  box-shadow:
+    0 0 1.55rem rgba(212, 175, 55, 0.34),
+    0 0 2.4rem rgba(255, 227, 156, 0.12);
   transform: translate(-50%, -50%) rotate(-8deg);
 }
 
@@ -5396,13 +5436,15 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--shadow {
   right: 24%;
-  border-top: 1px solid rgba(83, 216, 232, 0.44);
-  border-bottom: 1px solid rgba(181, 130, 255, 0.32);
+  border-top: 1px solid rgba(83, 216, 232, 0.6);
+  border-bottom: 1px solid rgba(181, 130, 255, 0.42);
   background:
-    radial-gradient(circle at 68% 50%, rgba(143, 231, 237, 0.52) 0 0.14rem, transparent 0.16rem),
-    radial-gradient(ellipse at 48% 50%, rgba(83, 216, 232, 0.13), rgba(181, 130, 255, 0.06) 58%, transparent 70%);
-  box-shadow: 0 0 1.35rem rgba(83, 216, 232, 0.18);
-  filter: saturate(0.9);
+    radial-gradient(circle at 68% 50%, rgba(143, 231, 237, 0.74) 0 0.15rem, transparent 0.17rem),
+    radial-gradient(ellipse at 48% 50%, rgba(83, 216, 232, 0.22), rgba(181, 130, 255, 0.1) 58%, transparent 70%);
+  box-shadow:
+    0 0 1.45rem rgba(83, 216, 232, 0.28),
+    0 0 2.2rem rgba(181, 130, 255, 0.1);
+  filter: saturate(1.05);
   transform: translate(50%, -50%) rotate(172deg);
 }
 
@@ -5416,15 +5458,17 @@ h3 {
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__junction {
   left: 50%;
   top: 50%;
-  width: 0.72rem;
+  width: 0.82rem;
   aspect-ratio: 1;
-  border: 1px solid rgba(244, 240, 232, 0.22);
+  border: 1px solid rgba(244, 240, 232, 0.34);
   border-radius: 50%;
-  background: rgba(244, 240, 232, 0.16);
+  background:
+    radial-gradient(circle, rgba(244, 240, 232, 0.7), rgba(212, 175, 55, 0.24) 42%, rgba(83, 216, 232, 0.18));
   box-shadow:
-    0 0 0 0.42rem rgba(244, 240, 232, 0.05),
-    0 0 1.35rem rgba(255, 227, 156, 0.12);
-  opacity: 0.72;
+    0 0 0 0.48rem rgba(244, 240, 232, 0.06),
+    0 0 1.55rem rgba(255, 227, 156, 0.22),
+    0 0 2.1rem rgba(83, 216, 232, 0.12);
+  opacity: 0.84;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5435,20 +5479,44 @@ h3 {
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core {
   right: 10%;
   top: 50%;
-  width: 3.35rem;
-  height: 2.25rem;
-  border: 1px solid rgba(181, 130, 255, 0.22);
+  width: 3.8rem;
+  height: 2.48rem;
+  border: 1px solid rgba(181, 130, 255, 0.32);
   border-radius: 50%;
   background:
-    radial-gradient(circle at 50% 50%, rgba(181, 130, 255, 0.16), transparent 68%),
-    linear-gradient(130deg, transparent 47%, rgba(83, 216, 232, 0.2) 49%, transparent 52%);
-  box-shadow: inset 0 0 1.1rem rgba(83, 216, 232, 0.08);
-  opacity: 0.54;
+    radial-gradient(circle at 50% 50%, rgba(181, 130, 255, 0.24), transparent 68%),
+    linear-gradient(130deg, transparent 47%, rgba(83, 216, 232, 0.28) 49%, transparent 52%);
+  box-shadow:
+    inset 0 0 1.1rem rgba(83, 216, 232, 0.12),
+    0 0 1.6rem rgba(181, 130, 255, 0.1);
+  opacity: 0.66;
   transform: translateY(-50%) rotate(-12deg);
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
     box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__charge {
+  bottom: 15%;
+  color: rgba(244, 240, 232, 0.58);
+  font-family: var(--font-ui);
+  font-size: 0.54rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition:
+    color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__charge--light {
+  left: 16%;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__charge--shadow {
+  right: 14%;
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label {
@@ -5482,7 +5550,8 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__mirror,
-.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__thread {
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__thread,
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__axis {
   opacity: 0.88;
   transform: translate(-50%, -50%) rotate(4deg) scale(1.05);
 }
@@ -5492,6 +5561,11 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__fish {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ambivalence"] .ambivalent-fish-instrument__charge {
+  color: rgba(244, 240, 232, 0.78);
   opacity: 1;
 }
 
@@ -5515,6 +5589,17 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__thread {
   transform: translate(-50%, -50%) rotate(7deg) scale(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__axis--horizontal {
+  opacity: 0.78;
+  filter: drop-shadow(0 0 0.95rem rgba(255, 227, 156, 0.18));
+  transform: translate(-50%, -50%) rotate(7deg) scaleX(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__axis--vertical {
+  opacity: 0.68;
+  transform: translate(-50%, -50%) rotate(12deg);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="ouroboros"] .ambivalent-fish-instrument__fish--light {
@@ -5551,6 +5636,22 @@ h3 {
   box-shadow:
     inset 0 0 1.1rem rgba(244, 240, 232, 0.09),
     0 0 1.65rem rgba(83, 216, 232, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__axis--horizontal {
+  opacity: 0.74;
+  background: linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.22), rgba(244, 240, 232, 0.16), rgba(83, 216, 232, 0.56), transparent);
+  transform: translate(-50%, -50%) rotate(-5deg);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__charge--shadow {
+  color: rgba(143, 231, 237, 0.92);
+  opacity: 1;
+  transform: translateX(-0.22rem);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument[data-active-panel="shadow-fish"] .ambivalent-fish-instrument__charge--light {
+  opacity: 0.46;
 }
 
 .chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro h1 {
@@ -9800,12 +9901,14 @@ h3 {
 		  .historical-strata-instrument__carrier,
 		  .historical-strata-instrument__depth,
 		  .ambivalent-fish-instrument__field,
+		  .ambivalent-fish-instrument__axis,
 		  .ambivalent-fish-instrument__mirror,
 		  .ambivalent-fish-instrument__ring,
 		  .ambivalent-fish-instrument__thread,
 		  .ambivalent-fish-instrument__fish,
 		  .ambivalent-fish-instrument__junction,
 		  .ambivalent-fish-instrument__shadow-core,
+		  .ambivalent-fish-instrument__charge,
 		  .alchemical-vessel-instrument__field,
 		  .alchemical-vessel-instrument__heat,
 		  .alchemical-vessel-instrument__vessel,
@@ -9927,12 +10030,14 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field,
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__axis,
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__mirror,
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring,
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__thread,
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish,
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__junction,
-	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core {
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__shadow-core,
+	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__charge {
 	    transition: none;
 	  }
 

--- a/src/visualizations/chapters/ch9/ThreeOuroborosViz.js
+++ b/src/visualizations/chapters/ch9/ThreeOuroborosViz.js
@@ -9,11 +9,11 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
 
-const SERPENT_CLR = new THREE.Color('#2e7d32');
-const SERPENT_DARK = new THREE.Color('#0a2a0a');
-const GOLD = new THREE.Color('#ffd700');
-const SILVER = new THREE.Color('#b8c7dd');
-const SHADOW = new THREE.Color('#24304f');
+const SERPENT_CLR = new THREE.Color('#53d8e8');
+const SERPENT_DARK = new THREE.Color('#123f38');
+const GOLD = new THREE.Color('#f2c95d');
+const SILVER = new THREE.Color('#f4f0e8');
+const SHADOW = new THREE.Color('#6d5a9c');
 
 export default class ThreeOuroborosViz extends BaseViz {
     constructor(c, o = {}) {
@@ -35,25 +35,29 @@ export default class ThreeOuroborosViz extends BaseViz {
 
     async init() {
         const R = this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas, antialias: true, alpha: false });
-        R.setPixelRatio(Math.min(devicePixelRatio, 2)); R.setSize(this.width, this.height); R.setClearColor(0x030308);
+        R.setPixelRatio(Math.min(devicePixelRatio, 2)); R.setSize(this.width, this.height); R.setClearColor(0x04050d);
         this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.FogExp2(0x030308, 0.01);
+        this.scene.fog = new THREE.FogExp2(0x04050d, 0.007);
         this.camera = new THREE.PerspectiveCamera(50, this.width / this.height, 0.1, 100);
-        this.camera.position.set(0, 5, 16);
+        this.camera.position.set(0, 4.7, 15);
+        this.focusTarget = new THREE.Vector3(0.9, 0, 0);
 
         this.mouse = new THREE.Vector2(); this.mouseSmooth = new THREE.Vector2();
         this._onMM = e => { this.mouse.x = (e.clientX / innerWidth) * 2 - 1; this.mouse.y = -(e.clientY / innerHeight) * 2 + 1; };
         addEventListener('mousemove', this._onMM);
 
+        this._createTeachingField();
+
         // Serpent body: torus geometry (the ouroboros ring)
         this.serpentBody = new THREE.Mesh(new THREE.TorusGeometry(4, 0.35, 16, 100), new THREE.MeshStandardMaterial({
-            color: SERPENT_CLR, emissive: SERPENT_DARK, emissiveIntensity: 0.3, roughness: 0.5, metalness: 0.3,
+            color: SERPENT_CLR, emissive: SERPENT_DARK, emissiveIntensity: 0.52, roughness: 0.45, metalness: 0.36,
+            transparent: true, opacity: 0.82,
         }));
         this.scene.add(this.serpentBody);
 
         // Serpent scale pattern (wireframe overlay)
         this.serpentWire = new THREE.Mesh(new THREE.TorusGeometry(4, 0.37, 16, 100), new THREE.MeshBasicMaterial({
-            color: SERPENT_CLR, wireframe: true, transparent: true, opacity: 0.1,
+            color: SERPENT_CLR, wireframe: true, transparent: true, opacity: 0.18,
         }));
         this.scene.add(this.serpentWire);
 
@@ -78,7 +82,7 @@ export default class ThreeOuroborosViz extends BaseViz {
         const flowGeo = new THREE.BufferGeometry();
         flowGeo.setAttribute('position', new THREE.BufferAttribute(flowPos, 3));
         this.flowPts = new THREE.Points(flowGeo, new THREE.PointsMaterial({
-            color: SERPENT_CLR, size: 0.06, transparent: true, opacity: 0.7, blending: THREE.AdditiveBlending, depthWrite: false,
+            color: GOLD, size: 0.07, transparent: true, opacity: 0.74, blending: THREE.AdditiveBlending, depthWrite: false,
         }));
         this.scene.add(this.flowPts);
 
@@ -120,7 +124,7 @@ export default class ThreeOuroborosViz extends BaseViz {
                 new THREE.MeshBasicMaterial({
                     color: glowColor,
                     transparent: true,
-                    opacity: 0.08,
+                    opacity: 0.11,
                     blending: THREE.AdditiveBlending,
                     depthWrite: false,
                 })
@@ -148,7 +152,7 @@ export default class ThreeOuroborosViz extends BaseViz {
         this.shadowVeil = new THREE.Mesh(
             new THREE.SphereGeometry(5.8, 28, 20),
             new THREE.MeshBasicMaterial({
-                color: 0x111832,
+                color: 0x172044,
                 transparent: true,
                 opacity: 0,
                 blending: THREE.AdditiveBlending,
@@ -160,7 +164,7 @@ export default class ThreeOuroborosViz extends BaseViz {
 
         // Inner recursion — smaller ouroboros inside
         this.innerSerpent = new THREE.Mesh(new THREE.TorusGeometry(1.5, 0.12, 10, 60), new THREE.MeshBasicMaterial({
-            color: SERPENT_CLR, transparent: true, opacity: 0.15, blending: THREE.AdditiveBlending,
+            color: GOLD, transparent: true, opacity: 0.18, blending: THREE.AdditiveBlending,
         }));
         this.scene.add(this.innerSerpent);
 
@@ -170,14 +174,98 @@ export default class ThreeOuroborosViz extends BaseViz {
         }));
         this.scene.add(this.innerSerpent2);
 
-        this.scene.add(new THREE.AmbientLight(0x0a150a, 0.3));
-        this.scene.add(new THREE.PointLight(0x2e7d32, 0.4, 15));
-        this.scene.add(new THREE.PointLight(0xffd700, 0.2, 8));
+        this.scene.add(new THREE.AmbientLight(0x101822, 0.45));
+        const serpentLight = new THREE.PointLight(0x53d8e8, 0.72, 16);
+        serpentLight.position.set(-2, 3, 5);
+        this.scene.add(serpentLight);
+        const goldLight = new THREE.PointLight(0xf2c95d, 0.55, 12);
+        goldLight.position.set(4, 2, 4);
+        this.scene.add(goldLight);
+        const shadowLight = new THREE.PointLight(0x7b6aa8, 0.42, 14);
+        shadowLight.position.set(5, -1, 3);
+        this.scene.add(shadowLight);
 
         this.composer = new EffectComposer(R);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloom = new UnrealBloomPass(new THREE.Vector2(this.width, this.height), 1.2, 0.5, 0.35);
         this.composer.addPass(this.bloom);
+    }
+
+    _createTeachingField() {
+        this.teachingField = new THREE.Group();
+
+        const makeVeil = (color, x) => {
+            const veil = new THREE.Mesh(
+                new THREE.PlaneGeometry(8.5, 11.5),
+                new THREE.MeshBasicMaterial({
+                    map: this._createRadialTexture(color),
+                    transparent: true,
+                    opacity: 0.18,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false,
+                    side: THREE.DoubleSide,
+                })
+            );
+            veil.position.set(x, 0, -3.5);
+            this.teachingField.add(veil);
+        };
+
+        makeVeil(GOLD, -3.1);
+        makeVeil(SERPENT_CLR, 3.1);
+
+        const lineMaterial = new THREE.LineBasicMaterial({
+            color: 0xf4f0e8,
+            transparent: true,
+            opacity: 0.16,
+            blending: THREE.AdditiveBlending,
+        });
+        this.teachingField.add(new THREE.Line(
+            new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(-7.2, 0, -1.6), new THREE.Vector3(7.2, 0, -1.6)]),
+            lineMaterial.clone()
+        ));
+        this.teachingField.add(new THREE.Line(
+            new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0, -4.9, -1.6), new THREE.Vector3(0, 4.9, -1.6)]),
+            lineMaterial.clone()
+        ));
+
+        const arcPoints = [];
+        for (let i = 0; i <= 160; i++) {
+            const a = (i / 160) * Math.PI * 2;
+            arcPoints.push(new THREE.Vector3(Math.cos(a) * 5.65, Math.sin(a) * 2.75, -1.9));
+        }
+        this.returnOrbit = new THREE.Line(
+            new THREE.BufferGeometry().setFromPoints(arcPoints),
+            new THREE.LineBasicMaterial({
+                color: 0xf2c95d,
+                transparent: true,
+                opacity: 0.22,
+                blending: THREE.AdditiveBlending,
+            })
+        );
+        this.teachingField.add(this.returnOrbit);
+
+        this.scene.add(this.teachingField);
+    }
+
+    _createRadialTexture(color) {
+        const size = 160;
+        const canvas = document.createElement('canvas');
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext('2d');
+        const r = Math.round(color.r * 255);
+        const g = Math.round(color.g * 255);
+        const b = Math.round(color.b * 255);
+        const gradient = ctx.createRadialGradient(size / 2, size / 2, 4, size / 2, size / 2, size / 2);
+        gradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, 0.72)`);
+        gradient.addColorStop(0.45, `rgba(${r}, ${g}, ${b}, 0.22)`);
+        gradient.addColorStop(0.78, `rgba(${r}, ${g}, ${b}, 0.06)`);
+        gradient.addColorStop(1, `rgba(${r}, ${g}, ${b}, 0)`);
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, size, size);
+        const texture = new THREE.CanvasTexture(canvas);
+        texture.colorSpace = THREE.SRGBColorSpace;
+        return texture;
     }
 
     update(dt) {
@@ -191,13 +279,22 @@ export default class ThreeOuroborosViz extends BaseViz {
         this.shadowFocus = THREE.MathUtils.damp(this.shadowFocus, panelId === 'shadow-fish' ? 1 : 0, dampRate, dt);
         this.mouseSmooth.lerp(this.mouse, 0.04);
 
+        if (this.teachingField) {
+            this.teachingField.rotation.z = Math.sin(t * 0.03 * motionScale) * 0.035;
+            this.teachingField.position.x = 0.3 + this.ambivalenceFocus * 0.18 - this.shadowFocus * 0.12;
+        }
+        if (this.returnOrbit) {
+            this.returnOrbit.material.opacity = 0.18 + this.ouroborosFocus * 0.22 + this.ambivalenceFocus * 0.08;
+            this.returnOrbit.rotation.z -= 0.0015 * motionScale * (0.7 + this.ouroborosFocus);
+        }
+
         // Serpent slow rotation (eating its tail)
         this.serpentBody.rotation.z += 0.003 * motionScale * (0.7 + this.ouroborosFocus * 1.4);
         this.serpentBody.rotation.x = Math.sin(t * 0.1 * motionScale) * (0.12 + this.ouroborosFocus * 0.1);
         this.serpentWire.rotation.z = this.serpentBody.rotation.z;
         this.serpentWire.rotation.x = this.serpentBody.rotation.x;
         this.serpentBody.scale.setScalar(0.92 + this.ouroborosFocus * 0.14 + this.shadowFocus * 0.08);
-        this.serpentWire.material.opacity = 0.08 + this.ouroborosFocus * 0.12 + this.shadowFocus * 0.04;
+        this.serpentWire.material.opacity = 0.14 + this.ouroborosFocus * 0.18 + this.shadowFocus * 0.06;
 
         // Junction follows rotation
         const jA = this.serpentBody.rotation.z;
@@ -214,7 +311,7 @@ export default class ThreeOuroborosViz extends BaseViz {
             fp[i * 3 + 2] = Math.sin(a) * 4 * Math.sin(this.serpentBody.rotation.x);
         }
         this.flowPts.geometry.attributes.position.needsUpdate = true;
-        this.flowPts.material.opacity = 0.35 + this.ouroborosFocus * 0.45 + this.shadowFocus * 0.16;
+        this.flowPts.material.opacity = 0.45 + this.ouroborosFocus * 0.44 + this.shadowFocus * 0.18;
 
         // Inner recursion rotation (opposite direction)
         this.innerSerpent.rotation.z -= 0.005 * motionScale * (0.5 + this.ouroborosFocus);
@@ -235,7 +332,7 @@ export default class ThreeOuroborosViz extends BaseViz {
             fish.rotation.y = -angle + Math.PI / 2;
             fish.rotation.z = Math.sin(t * 0.25 * motionScale + angle) * 0.08;
             const focus = isShadow ? Math.max(this.ambivalenceFocus * 0.75, this.shadowFocus) : this.ambivalenceFocus;
-            const opacity = isShadow ? 0.34 + focus * 0.42 : 0.38 + focus * 0.5;
+            const opacity = isShadow ? 0.46 + focus * 0.42 : 0.52 + focus * 0.46;
             fish.userData.bodyMat.opacity = opacity;
             fish.userData.tailMat.opacity = opacity * 0.8;
             fish.userData.glowMat.opacity = (isShadow ? 0.04 : 0.07) + focus * (isShadow ? 0.1 : 0.16);
@@ -254,11 +351,11 @@ export default class ThreeOuroborosViz extends BaseViz {
         this.oppositionLine.geometry.attributes.position.needsUpdate = true;
         const lineScale = this.width < 700 ? 0 : 1;
         this.oppositionLine.material.opacity = (0.04 + this.ambivalenceFocus * 0.14 + this.shadowFocus * 0.04) * lineScale;
-        this.shadowVeil.material.opacity = this.shadowFocus * 0.18;
+        this.shadowVeil.material.opacity = this.shadowFocus * 0.22;
 
         // Death-rebirth dissolution: periodic opacity pulse
         const drCycle = Math.sin(t * 0.15 * motionScale);
-        this.serpentBody.material.opacity = 0.58 + drCycle * 0.18 + this.ouroborosFocus * 0.22 + this.shadowFocus * 0.12;
+        this.serpentBody.material.opacity = 0.7 + drCycle * 0.14 + this.ouroborosFocus * 0.2 + this.shadowFocus * 0.1;
         this.serpentBody.material.transparent = true;
 
         // Camera
@@ -267,9 +364,9 @@ export default class ThreeOuroborosViz extends BaseViz {
         this.camera.position.x = Math.sin(ca) * camRadius;
         this.camera.position.y = 5 + this.mouseSmooth.y * 3 - this.shadowFocus * 0.4;
         this.camera.position.z = Math.cos(ca) * camRadius;
-        this.camera.lookAt(0, 0, 0);
+        this.camera.lookAt(this.focusTarget);
         if (this.bloom) {
-            this.bloom.strength = 1.05 + this.ouroborosFocus * 0.35 + this.ambivalenceFocus * 0.16 + this.shadowFocus * 0.2;
+            this.bloom.strength = 1.16 + this.ouroborosFocus * 0.34 + this.ambivalenceFocus * 0.18 + this.shadowFocus * 0.24;
         }
     }
 
@@ -282,7 +379,15 @@ export default class ThreeOuroborosViz extends BaseViz {
     dispose() {
         removeEventListener('mousemove', this._onMM);
         this.renderer?.dispose(); this.renderer?.forceContextLoss();
-        this.scene?.traverse(o => { o.geometry?.dispose(); if (o.material) [].concat(o.material).forEach(m => m.dispose()); });
+        this.scene?.traverse(o => {
+            o.geometry?.dispose();
+            if (o.material) {
+                [].concat(o.material).forEach(m => {
+                    m.map?.dispose();
+                    m.dispose();
+                });
+            }
+        });
         this.composer = null; this.scene = null; this.renderer = null; super.dispose();
     }
 }


### PR DESCRIPTION
## Summary
- brighten Chapter 9's ouroboros scene with soft gold/cyan teaching veils, stronger return orbit, clearer polarity lighting, and texture cleanup
- add axis and charge marks to the ambivalent fish instrument so paradox, return, and shadow are visible without extra prose
- extend smoke coverage for the new Chapter 9 marks, reduced-motion checks, and mobile containment

## Skill stack
- Aion skill-routing playbook
- orchestration/autopilot subagent lanes
- frontend/design taste review via screenshot inspection
- Playwright browser evidence
- accessibility and webapp smoke testing
- GitHub publish flow

## Routes changed
- /journey/chapter/ch9

## Visual thesis
Chapter 9 should read as an active paradox instrument: the same fish-symbol carries salvific gold and counter-pole cyan, returns through an ouroboric loop, and keeps the shadow inside the total field.

## Browser evidence
- desktop, mobile, and 320px narrow screenshots captured locally under ignored test-results/ch9-ambivalence-field/
- no console errors, no unexpected 404s, no horizontal overflow

## Checks
- npm run lint
- npx tsc --noEmit
- git diff --check
- node --check src/visualizations/chapters/ch9/ThreeOuroborosViz.js && node --check scripts/testing/app-shell-smoke.mjs
- npm run build
- AION_SMOKE_PORT=4174 node scripts/testing/app-shell-smoke.mjs --shard=foundation
- AION_SMOKE_PORT=4176 node scripts/testing/app-shell-smoke.mjs --shard=scene-controls
- AION_SMOKE_PORT=4177 node scripts/testing/app-shell-smoke.mjs --shard=mobile
- AION_SMOKE_PORT=4180 node scripts/testing/app-shell-smoke.mjs --shard=chapter-routes
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- AION_A11Y_PORT=4181 npm run test:a11y:app
- AION_VISUAL_QA_PORT=4182 npm run test:visual:control-tower
- npm run build:pages && npm run test:pages:artifact

## Residual debt
- next strongest candidates from scout review: Home orientation route and the Chapters 10-12 alchemy family
- existing three.js bundle size warning remains unchanged as a project-level performance backlog
