### PR TITLE
[codex] Refine chapter ten alchemical lab

### DIFF
--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -121,11 +121,17 @@ async function waitForServer(server) {
 function watchForRouteFailures(page) {
   const consoleErrors = [];
   const notFound = [];
+  const pageErrors = [];
+  const requestFailures = [];
 
   page.on('console', (message) => {
     if (message.type() === 'error') {
       consoleErrors.push(message.text());
     }
+  });
+
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message);
   });
 
   page.on('response', (response) => {
@@ -135,7 +141,15 @@ function watchForRouteFailures(page) {
     }
   });
 
-  return { consoleErrors, notFound };
+  page.on('requestfailed', (request) => {
+    const url = request.url();
+    const errorText = request.failure()?.errorText || 'request failed';
+    if (!url.endsWith('/favicon.ico') && errorText !== 'net::ERR_ABORTED') {
+      requestFailures.push(`${errorText}: ${url}`);
+    }
+  });
+
+  return { consoleErrors, notFound, pageErrors, requestFailures };
 }
 
 async function withWatchedPage(browser, failures, callback, { viewport = desktopViewport } = {}) {
@@ -146,6 +160,8 @@ async function withWatchedPage(browser, failures, callback, { viewport = desktop
     await callback(page);
   } finally {
     failures.push(...routeFailures.notFound.map((url) => `404 response: ${url}`));
+    failures.push(...routeFailures.pageErrors.map((message) => `page error: ${message}`));
+    failures.push(...routeFailures.requestFailures.map((message) => `request failed: ${message}`));
     failures.push(...routeFailures.consoleErrors.map((message) => `console error: ${message}`));
     await page.close();
   }
@@ -1151,7 +1167,7 @@ async function smokeReducedMotion(browser, failures) {
   const chapterTenInstrumentCount = await page.locator('.alchemical-vessel-instrument').count();
   const chapterTenInstrumentBox = await page.locator('.alchemical-vessel-instrument').boundingBox();
   const chapterTenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
-  const chapterTenInstrumentMotion = await page.locator('.alchemical-vessel-instrument__field, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__vessel, .alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__fish, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__thread, .alchemical-vessel-instrument__particle, .alchemical-vessel-instrument__stages').evaluateAll((nodes) => nodes.map((node) => {
+  const chapterTenInstrumentMotion = await page.locator('.alchemical-vessel-instrument__field, .alchemical-vessel-instrument__aura, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__flame, .alchemical-vessel-instrument__retort, .alchemical-vessel-instrument__vessel, .alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__fish, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__plough, .alchemical-vessel-instrument__thread, .alchemical-vessel-instrument__particle, .alchemical-vessel-instrument__stages').evaluateAll((nodes) => nodes.map((node) => {
     const styles = window.getComputedStyle(node);
     return {
       animationName: styles.animationName,
@@ -2561,11 +2577,15 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterTenInstrumentRole = await chapterTenInstrument.getAttribute('role');
   const chapterTenInstrumentLabel = await chapterTenInstrument.getAttribute('aria-label');
   const chapterTenInstrumentPanel = await chapterTenInstrument.getAttribute('data-active-panel');
+  const chapterTenInstrumentAuraCount = await page.locator('.alchemical-vessel-instrument__aura').count();
   const chapterTenInstrumentStageCount = await page.locator('.alchemical-vessel-instrument__stage').count();
   const chapterTenInstrumentParticleCount = await page.locator('.alchemical-vessel-instrument__particle').count();
+  const chapterTenInstrumentFlameCount = await page.locator('.alchemical-vessel-instrument__flame').count();
+  const chapterTenInstrumentRetortCount = await page.locator('.alchemical-vessel-instrument__retort').count();
+  const chapterTenInstrumentPloughCount = await page.locator('.alchemical-vessel-instrument__plough').count();
   const chapterTenInstrumentLabelCount = await page.locator('.alchemical-vessel-instrument__label').count();
   const chapterTenInitialDescription = await page.locator('#scene-host-description-ch10').textContent();
-  const chapterTenInstrumentMarksVisible = await page.locator('.alchemical-vessel-instrument__field, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__vessel, .alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__fish, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__thread, .alchemical-vessel-instrument__particle, .alchemical-vessel-instrument__stages').evaluateAll((nodes) => nodes.length >= 14 && nodes.every((node) => {
+  const chapterTenInstrumentMarksVisible = await page.locator('.alchemical-vessel-instrument__field, .alchemical-vessel-instrument__aura, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__flame, .alchemical-vessel-instrument__retort, .alchemical-vessel-instrument__vessel, .alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__fish, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__plough, .alchemical-vessel-instrument__thread, .alchemical-vessel-instrument__particle, .alchemical-vessel-instrument__stages').evaluateAll((nodes) => nodes.length >= 19 && nodes.every((node) => {
     const styles = window.getComputedStyle(node);
     const box = node.getBoundingClientRect();
     return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
@@ -2590,8 +2610,12 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterTenReferenceCount !== 3) failures.push(`chapter 10 reference node count mismatch: ${chapterTenReferenceCount}`);
   if (chapterTenPanelIds.join(',') !== 'vessel,prima,opus') failures.push(`chapter 10 reference nodes out of order: ${chapterTenPanelIds.join(',')}`);
   if (chapterTenInstrumentCount !== 1) failures.push(`chapter 10 alchemical vessel instrument count mismatch: ${chapterTenInstrumentCount}`);
+  if (chapterTenInstrumentAuraCount !== 2) failures.push(`chapter 10 alchemical vessel aura count mismatch: ${chapterTenInstrumentAuraCount}`);
   if (chapterTenInstrumentStageCount !== 4) failures.push(`chapter 10 alchemical vessel stage count mismatch: ${chapterTenInstrumentStageCount}`);
   if (chapterTenInstrumentParticleCount !== 4) failures.push(`chapter 10 alchemical vessel particle count mismatch: ${chapterTenInstrumentParticleCount}`);
+  if (chapterTenInstrumentFlameCount !== 1) failures.push(`chapter 10 alchemical vessel flame count mismatch: ${chapterTenInstrumentFlameCount}`);
+  if (chapterTenInstrumentRetortCount !== 1) failures.push(`chapter 10 alchemical vessel retort count mismatch: ${chapterTenInstrumentRetortCount}`);
+  if (chapterTenInstrumentPloughCount !== 1) failures.push(`chapter 10 alchemical vessel plough count mismatch: ${chapterTenInstrumentPloughCount}`);
   if (chapterTenInstrumentLabelCount !== 3) failures.push(`chapter 10 alchemical vessel label count mismatch: ${chapterTenInstrumentLabelCount}`);
   if (chapterTenInstrumentRole !== 'img') failures.push(`chapter 10 alchemical vessel instrument role mismatch: ${chapterTenInstrumentRole}`);
   if (!chapterTenInstrumentLabel?.includes('Alchemical vessel model') || !chapterTenInstrumentLabel?.includes('fish-symbol enters') || !chapterTenInstrumentLabel?.includes('Current emphasis: Alchemy')) {
@@ -2613,14 +2637,14 @@ async function smokeChapterSceneControls(page, failures) {
   const primaDescription = await page.locator('#scene-host-description-ch10').textContent();
   const primaInstrumentPanel = await chapterTenInstrument.getAttribute('data-active-panel');
   const primaInstrumentLabel = await chapterTenInstrument.getAttribute('aria-label');
-  const primaVisualState = await page.locator('.alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__particle').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  const primaVisualState = await page.locator('.alchemical-vessel-instrument__aura, .alchemical-vessel-instrument__bath, .alchemical-vessel-instrument__magnet, .alchemical-vessel-instrument__particle').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   if (primaPressed !== 'true') failures.push(`chapter 10 prima reference did not become active: ${primaPressed}`);
   if (primaPanelActive !== 1) failures.push(`chapter 10 prima panel did not become active: ${primaPanelActive}`);
   if (primaInstrumentPanel !== 'prima') failures.push(`chapter 10 alchemical vessel instrument did not follow prima panel: ${primaInstrumentPanel}`);
   if (!primaInstrumentLabel?.includes('Current emphasis: Prima Materia') || !primaInstrumentLabel?.includes('The raw state is not a mistake')) {
     failures.push(`chapter 10 alchemical vessel instrument label did not follow prima panel: ${primaInstrumentLabel}`);
   }
-  if (primaVisualState.length !== 6 || !primaVisualState.every((opacity) => opacity >= 0.62)) {
+  if (primaVisualState.length !== 8 || !primaVisualState.every((opacity) => opacity >= 0.62)) {
     failures.push(`chapter 10 alchemical vessel instrument did not visually emphasize prima materia: ${primaVisualState.join(',')}`);
   }
   if (!primaDescription?.includes('Prima Materia: Begin with the mixed thing')) failures.push(`chapter 10 scene description did not follow prima panel: ${primaDescription}`);
@@ -2635,7 +2659,7 @@ async function smokeChapterSceneControls(page, failures) {
   const opusDescription = await page.locator('#scene-host-description-ch10').textContent();
   const opusInstrumentPanel = await chapterTenInstrument.getAttribute('data-active-panel');
   const opusInstrumentLabel = await chapterTenInstrument.getAttribute('aria-label');
-  const opusVisualState = await page.locator('.alchemical-vessel-instrument__stages, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__thread--ascent').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  const opusVisualState = await page.locator('.alchemical-vessel-instrument__stages, .alchemical-vessel-instrument__heat, .alchemical-vessel-instrument__flame, .alchemical-vessel-instrument__plough, .alchemical-vessel-instrument__lapis, .alchemical-vessel-instrument__thread--ascent').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   const chapterTenScrollY = await page.evaluate(() => window.scrollY);
   if (opusPressed !== 'true') failures.push(`chapter 10 scene control did not become active: ${opusPressed}`);
   if (opusPanelActive !== 1) failures.push(`chapter 10 opus panel did not become active: ${opusPanelActive}`);
@@ -2643,7 +2667,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (!opusInstrumentLabel?.includes('Current emphasis: Opus') || !opusInstrumentLabel?.includes('Alchemy gives psychology a theater')) {
     failures.push(`chapter 10 alchemical vessel instrument label did not follow opus panel: ${opusInstrumentLabel}`);
   }
-  if (opusVisualState.length !== 4 || !opusVisualState.every((opacity) => opacity >= 0.65)) {
+  if (opusVisualState.length !== 6 || !opusVisualState.every((opacity) => opacity >= 0.65)) {
     failures.push(`chapter 10 alchemical vessel instrument did not visually emphasize opus: ${opusVisualState.join(',')}`);
   }
   if (!opusDescription?.includes('Opus: Matter teaches psyche')) failures.push(`chapter 10 scene description did not follow opus panel: ${opusDescription}`);
@@ -3534,7 +3558,13 @@ async function smokeMobile(page, failures) {
     if (viewport.width === mobileViewport.width) {
       const chapterTenCanvas = page.locator('.scene-host canvas').first();
       const chapterTenCanvasCount = await chapterTenCanvas.count();
-      if (chapterTenCanvasCount > 0) {
+      if (chapterTenCanvasCount !== 1) {
+        failures.push(`mobile chapter 10 expected one ready canvas at ${viewport.width}x${viewport.height} but found ${chapterTenCanvasCount}`);
+      } else {
+        const chapterTenCanvasBox = await chapterTenCanvas.boundingBox();
+        if (!chapterTenCanvasBox || chapterTenCanvasBox.width < 300 || chapterTenCanvasBox.height < 260) {
+          failures.push(`mobile chapter 10 canvas geometry too small at ${viewport.width}x${viewport.height}: ${chapterTenCanvasBox ? `${Math.round(chapterTenCanvasBox.width)}x${Math.round(chapterTenCanvasBox.height)}` : 'missing'}`);
+        }
         const chapterTenPixelSample = await waitForCanvasPixels(chapterTenCanvas);
         recordCanvasPixelFailure(failures, `mobile chapter 10 at ${viewport.width}x${viewport.height}`, chapterTenPixelSample);
       }

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -288,12 +288,17 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               aria-label={alchemicalVesselInstrumentLabel}
             >
               <span className="alchemical-vessel-instrument__field" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__aura alchemical-vessel-instrument__aura--solve" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__aura alchemical-vessel-instrument__aura--coagula" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__heat" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__flame" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__retort" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__vessel" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__bath" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__fish" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__magnet" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__lapis" aria-hidden="true" />
+              <span className="alchemical-vessel-instrument__plough" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__thread alchemical-vessel-instrument__thread--descent" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__thread alchemical-vessel-instrument__thread--ascent" aria-hidden="true" />
               <span className="alchemical-vessel-instrument__particle alchemical-vessel-instrument__particle--one" aria-hidden="true" />

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -5764,19 +5764,20 @@ h3 {
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument {
   position: relative;
   width: min(31rem, 100%);
-  min-height: clamp(6.8rem, 10.2vh, 7.85rem);
+  min-height: clamp(7.75rem, 11.4vh, 8.85rem);
   overflow: hidden;
   margin-top: 0.78rem;
   border: 1px solid rgba(244, 240, 232, 0.12);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 29% 58%, rgba(83, 216, 232, 0.13), transparent 4.6rem),
-    radial-gradient(circle at 52% 56%, rgba(212, 175, 55, 0.16), transparent 4.5rem),
-    radial-gradient(circle at 78% 70%, rgba(194, 55, 43, 0.12), transparent 4.6rem),
-    linear-gradient(90deg, rgba(7, 8, 13, 0.86), rgba(11, 9, 12, 0.72) 48%, rgba(19, 8, 7, 0.62));
+    radial-gradient(circle at 26% 52%, rgba(83, 216, 232, 0.18), transparent 5.2rem),
+    radial-gradient(circle at 51% 53%, rgba(212, 175, 55, 0.24), transparent 5.6rem),
+    radial-gradient(circle at 74% 68%, rgba(194, 55, 43, 0.17), transparent 5.2rem),
+    linear-gradient(90deg, rgba(7, 9, 13, 0.9), rgba(12, 9, 10, 0.78) 46%, rgba(24, 8, 6, 0.68));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.24);
+    0 1.4rem 4rem rgba(0, 0, 0, 0.24),
+    0 0 3.6rem rgba(212, 175, 55, 0.06);
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::before,
@@ -5794,8 +5795,8 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::after {
   left: 50%;
-  bottom: 1.02rem;
-  width: 58%;
+  bottom: 1.16rem;
+  width: 64%;
   height: 0.06rem;
   background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.28), transparent);
   box-shadow: 0 0 1.2rem rgba(244, 240, 232, 0.1);
@@ -5803,12 +5804,16 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__field,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__heat,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__flame,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages,
@@ -5829,21 +5834,52 @@ h3 {
     transform 0.55s var(--motion-spring);
 }
 
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura {
+  left: 50%;
+  top: 54%;
+  width: 11.6rem;
+  height: 5.8rem;
+  border-radius: 50%;
+  opacity: 0.44;
+  transform: translate(-50%, -50%) rotate(-8deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura--solve {
+  border-top: 1px solid rgba(83, 216, 232, 0.32);
+  border-left: 1px solid rgba(83, 216, 232, 0.16);
+  background: radial-gradient(ellipse at 38% 48%, rgba(83, 216, 232, 0.12), transparent 68%);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura--coagula {
+  width: 9.4rem;
+  height: 4.9rem;
+  border-bottom: 1px solid rgba(255, 173, 112, 0.3);
+  border-right: 1px solid rgba(255, 227, 156, 0.16);
+  background: radial-gradient(ellipse at 64% 58%, rgba(212, 175, 55, 0.14), transparent 68%);
+  transform: translate(-50%, -50%) rotate(12deg);
+}
+
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel {
   left: 50%;
   top: 50%;
-  width: 6.25rem;
-  height: 5.35rem;
-  border: 1px solid rgba(143, 231, 237, 0.34);
-  border-top-color: rgba(244, 240, 232, 0.18);
+  width: 7.05rem;
+  height: 5.95rem;
+  border: 1px solid rgba(143, 231, 237, 0.46);
+  border-top-color: rgba(244, 240, 232, 0.26);
   border-radius: 45% 45% 52% 52%;
   background:
-    linear-gradient(90deg, transparent 46%, rgba(244, 240, 232, 0.16) 49%, transparent 52%),
-    radial-gradient(ellipse at 50% 62%, rgba(255, 227, 156, 0.12), transparent 70%);
+    linear-gradient(90deg, transparent 45%, rgba(244, 240, 232, 0.22) 49%, transparent 53%),
+    radial-gradient(ellipse at 50% 58%, rgba(83, 216, 232, 0.12), transparent 42%),
+    radial-gradient(ellipse at 50% 66%, rgba(255, 227, 156, 0.18), transparent 72%);
   box-shadow:
-    inset 0 0 1.25rem rgba(143, 231, 237, 0.1),
-    0 0 1.7rem rgba(83, 216, 232, 0.14);
-  opacity: 0.74;
+    inset 0 0 1.45rem rgba(143, 231, 237, 0.13),
+    0 0 2.1rem rgba(83, 216, 232, 0.18),
+    0 0 2.6rem rgba(212, 175, 55, 0.08);
+  opacity: 0.82;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5851,17 +5887,61 @@ h3 {
     box-shadow 0.55s var(--motion-spring);
 }
 
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort {
+  left: 50%;
+  top: 47%;
+  width: 4.35rem;
+  height: 4.35rem;
+  border: 1px solid rgba(244, 240, 232, 0.16);
+  border-top-color: rgba(143, 231, 237, 0.42);
+  border-radius: 50%;
+  opacity: 0.56;
+  transform: translate(-50%, -50%) rotate(-18deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort::before,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort::before {
+  left: 50%;
+  top: -1.02rem;
+  width: 0.74rem;
+  height: 1.34rem;
+  border: 1px solid rgba(143, 231, 237, 0.28);
+  border-bottom: 0;
+  border-radius: 999px 999px 0 0;
+  transform: translateX(-50%);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort::after {
+  left: 50%;
+  bottom: 0.24rem;
+  width: 3.4rem;
+  height: 0.86rem;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.18), transparent 72%);
+  transform: translateX(-50%);
+}
+
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath {
   left: 50%;
   top: 59%;
-  width: 4.8rem;
-  height: 1.18rem;
+  width: 5.4rem;
+  height: 1.28rem;
   border-radius: 50%;
   background:
-    radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.26), transparent 68%),
+    radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.34), transparent 68%),
     linear-gradient(90deg, rgba(83, 216, 232, 0.18), rgba(212, 175, 55, 0.14), rgba(194, 55, 43, 0.12));
-  box-shadow: 0 0 1.35rem rgba(83, 216, 232, 0.14);
-  opacity: 0.64;
+  box-shadow: 0 0 1.55rem rgba(83, 216, 232, 0.18);
+  opacity: 0.72;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5943,18 +6023,37 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__heat {
   left: 50%;
-  bottom: 1.26rem;
-  width: 5rem;
-  height: 1.22rem;
+  bottom: 1.34rem;
+  width: 5.8rem;
+  height: 1.36rem;
   border-radius: 50%;
   background:
-    radial-gradient(ellipse at 50% 70%, rgba(194, 55, 43, 0.38), rgba(212, 175, 55, 0.18) 46%, transparent 72%);
+    radial-gradient(ellipse at 50% 70%, rgba(194, 55, 43, 0.46), rgba(212, 175, 55, 0.24) 46%, transparent 72%);
   filter: blur(0.08rem);
-  opacity: 0.58;
+  opacity: 0.66;
   transform: translateX(-50%);
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__flame {
+  left: 50%;
+  bottom: 1.42rem;
+  width: 2.65rem;
+  height: 2.8rem;
+  border-radius: 50% 50% 46% 46%;
+  background:
+    radial-gradient(ellipse at 50% 72%, rgba(255, 227, 156, 0.42), transparent 54%),
+    radial-gradient(ellipse at 50% 35%, rgba(194, 55, 43, 0.34), transparent 68%);
+  filter: blur(0.03rem);
+  opacity: 0.52;
+  transform: translateX(-50%) scaleY(0.74);
+  transform-origin: 50% 100%;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread {
@@ -6016,9 +6115,52 @@ h3 {
   background: rgba(194, 55, 43, 0.7);
 }
 
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough {
+  left: 31%;
+  bottom: 1.05rem;
+  width: 4.85rem;
+  height: 1.08rem;
+  border-bottom: 1px solid rgba(255, 227, 156, 0.3);
+  border-radius: 50%;
+  opacity: 0.44;
+  transform: translateX(-50%) rotate(-8deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough::before,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough::before {
+  left: 22%;
+  top: 0.38rem;
+  width: 1.9rem;
+  height: 0.3rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(83, 216, 232, 0.42), rgba(255, 227, 156, 0.42));
+  box-shadow: 0 0 0.9rem rgba(83, 216, 232, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough::after {
+  right: 0.2rem;
+  top: 0.22rem;
+  width: 0.88rem;
+  height: 0.56rem;
+  border-right: 1px solid rgba(255, 227, 156, 0.42);
+  border-bottom: 1px solid rgba(255, 227, 156, 0.32);
+  transform: rotate(-19deg);
+}
+
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages {
   left: 50%;
-  bottom: 1.08rem;
+  bottom: 1.12rem;
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.18rem;
@@ -6085,6 +6227,8 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__vessel,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__retort,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__aura--solve,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__fish,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__thread--descent {
   opacity: 1;
@@ -6093,11 +6237,18 @@ h3 {
     0 0 1.75rem rgba(83, 216, 232, 0.18);
 }
 
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__retort {
+  box-shadow: 0 0 1.6rem rgba(83, 216, 232, 0.2);
+  transform: translate(-50%, -50%) rotate(-12deg) scale(1.06);
+}
+
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="vessel"] .alchemical-vessel-instrument__fish {
   transform: translate(-34%, -50%) rotate(-4deg) scale(1.08);
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__bath,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__aura--solve,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__aura--coagula,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__magnet,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="prima"] .alchemical-vessel-instrument__particle {
   opacity: 1;
@@ -6129,6 +6280,8 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__stages,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__heat,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__flame,
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__plough,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__lapis,
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__thread--ascent {
   opacity: 1;
@@ -6141,6 +6294,17 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__heat {
   transform: translateX(-50%) scaleX(1.18);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__flame {
+  filter: blur(0);
+  transform: translateX(-50%) scaleY(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__plough {
+  border-color: rgba(255, 227, 156, 0.48);
+  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.16);
+  transform: translateX(-39%) rotate(-4deg);
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument[data-active-panel="opus"] .alchemical-vessel-instrument__lapis {
@@ -9910,12 +10074,16 @@ h3 {
 		  .ambivalent-fish-instrument__shadow-core,
 		  .ambivalent-fish-instrument__charge,
 		  .alchemical-vessel-instrument__field,
+		  .alchemical-vessel-instrument__aura,
 		  .alchemical-vessel-instrument__heat,
+		  .alchemical-vessel-instrument__flame,
+		  .alchemical-vessel-instrument__retort,
 		  .alchemical-vessel-instrument__vessel,
 		  .alchemical-vessel-instrument__bath,
 		  .alchemical-vessel-instrument__fish,
 		  .alchemical-vessel-instrument__magnet,
 		  .alchemical-vessel-instrument__lapis,
+		  .alchemical-vessel-instrument__plough,
 			  .alchemical-vessel-instrument__thread,
 			  .alchemical-vessel-instrument__particle,
 			  .alchemical-vessel-instrument__stages,
@@ -10042,12 +10210,16 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__field,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura,
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__heat,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__flame,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort,
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel,
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath,
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish,
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet,
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis,
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough,
 		  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread,
 		  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__particle,
 		  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages {
@@ -12153,7 +12325,7 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument {
-	    min-height: 6.65rem;
+	    min-height: 7.1rem;
 	    margin-top: 0.66rem;
 	  }
 
@@ -12162,12 +12334,27 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel {
-	    width: 4.9rem;
-	    height: 4.35rem;
+	    width: 5.3rem;
+	    height: 4.55rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura {
+	    width: 8.3rem;
+	    height: 4.5rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura--coagula {
+	    width: 6.9rem;
+	    height: 3.85rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort {
+	    width: 3.45rem;
+	    height: 3.45rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath {
-	    width: 3.85rem;
+	    width: 4.15rem;
 	    height: 1rem;
 	  }
 
@@ -12185,6 +12372,17 @@ h3 {
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis {
 	    left: 74%;
 	    width: 0.92rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__flame {
+	    width: 2rem;
+	    height: 2.12rem;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough {
+	    left: 28%;
+	    width: 3.45rem;
+	    height: 0.92rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread {

--- a/src/visualizations/chapters/ch10/ThreeAlchemyViz.js
+++ b/src/visualizations/chapters/ch10/ThreeAlchemyViz.js
@@ -25,10 +25,11 @@ const ECHENEIS_CYAN = new THREE.Color('#22d3ee');
 const SHIP_GREY = new THREE.Color('#3a3a4a');
 const MAGNET_PURPLE = new THREE.Color('#6a2c91');
 const LAPIS_GOLD = new THREE.Color('#d4af37');
+const FIRE_ORANGE = new THREE.Color('#ff8a3d');
 const YOKE_BROWN = new THREE.Color('#8b6914');
 const VOID = 0x030308;
 
-const MAGNET_PARTICLES = 200;
+const MAGNET_PARTICLES = 260;
 
 export default class ThreeAlchemyViz extends BaseViz {
     constructor(container, opts = {}) {
@@ -37,6 +38,8 @@ export default class ThreeAlchemyViz extends BaseViz {
         this.vesselFocus = 1;
         this.primaFocus = 0;
         this.opusFocus = 0;
+        this.labMaterials = [];
+        this.labStageStones = [];
         this.reducedMotion = false;
     }
 
@@ -74,14 +77,29 @@ export default class ThreeAlchemyViz extends BaseViz {
         this._createLapisAnimatus();
         this._createYokedFish();
         this._createAlchemicalGround();
+        this._createLaboratoryField();
         this._createLights();
 
         this.composer = new EffectComposer(this.renderer);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(this.width, this.height), 1.2, 0.5, 0.4
+            new THREE.Vector2(this.width, this.height), 1.35, 0.48, 0.32
         );
         this.composer.addPass(this.bloomPass);
+    }
+
+    _makeLabMaterial({ color, opacity = 0.45, additive = true, side = THREE.DoubleSide, wireframe = false }) {
+        const mat = new THREE.MeshBasicMaterial({
+            color,
+            transparent: true,
+            opacity,
+            side,
+            wireframe,
+            blending: additive ? THREE.AdditiveBlending : THREE.NormalBlending,
+            depthWrite: false,
+        });
+        this.labMaterials.push(mat);
+        return mat;
     }
 
     _createEcheneis() {
@@ -89,8 +107,8 @@ export default class ThreeAlchemyViz extends BaseViz {
         const bodyGeo = new THREE.SphereGeometry(0.1, 10, 8);
         bodyGeo.scale(2, 0.5, 0.4);
         const bodyMat = new THREE.MeshStandardMaterial({
-            color: ECHENEIS_CYAN, emissive: ECHENEIS_CYAN, emissiveIntensity: 0.8,
-            transparent: true, opacity: 0.8,
+            color: ECHENEIS_CYAN, emissive: ECHENEIS_CYAN, emissiveIntensity: 1.2,
+            transparent: true, opacity: 0.88,
         });
         this.echeneisBody = new THREE.Mesh(bodyGeo, bodyMat);
         this.echeneisGroup.add(this.echeneisBody);
@@ -98,12 +116,12 @@ export default class ThreeAlchemyViz extends BaseViz {
         // Aura of stopping power
         const auraGeo = new THREE.SphereGeometry(0.5, 12, 12);
         this.echeneisAura = new THREE.Mesh(auraGeo, new THREE.MeshBasicMaterial({
-            color: ECHENEIS_CYAN, transparent: true, opacity: 0.05,
+            color: ECHENEIS_CYAN, transparent: true, opacity: 0.09,
             blending: THREE.AdditiveBlending,
         }));
         this.echeneisGroup.add(this.echeneisAura);
 
-        this.echeneisGroup.position.set(-4, 2, 1);
+        this.echeneisGroup.position.set(-4.2, 2.1, 1);
         this.scene.add(this.echeneisGroup);
     }
 
@@ -164,7 +182,7 @@ export default class ThreeAlchemyViz extends BaseViz {
         const geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
         this.magnetField = new THREE.Points(geo, new THREE.PointsMaterial({
-            color: MAGNET_PURPLE, size: 0.08, transparent: true, opacity: 0.5,
+            color: ECHENEIS_CYAN, size: 0.095, transparent: true, opacity: 0.52,
             blending: THREE.AdditiveBlending, depthWrite: false,
         }));
         this.scene.add(this.magnetField);
@@ -172,8 +190,8 @@ export default class ThreeAlchemyViz extends BaseViz {
         // Magnet core
         const magnetGeo = new THREE.OctahedronGeometry(0.3, 0);
         this.magnetCore = new THREE.Mesh(magnetGeo, new THREE.MeshStandardMaterial({
-            color: MAGNET_PURPLE, emissive: MAGNET_PURPLE, emissiveIntensity: 0.6,
-            transparent: true, opacity: 0.7,
+            color: MAGNET_PURPLE, emissive: MAGNET_PURPLE, emissiveIntensity: 0.9,
+            transparent: true, opacity: 0.78,
         }));
         this.magnetCore.position.set(3, -1, 1);
         this.scene.add(this.magnetCore);
@@ -184,8 +202,8 @@ export default class ThreeAlchemyViz extends BaseViz {
 
         const stoneGeo = new THREE.DodecahedronGeometry(0.5, 0);
         const stoneMat = new THREE.MeshStandardMaterial({
-            color: LAPIS_GOLD, emissive: LAPIS_GOLD, emissiveIntensity: 0.4,
-            metalness: 0.7, roughness: 0.2, transparent: true, opacity: 0.7,
+            color: LAPIS_GOLD, emissive: LAPIS_GOLD, emissiveIntensity: 0.75,
+            metalness: 0.68, roughness: 0.18, transparent: true, opacity: 0.82,
         });
         this.lapisStone = new THREE.Mesh(stoneGeo, stoneMat);
         this.lapisGroup.add(this.lapisStone);
@@ -198,21 +216,87 @@ export default class ThreeAlchemyViz extends BaseViz {
         }));
         this.lapisGroup.add(this.heartAura);
 
-        this.lapisGroup.position.set(0, -2, 2);
+        this.lapisGroup.position.set(0, -1.18, 1.2);
         this.scene.add(this.lapisGroup);
 
-        const vesselGeo = new THREE.SphereGeometry(1.25, 28, 18);
+        const vesselGeo = new THREE.SphereGeometry(1.7, 36, 22);
         vesselGeo.scale(1.15, 1.35, 1);
         this.vesselGlass = new THREE.Mesh(vesselGeo, new THREE.MeshBasicMaterial({
             color: 0x9fdcff,
             transparent: true,
-            opacity: 0.035,
+            opacity: 0.075,
             blending: THREE.AdditiveBlending,
             wireframe: true,
             depthWrite: false,
         }));
         this.vesselGlass.position.copy(this.lapisGroup.position);
         this.scene.add(this.vesselGlass);
+    }
+
+    _createLaboratoryField() {
+        this.labField = new THREE.Group();
+        this.labField.position.set(0, -1.1, 0.4);
+
+        const retortGeo = new THREE.TorusGeometry(1.95, 0.018, 12, 128);
+        this.retortOuter = new THREE.Mesh(retortGeo, this._makeLabMaterial({ color: ECHENEIS_CYAN, opacity: 0.34 }));
+        this.retortOuter.scale.set(1.18, 0.72, 1);
+        this.retortOuter.rotation.z = -0.18;
+        this.labField.add(this.retortOuter);
+
+        this.retortInner = new THREE.Mesh(retortGeo, this._makeLabMaterial({ color: LAPIS_GOLD, opacity: 0.28 }));
+        this.retortInner.scale.set(0.82, 0.5, 1);
+        this.retortInner.rotation.z = 0.28;
+        this.labField.add(this.retortInner);
+
+        const crucibleGeo = new THREE.CylinderGeometry(1.28, 1.72, 1.75, 48, 1, true);
+        this.crucible = new THREE.Mesh(crucibleGeo, this._makeLabMaterial({ color: ECHENEIS_CYAN, opacity: 0.1, side: THREE.DoubleSide, wireframe: true }));
+        this.crucible.position.y = -0.32;
+        this.crucible.scale.set(1.06, 1.08, 0.72);
+        this.labField.add(this.crucible);
+
+        const flameGeo = new THREE.ConeGeometry(1.18, 2.36, 40, 1, true);
+        this.alembicFlame = new THREE.Mesh(flameGeo, this._makeLabMaterial({ color: FIRE_ORANGE, opacity: 0.18, side: THREE.DoubleSide }));
+        this.alembicFlame.position.y = -2.18;
+        this.alembicFlame.rotation.x = Math.PI;
+        this.labField.add(this.alembicFlame);
+
+        const linePositions = new Float32Array([
+            -4.2, 3.2, 0.2, -1.34, 0.15, 0.2,
+            -1.34, 0.15, 0.2, 0, -0.2, 0.2,
+            0, -0.2, 0.2, 2.9, 0.35, 0.2,
+            -3.5, -2.68, 0.2, 3.5, -2.68, 0.2,
+        ]);
+        const lineGeo = new THREE.BufferGeometry();
+        lineGeo.setAttribute('position', new THREE.BufferAttribute(linePositions, 3));
+        this.labThreads = new THREE.LineSegments(lineGeo, new THREE.LineBasicMaterial({
+            color: LAPIS_GOLD,
+            transparent: true,
+            opacity: 0.24,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+        }));
+        this.labField.add(this.labThreads);
+
+        const stageColors = [NIGREDO_BLACK, ALBEDO_WHITE, CITRINITAS, RUBEDO_RED];
+        stageColors.forEach((color, index) => {
+            const stage = new THREE.Mesh(
+                new THREE.SphereGeometry(0.17, 18, 12),
+                new THREE.MeshStandardMaterial({
+                    color,
+                    emissive: color,
+                    emissiveIntensity: index === 0 ? 0.18 : 0.55,
+                    metalness: 0.4,
+                    roughness: 0.22,
+                    transparent: true,
+                    opacity: 0.78,
+                }),
+            );
+            stage.position.set(-2.25 + index * 1.5, -2.7, 0.58);
+            this.labStageStones.push(stage);
+            this.labField.add(stage);
+        });
+
+        this.scene.add(this.labField);
     }
 
     _createYokedFish() {
@@ -252,7 +336,7 @@ export default class ThreeAlchemyViz extends BaseViz {
         for (let i = 0; i < 4; i++) {
             const stripGeo = new THREE.PlaneGeometry(4, 1);
             const stripMat = new THREE.MeshBasicMaterial({
-                color: stages[i], transparent: true, opacity: 0.06,
+                color: stages[i], transparent: true, opacity: 0.085,
                 side: THREE.DoubleSide,
             });
             const strip = new THREE.Mesh(stripGeo, stripMat);
@@ -264,18 +348,22 @@ export default class ThreeAlchemyViz extends BaseViz {
     }
 
     _createLights() {
-        this.scene.add(new THREE.AmbientLight(0x0a0a15, 0.3));
-        const echeneisLight = new THREE.PointLight(0x22d3ee, 0.6, 12);
+        this.scene.add(new THREE.AmbientLight(0x0a0a15, 0.42));
+        const echeneisLight = new THREE.PointLight(0x22d3ee, 0.85, 12);
         echeneisLight.position.set(-4, 3, 3);
         this.scene.add(echeneisLight);
 
-        const magnetLight = new THREE.PointLight(0x6a2c91, 0.5, 15);
+        const magnetLight = new THREE.PointLight(0x6a2c91, 0.68, 15);
         magnetLight.position.set(3, -2, 3);
         this.scene.add(magnetLight);
 
-        const lapisLight = new THREE.PointLight(0xd4af37, 0.4, 10);
-        lapisLight.position.set(0, -2, 3);
+        const lapisLight = new THREE.PointLight(0xd4af37, 0.78, 12);
+        lapisLight.position.set(0, -1.2, 3);
         this.scene.add(lapisLight);
+
+        const fireLight = new THREE.PointLight(0xff8a3d, 0.52, 9);
+        fireLight.position.set(0, -3.1, 2.2);
+        this.scene.add(fireLight);
     }
 
     update(dt) {
@@ -293,8 +381,8 @@ export default class ThreeAlchemyViz extends BaseViz {
         this.echeneisGroup.position.x = -3 + Math.sin(t * 0.08 * motionScale) * 0.3;
         this.echeneisGroup.position.y = 2 + Math.sin(t * 0.15 * motionScale) * 0.2;
         this.echeneisGroup.scale.setScalar(0.88 + this.vesselFocus * 0.28);
-        this.echeneisBody.material.opacity = 0.36 + this.vesselFocus * 0.5;
-        this.echeneisAura.material.opacity = (0.03 + Math.sin(t * 0.6 * motionScale) * 0.02) + this.vesselFocus * 0.13;
+        this.echeneisBody.material.opacity = 0.42 + this.vesselFocus * 0.5;
+        this.echeneisAura.material.opacity = (0.06 + Math.sin(t * 0.6 * motionScale) * 0.02) + this.vesselFocus * 0.15;
 
         // Ship halted — only rocking
         this.shipGroup.rotation.z = Math.sin(t * 0.12 * motionScale) * 0.03;
@@ -325,22 +413,52 @@ export default class ThreeAlchemyViz extends BaseViz {
             }
         }
         this.magnetField.geometry.attributes.position.needsUpdate = true;
-        this.magnetField.material.opacity = 0.16 + this.primaFocus * 0.55;
+        this.magnetField.material.opacity = 0.2 + this.primaFocus * 0.58;
         this.magnetCore.rotation.y = t * 0.1 * motionScale;
         this.magnetCore.scale.setScalar(0.72 + this.primaFocus * 0.5);
-        this.magnetCore.material.opacity = 0.28 + this.primaFocus * 0.56;
+        this.magnetCore.material.opacity = 0.32 + this.primaFocus * 0.58;
 
         // Lapis heartbeat — systole/diastole
         const heartbeat = Math.sin(t * 2 * motionScale); // Fast pulse
         const pulse = heartbeat > 0.7 ? 1 : 0; // Sharp beat
         this.lapisStone.scale.setScalar(0.82 + this.primaFocus * 0.16 + this.opusFocus * 0.22 + pulse * 0.15);
-        this.lapisStone.material.opacity = 0.3 + this.primaFocus * 0.22 + this.opusFocus * 0.32;
-        this.lapisStone.material.emissiveIntensity = 0.22 + this.opusFocus * 0.38 + pulse * 0.5;
-        this.heartAura.material.opacity = pulse * (0.04 + this.opusFocus * 0.08);
+        this.lapisStone.material.opacity = 0.44 + this.primaFocus * 0.2 + this.opusFocus * 0.34;
+        this.lapisStone.material.emissiveIntensity = 0.38 + this.opusFocus * 0.46 + pulse * 0.5;
+        this.heartAura.material.opacity = pulse * (0.06 + this.opusFocus * 0.1);
         this.heartAura.scale.setScalar(1 + pulse * 0.5 + this.opusFocus * 0.2);
         this.lapisStone.rotation.y = t * 0.05 * motionScale;
-        this.vesselGlass.material.opacity = 0.02 + this.vesselFocus * 0.04 + this.primaFocus * 0.04 + this.opusFocus * 0.05;
+        this.vesselGlass.material.opacity = 0.04 + this.vesselFocus * 0.055 + this.primaFocus * 0.045 + this.opusFocus * 0.055;
         this.vesselGlass.rotation.y = -t * 0.025 * motionScale;
+
+        if (this.labField) {
+            this.labField.rotation.y = Math.sin(t * 0.08 * motionScale) * 0.08 + this.mouseSmooth.x * 0.05;
+            this.labField.scale.setScalar(1 + this.vesselFocus * 0.03 + this.opusFocus * 0.04);
+        }
+        if (this.retortOuter) {
+            this.retortOuter.rotation.z = -0.18 + Math.sin(t * 0.14 * motionScale) * 0.08;
+            this.retortOuter.material.opacity = 0.24 + this.vesselFocus * 0.18 + this.primaFocus * 0.08;
+        }
+        if (this.retortInner) {
+            this.retortInner.rotation.z = 0.28 - Math.sin(t * 0.12 * motionScale) * 0.08;
+            this.retortInner.material.opacity = 0.2 + this.opusFocus * 0.2 + this.primaFocus * 0.08;
+        }
+        if (this.crucible) {
+            this.crucible.material.opacity = 0.08 + this.vesselFocus * 0.05 + this.primaFocus * 0.05 + this.opusFocus * 0.05;
+        }
+        if (this.alembicFlame) {
+            this.alembicFlame.scale.set(1 + this.opusFocus * 0.1, 0.74 + this.opusFocus * 0.44 + Math.sin(t * 1.3 * motionScale) * 0.04, 1);
+            this.alembicFlame.material.opacity = 0.12 + this.opusFocus * 0.22;
+        }
+        if (this.labThreads) {
+            this.labThreads.material.opacity = 0.18 + this.vesselFocus * 0.08 + this.opusFocus * 0.16;
+        }
+        this.labStageStones?.forEach((stage, index) => {
+            const stageLift = index / Math.max(this.labStageStones.length - 1, 1);
+            stage.position.y = -2.7 + this.opusFocus * 0.2 * stageLift + Math.sin(t * 0.6 * motionScale + index) * 0.025;
+            stage.scale.setScalar(0.88 + this.opusFocus * (0.18 + stageLift * 0.2));
+            stage.material.opacity = 0.6 + this.opusFocus * 0.28;
+            stage.material.emissiveIntensity = 0.32 + this.opusFocus * (0.32 + stageLift * 0.22);
+        });
 
         // Yoked fish ploughing across stages
         this.yokeGroup.position.x = -5 + ((t * 0.2 * motionScale * (0.5 + this.opusFocus)) % 14);
@@ -356,12 +474,12 @@ export default class ThreeAlchemyViz extends BaseViz {
 
         // Camera
         const camAngle = t * 0.015 * motionScale + this.mouseSmooth.x * 0.3;
-        const camH = 2 + this.mouseSmooth.y * 3 - this.opusFocus * 0.6;
-        const camRadius = 14 - this.vesselFocus * 1.2 - this.primaFocus * 0.6 + this.opusFocus * 0.8;
+        const camH = 1.65 + this.mouseSmooth.y * 2.4 - this.opusFocus * 0.45;
+        const camRadius = 12.3 - this.vesselFocus * 0.95 - this.primaFocus * 0.46 + this.opusFocus * 0.7;
         this.camera.position.set(Math.sin(camAngle) * camRadius, camH, Math.cos(camAngle) * camRadius);
-        this.camera.lookAt(this.primaFocus * 1.2 - this.vesselFocus * 0.8, -0.5 - this.opusFocus * 0.8, 0);
+        this.camera.lookAt(this.primaFocus * 0.74 - this.vesselFocus * 0.34, -0.86 - this.opusFocus * 0.58, 0.2);
 
-        if (this.bloomPass) this.bloomPass.strength = 0.95 + Math.sin(t * 0.1 * motionScale) * 0.2 + this.vesselFocus * 0.2 + this.opusFocus * 0.18;
+        if (this.bloomPass) this.bloomPass.strength = 1.08 + Math.sin(t * 0.1 * motionScale) * 0.18 + this.vesselFocus * 0.18 + this.opusFocus * 0.24;
     }
 
     render() { this.composer?.render(); }


### PR DESCRIPTION
## Summary
- turn Chapter 10's Three.js scene into a brighter alchemical laboratory with a central vessel field, retort rings, flame, opus stones, stronger lapis glow, and richer particle flow
- add static/reduced-motion teaching marks to the Chapter 10 alchemical vessel instrument: solve/coagula auras, retort, flame, and plough
- tighten app-shell smoke coverage for Chapter 10 markers, mobile canvas geometry, page errors, and failed requests while ignoring normal route-change aborts

## Skill stack
- Aion skill-routing playbook
- orchestration-autopilot subagent lanes
- frontend-design-pro and high-end-visual-design direction
- storytelling-web visual-first narrative framing
- Browser/Playwright visual QA
- accessibility and webapp smoke testing
- GitHub publish flow

## Routes changed
- /journey/chapter/ch10

## Visual thesis
Chapter 10 should read as an alchemical laboratory before the reader studies the panels: the fish enters a glass vessel, prima materia rises through a charged field, and the opus line visibly transforms toward the lapis.

## Browser evidence
- local desktop, mobile, and 320px narrow inspections for /journey/chapter/ch10
- desktop canvas sample: 784 visible pixels; mobile canvas sample: 400 visible pixels
- no console errors, no unexpected network/404 failures, no horizontal overflow
- regenerated Control Tower screenshots under ignored test-results/control-tower/latest/

## Checks
- node --check src/visualizations/chapters/ch10/ThreeAlchemyViz.js
- node --check scripts/testing/app-shell-smoke.mjs
- npm run build
- git diff --check
- AION_SMOKE_PORT=4192 node scripts/testing/app-shell-smoke.mjs --shard=scene-controls
- AION_SMOKE_PORT=4193 node scripts/testing/app-shell-smoke.mjs --shard=mobile (failed once due over-strict net::ERR_ABORTED watcher; fixed and reran)
- AION_SMOKE_PORT=4195 node scripts/testing/app-shell-smoke.mjs --shard=mobile
- AION_SMOKE_PORT=4194 node scripts/testing/app-shell-smoke.mjs --shard=chapter-routes
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run test:app
- npm run ci:chapter-shell
- AION_A11Y_PORT=4197 npm run test:a11y:app
- npm test
- AION_SMOKE_PORT=4198 node scripts/testing/app-shell-smoke.mjs --shard=foundation
- AION_VISUAL_QA_PORT=4199 npm run test:visual:control-tower
- npm run build:pages && npm run test:pages:artifact

## Residual debt
- next visual candidates from scout lanes: Chapter 8 historical fish strata, Chapters 2-4 psyche arc, and support-route follow-up passes
- existing large three.js vendor chunk warning remains a project-level performance backlog
