### PR TITLE
[codex] Restore chapter eleven scene field

### DIFF
--- a/scripts/testing/app-accessibility-smoke.mjs
+++ b/scripts/testing/app-accessibility-smoke.mjs
@@ -795,7 +795,7 @@ async function checkChapterElevenDynamicAccessibility(page, failures) {
   const initialDescription = await page.locator('#scene-host-description-ch11').textContent();
 
   if (!instrumentVisible) failures.push('/journey/chapter/ch11: philosophical tree instrument is missing an accessible image role');
-  if (!initialInstrumentLabel?.includes('Current emphasis: Mediator') || !initialInstrumentLabel?.includes('Mercurius holds the middle')) failures.push(`/journey/chapter/ch11: initial instrument label mismatch: ${initialInstrumentLabel}`);
+  if (!initialInstrumentLabel?.includes('Current emphasis: Mediator') || !initialInstrumentLabel?.includes('Mercurius holds the middle') || !initialInstrumentLabel?.includes('mirror returns the image')) failures.push(`/journey/chapter/ch11: initial instrument label mismatch: ${initialInstrumentLabel}`);
   if (!initialDescription?.includes('Mediator: The slippery middle')) failures.push(`/journey/chapter/ch11: initial scene description mismatch: ${initialDescription}`);
 
   const opus = page.getByRole('button', { name: /02\s+Opus/ });

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -1224,7 +1224,7 @@ async function smokeReducedMotion(browser, failures) {
   const chapterElevenInstrumentCount = await page.locator('.alchemical-tree-instrument').count();
   const chapterElevenInstrumentBox = await page.locator('.alchemical-tree-instrument').boundingBox();
   const chapterElevenReferenceMapBox = await page.locator('.chapter-stage__reference-map').boundingBox();
-  const chapterElevenInstrumentMotion = await page.locator('.alchemical-tree-instrument__field, .alchemical-tree-instrument__root, .alchemical-tree-instrument__trunk, .alchemical-tree-instrument__branch, .alchemical-tree-instrument__thread, .alchemical-tree-instrument__mercurius, .alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__stone, .alchemical-tree-instrument__reflection').evaluateAll((nodes) => nodes.map((node) => {
+  const chapterElevenInstrumentMotion = await page.locator('.alchemical-tree-instrument__field, .alchemical-tree-instrument__halo, .alchemical-tree-instrument__root, .alchemical-tree-instrument__trunk, .alchemical-tree-instrument__branch, .alchemical-tree-instrument__thread, .alchemical-tree-instrument__mercurius, .alchemical-tree-instrument__seed, .alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__stone, .alchemical-tree-instrument__mirror, .alchemical-tree-instrument__reflection').evaluateAll((nodes) => nodes.map((node) => {
     const styles = window.getComputedStyle(node);
     return {
       animationName: styles.animationName,
@@ -2700,9 +2700,12 @@ async function smokeChapterSceneControls(page, failures) {
   const chapterElevenInstrumentStageCount = await page.locator('.alchemical-tree-instrument__stage').count();
   const chapterElevenInstrumentRootCount = await page.locator('.alchemical-tree-instrument__root').count();
   const chapterElevenInstrumentBranchCount = await page.locator('.alchemical-tree-instrument__branch').count();
+  const chapterElevenInstrumentHaloCount = await page.locator('.alchemical-tree-instrument__halo').count();
+  const chapterElevenInstrumentSeedCount = await page.locator('.alchemical-tree-instrument__seed').count();
+  const chapterElevenInstrumentMirrorCount = await page.locator('.alchemical-tree-instrument__mirror').count();
   const chapterElevenInstrumentLabelCount = await page.locator('.alchemical-tree-instrument__label').count();
   const chapterElevenInitialDescription = await page.locator('#scene-host-description-ch11').textContent();
-  const chapterElevenInstrumentMarksVisible = await page.locator('.alchemical-tree-instrument__field, .alchemical-tree-instrument__root, .alchemical-tree-instrument__trunk, .alchemical-tree-instrument__branch, .alchemical-tree-instrument__thread, .alchemical-tree-instrument__mercurius, .alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__stone, .alchemical-tree-instrument__reflection').evaluateAll((nodes) => nodes.length >= 18 && nodes.every((node) => {
+  const chapterElevenInstrumentMarksVisible = await page.locator('.alchemical-tree-instrument__field, .alchemical-tree-instrument__halo, .alchemical-tree-instrument__root, .alchemical-tree-instrument__trunk, .alchemical-tree-instrument__branch, .alchemical-tree-instrument__thread, .alchemical-tree-instrument__mercurius, .alchemical-tree-instrument__seed, .alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__stone, .alchemical-tree-instrument__mirror, .alchemical-tree-instrument__reflection').evaluateAll((nodes) => nodes.length >= 22 && nodes.every((node) => {
     const styles = window.getComputedStyle(node);
     const box = node.getBoundingClientRect();
     return styles.display !== 'none' && Number(styles.opacity) > 0 && box.width > 0 && box.height > 0;
@@ -2730,6 +2733,9 @@ async function smokeChapterSceneControls(page, failures) {
   if (chapterElevenInstrumentStageCount !== 4) failures.push(`chapter 11 alchemical tree stage count mismatch: ${chapterElevenInstrumentStageCount}`);
   if (chapterElevenInstrumentRootCount !== 3) failures.push(`chapter 11 alchemical tree root count mismatch: ${chapterElevenInstrumentRootCount}`);
   if (chapterElevenInstrumentBranchCount !== 2) failures.push(`chapter 11 alchemical tree branch count mismatch: ${chapterElevenInstrumentBranchCount}`);
+  if (chapterElevenInstrumentHaloCount !== 1) failures.push(`chapter 11 alchemical tree halo count mismatch: ${chapterElevenInstrumentHaloCount}`);
+  if (chapterElevenInstrumentSeedCount !== 2) failures.push(`chapter 11 alchemical tree seed count mismatch: ${chapterElevenInstrumentSeedCount}`);
+  if (chapterElevenInstrumentMirrorCount !== 1) failures.push(`chapter 11 alchemical tree mirror count mismatch: ${chapterElevenInstrumentMirrorCount}`);
   if (chapterElevenInstrumentLabelCount !== 3) failures.push(`chapter 11 alchemical tree label count mismatch: ${chapterElevenInstrumentLabelCount}`);
   if (chapterElevenInstrumentRole !== 'img') failures.push(`chapter 11 alchemical tree instrument role mismatch: ${chapterElevenInstrumentRole}`);
   if (!chapterElevenInstrumentLabel?.includes('Philosophical tree model') || !chapterElevenInstrumentLabel?.includes('Mercurius holds the middle') || !chapterElevenInstrumentLabel?.includes('Current emphasis: Mediator')) {
@@ -2751,14 +2757,14 @@ async function smokeChapterSceneControls(page, failures) {
   const opusWheelDescription = await page.locator('#scene-host-description-ch11').textContent();
   const opusWheelInstrumentPanel = await chapterElevenInstrument.getAttribute('data-active-panel');
   const opusWheelInstrumentLabel = await chapterElevenInstrument.getAttribute('aria-label');
-  const opusWheelVisualState = await page.locator('.alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__thread').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  const opusWheelVisualState = await page.locator('.alchemical-tree-instrument__wheel, .alchemical-tree-instrument__stage, .alchemical-tree-instrument__thread, .alchemical-tree-instrument__halo').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   if (opusWheelPressed !== 'true') failures.push(`chapter 11 opus wheel reference did not become active: ${opusWheelPressed}`);
   if (opusWheelPanelActive !== 1) failures.push(`chapter 11 opus wheel panel did not become active: ${opusWheelPanelActive}`);
   if (opusWheelInstrumentPanel !== 'opus-wheel') failures.push(`chapter 11 alchemical tree instrument did not follow opus wheel panel: ${opusWheelInstrumentPanel}`);
   if (!opusWheelInstrumentLabel?.includes('Current emphasis: Opus') || !opusWheelInstrumentLabel?.includes('Change returns to deepen itself')) {
     failures.push(`chapter 11 alchemical tree instrument label did not follow opus panel: ${opusWheelInstrumentLabel}`);
   }
-  if (opusWheelVisualState.length !== 7 || !opusWheelVisualState.every((opacity) => opacity >= 0.65)) {
+  if (opusWheelVisualState.length !== 8 || !opusWheelVisualState.every((opacity) => opacity >= 0.65)) {
     failures.push(`chapter 11 alchemical tree instrument did not visually emphasize opus wheel: ${opusWheelVisualState.join(',')}`);
   }
   if (!opusWheelDescription?.includes('Opus: Transformation repeats')) failures.push(`chapter 11 scene description did not follow opus panel: ${opusWheelDescription}`);
@@ -2773,7 +2779,7 @@ async function smokeChapterSceneControls(page, failures) {
   const stoneDescription = await page.locator('#scene-host-description-ch11').textContent();
   const stoneInstrumentPanel = await chapterElevenInstrument.getAttribute('data-active-panel');
   const stoneInstrumentLabel = await chapterElevenInstrument.getAttribute('aria-label');
-  const stoneVisualState = await page.locator('.alchemical-tree-instrument__stone, .alchemical-tree-instrument__reflection, .alchemical-tree-instrument__field').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
+  const stoneVisualState = await page.locator('.alchemical-tree-instrument__stone, .alchemical-tree-instrument__mirror, .alchemical-tree-instrument__reflection, .alchemical-tree-instrument__field, .alchemical-tree-instrument__seed--matter').evaluateAll((nodes) => nodes.map((node) => Number(window.getComputedStyle(node).opacity)));
   const chapterElevenScrollY = await page.evaluate(() => window.scrollY);
   if (stonePressed !== 'true') failures.push(`chapter 11 scene control did not become active: ${stonePressed}`);
   if (stonePanelActive !== 1) failures.push(`chapter 11 stone panel did not become active: ${stonePanelActive}`);
@@ -2781,7 +2787,7 @@ async function smokeChapterSceneControls(page, failures) {
   if (!stoneInstrumentLabel?.includes('Current emphasis: Stone') || !stoneInstrumentLabel?.includes('Completion keeps the opposites alive')) {
     failures.push(`chapter 11 alchemical tree instrument label did not follow stone panel: ${stoneInstrumentLabel}`);
   }
-  if (stoneVisualState.length !== 4 || !stoneVisualState.every((opacity) => opacity >= 0.65)) {
+  if (stoneVisualState.length !== 6 || !stoneVisualState.every((opacity) => opacity >= 0.65)) {
     failures.push(`chapter 11 alchemical tree instrument did not visually emphasize lapis: ${stoneVisualState.join(',')}`);
   }
   if (!stoneDescription?.includes('Stone: The goal is a formed paradox')) failures.push(`chapter 11 scene description did not follow stone panel: ${stoneDescription}`);

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -77,7 +77,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const historicalStrataInstrumentLabel = `Historical strata model: five translucent layers accumulate around the fish motif, an early Christian carrier image gathers the symbol into a readable form, and older meanings keep speaking below later interpretation. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const ambivalentFishInstrumentLabel = `Ambivalent fish model: one fish-symbol carries blessing and threat across a split field, an ouroboric return shows opposition circling back into itself, and the shadow fish keeps the Antichrist counter-pole inside the total image. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const alchemicalVesselInstrumentLabel = `Alchemical vessel model: the fish-symbol enters a sealed vessel, prima materia gathers as unsettled particles, heat presses the image through four opus stages, and a lapis point appears as transformation takes form. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
-  const alchemicalTreeInstrumentLabel = `Philosophical tree model: Mercurius holds the middle between matter and spirit, the opus wheel repeats transformation, and the lapis Coniunctio holds a formed union of opposites. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
+  const alchemicalTreeInstrumentLabel = `Philosophical tree model: Mercurius holds the middle between matter and spirit, an inverted root-and-branch tree makes the opus visible, the mirror returns the image to the psyche, and the lapis Coniunctio holds a formed union of opposites. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const amplificationLensInstrumentLabel = `Amplification lens model: a disciplined symbolic lens holds religious image, alchemical image, and psychic projection in relation; shared roots keep the traditions connected, and the bridge turns inherited images toward inner experience. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const gnosticConstellationInstrumentLabel = `Gnostic constellation model: emanation rings move from fullness into differentiated images, a symbolic fourfold pattern makes the Self readable, and a rupture field keeps wisdom and fall in tension. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
 
@@ -324,6 +324,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
             >
               <span className="alchemical-tree-instrument__field alchemical-tree-instrument__field--above" aria-hidden="true" />
               <span className="alchemical-tree-instrument__field alchemical-tree-instrument__field--below" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__halo" aria-hidden="true" />
               <span className="alchemical-tree-instrument__root alchemical-tree-instrument__root--one" aria-hidden="true" />
               <span className="alchemical-tree-instrument__root alchemical-tree-instrument__root--two" aria-hidden="true" />
               <span className="alchemical-tree-instrument__root alchemical-tree-instrument__root--three" aria-hidden="true" />
@@ -333,12 +334,15 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               <span className="alchemical-tree-instrument__thread alchemical-tree-instrument__thread--ascent" aria-hidden="true" />
               <span className="alchemical-tree-instrument__thread alchemical-tree-instrument__thread--descent" aria-hidden="true" />
               <span className="alchemical-tree-instrument__mercurius" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__seed alchemical-tree-instrument__seed--spirit" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__seed alchemical-tree-instrument__seed--matter" aria-hidden="true" />
               <span className="alchemical-tree-instrument__wheel" aria-hidden="true">
                 {alchemicalTreeStages.map((stage) => (
                   <span key={stage} className={`alchemical-tree-instrument__stage alchemical-tree-instrument__stage--${stage}`} />
                 ))}
               </span>
               <span className="alchemical-tree-instrument__stone" aria-hidden="true" />
+              <span className="alchemical-tree-instrument__mirror" aria-hidden="true" />
               <span className="alchemical-tree-instrument__reflection" aria-hidden="true" />
               <span className="alchemical-tree-instrument__label alchemical-tree-instrument__label--mercurius" aria-hidden="true">Mercurius</span>
               <span className="alchemical-tree-instrument__label alchemical-tree-instrument__label--opus" aria-hidden="true">opus wheel</span>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -6429,20 +6429,22 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument {
   position: relative;
-  width: min(31rem, 100%);
-  min-height: clamp(7.3rem, 11vh, 8.35rem);
+  width: min(33rem, 100%);
+  min-height: clamp(8.65rem, 13.5vh, 9.85rem);
   overflow: hidden;
   margin-top: 0.78rem;
   border: 1px solid rgba(244, 240, 232, 0.12);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 28% 52%, rgba(83, 216, 232, 0.12), transparent 4.9rem),
-    radial-gradient(circle at 51% 48%, rgba(212, 175, 55, 0.15), transparent 4.6rem),
-    radial-gradient(circle at 75% 62%, rgba(181, 130, 255, 0.11), transparent 4.9rem),
-    linear-gradient(90deg, rgba(7, 8, 13, 0.86), rgba(11, 9, 12, 0.72) 48%, rgba(12, 7, 18, 0.62));
+    radial-gradient(circle at 26% 62%, rgba(83, 216, 232, 0.18), transparent 5.8rem),
+    radial-gradient(circle at 50% 48%, rgba(212, 175, 55, 0.22), transparent 5.6rem),
+    radial-gradient(circle at 77% 56%, rgba(255, 111, 82, 0.12), transparent 5.2rem),
+    radial-gradient(circle at 72% 68%, rgba(181, 130, 255, 0.12), transparent 5rem),
+    linear-gradient(90deg, rgba(7, 8, 13, 0.9), rgba(11, 9, 12, 0.76) 48%, rgba(18, 8, 16, 0.68));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.24);
+    0 1.5rem 4.6rem rgba(0, 0, 0, 0.28),
+    0 0 3rem rgba(212, 175, 55, 0.06);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::before,
@@ -6469,14 +6471,17 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__halo,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mirror,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
   position: absolute;
@@ -6485,10 +6490,10 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field {
   left: 50%;
-  width: 74%;
-  height: 3.2rem;
+  width: 78%;
+  height: 3.72rem;
   border-radius: 50%;
-  opacity: 0.5;
+  opacity: 0.6;
   transform: translateX(-50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6496,24 +6501,46 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field--above {
-  top: 0.75rem;
-  background: radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.12), transparent 70%);
+  top: 0.58rem;
+  background: radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.18), transparent 70%);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field--below {
-  bottom: 0.7rem;
-  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.13), transparent 70%);
+  bottom: 0.52rem;
+  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.18), transparent 70%);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__halo {
+  left: 50%;
+  top: 50%;
+  width: 13.8rem;
+  height: 7.4rem;
+  border: 1px solid rgba(255, 227, 156, 0.16);
+  border-radius: 50%;
+  opacity: 0.52;
+  box-shadow:
+    inset 0 0 2rem rgba(255, 227, 156, 0.06),
+    0 0 2.4rem rgba(83, 216, 232, 0.08);
+  transform: translate(-50%, -50%) rotate(-8deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk {
   left: 50%;
-  top: 16%;
-  width: 0.18rem;
-  height: 66%;
+  top: 11%;
+  width: 0.24rem;
+  height: 76%;
   border-radius: 999px;
-  background: linear-gradient(180deg, rgba(255, 227, 156, 0.72), rgba(143, 231, 237, 0.58));
-  box-shadow: 0 0 1rem rgba(83, 216, 232, 0.16);
-  opacity: 0.72;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(244, 240, 232, 0.95) 0 0.11rem, transparent 0.13rem),
+    linear-gradient(180deg, rgba(255, 227, 156, 0.86), rgba(143, 231, 237, 0.78));
+  box-shadow:
+    0 0 1.35rem rgba(83, 216, 232, 0.24),
+    0 0 1.05rem rgba(212, 175, 55, 0.18);
+  opacity: 0.82;
   transform: translateX(-50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6522,12 +6549,13 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root {
   left: 50%;
-  bottom: 1.12rem;
-  width: 7.8rem;
-  height: 2.05rem;
-  border-bottom: 1px solid rgba(83, 216, 232, 0.24);
+  bottom: 1.03rem;
+  width: 9.3rem;
+  height: 2.8rem;
+  border-bottom: 1px solid rgba(83, 216, 232, 0.34);
   border-radius: 50%;
-  opacity: 0.44;
+  opacity: 0.58;
+  filter: drop-shadow(0 0 0.72rem rgba(83, 216, 232, 0.14));
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -6538,23 +6566,24 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root--two {
-  width: 5.8rem;
+  width: 7.05rem;
   transform: translateX(-50%) rotate(16deg);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root--three {
-  width: 4.3rem;
+  width: 5.25rem;
   transform: translateX(-50%) rotate(0deg);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch {
   left: 50%;
-  top: 34%;
-  width: 8.4rem;
-  height: 2.85rem;
-  border-top: 1px solid rgba(255, 227, 156, 0.26);
+  top: 27%;
+  width: 9.9rem;
+  height: 3.15rem;
+  border-top: 1px solid rgba(255, 227, 156, 0.34);
   border-radius: 50%;
-  opacity: 0.44;
+  opacity: 0.58;
+  filter: drop-shadow(0 0 0.72rem rgba(212, 175, 55, 0.14));
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -6571,10 +6600,10 @@ h3 {
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread {
   left: 50%;
   top: 50%;
-  width: 12.6rem;
-  height: 4.6rem;
+  width: 14.8rem;
+  height: 5.35rem;
   border-radius: 50%;
-  opacity: 0.38;
+  opacity: 0.5;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
@@ -6582,21 +6611,21 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread--ascent {
-  border-top: 1px solid rgba(255, 227, 156, 0.24);
+  border-top: 1px solid rgba(255, 227, 156, 0.34);
   transform: translate(-50%, -50%) rotate(-12deg);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread--descent {
-  border-bottom: 1px solid rgba(83, 216, 232, 0.24);
+  border-bottom: 1px solid rgba(83, 216, 232, 0.34);
   transform: translate(-50%, -50%) rotate(12deg);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius {
   left: 50%;
   top: 48%;
-  width: 1.05rem;
-  height: 2.85rem;
-  border: 1px solid rgba(143, 231, 237, 0.36);
+  width: 1.16rem;
+  height: 3.34rem;
+  border: 1px solid rgba(143, 231, 237, 0.48);
   border-radius: 999px;
   background:
     radial-gradient(circle at 50% 18%, rgba(255, 227, 156, 0.94) 0 0.14rem, transparent 0.16rem),
@@ -6605,6 +6634,19 @@ h3 {
   box-shadow:
     inset 0 0 0.8rem rgba(143, 231, 237, 0.08),
     0 0 1.45rem rgba(83, 216, 232, 0.16);
+  opacity: 0.84;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed {
+  left: 50%;
+  width: 0.62rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
   opacity: 0.72;
   transform: translate(-50%, -50%);
   transition:
@@ -6613,10 +6655,22 @@ h3 {
     box-shadow 0.55s var(--motion-spring);
 }
 
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed--spirit {
+  top: 21%;
+  background: rgba(255, 227, 156, 0.92);
+  box-shadow: 0 0 1.1rem rgba(212, 175, 55, 0.34);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed--matter {
+  top: 75%;
+  background: rgba(83, 216, 232, 0.9);
+  box-shadow: 0 0 1.1rem rgba(83, 216, 232, 0.34);
+}
+
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel {
-  right: 14%;
-  top: 51%;
-  width: 4.9rem;
+  right: 11%;
+  top: 50%;
+  width: 5.65rem;
   aspect-ratio: 1;
   border: 1px solid rgba(255, 227, 156, 0.28);
   border-radius: 50%;
@@ -6626,7 +6680,7 @@ h3 {
   box-shadow:
     inset 0 0 1rem rgba(3, 3, 7, 0.7),
     0 0 1.55rem rgba(212, 175, 55, 0.14);
-  opacity: 0.68;
+  opacity: 0.74;
   transform: translateY(-50%);
   animation: alchemical-tree-wheel 18s linear infinite;
   transition:
@@ -6689,9 +6743,9 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone {
-  left: 27%;
+  left: 24%;
   top: 58%;
-  width: 1.28rem;
+  width: 1.5rem;
   aspect-ratio: 1;
   border: 1px solid rgba(255, 227, 156, 0.42);
   border-radius: 34%;
@@ -6702,7 +6756,7 @@ h3 {
   box-shadow:
     0 0 0 0.5rem rgba(212, 175, 55, 0.05),
     0 0 1.35rem rgba(212, 175, 55, 0.2);
-  opacity: 0.62;
+  opacity: 0.7;
   transform: translate(-50%, -50%) rotate(45deg) scale(0.9);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6710,17 +6764,38 @@ h3 {
     box-shadow 0.55s var(--motion-spring);
 }
 
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mirror {
+  left: 24%;
+  top: 74%;
+  width: 5.35rem;
+  height: 1.08rem;
+  border: 1px solid rgba(83, 216, 232, 0.17);
+  border-radius: 50%;
+  background:
+    radial-gradient(ellipse at 50% 48%, rgba(244, 240, 232, 0.2), transparent 18%),
+    radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.2), transparent 72%);
+  box-shadow:
+    inset 0 0 0.8rem rgba(83, 216, 232, 0.08),
+    0 0 1.25rem rgba(83, 216, 232, 0.14);
+  opacity: 0.58;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection {
-  left: 27%;
-  top: 71%;
-  width: 4rem;
-  height: 0.84rem;
+  left: 24%;
+  top: 74%;
+  width: 4.2rem;
+  height: 0.92rem;
   border-radius: 50%;
   background:
     radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.22), transparent 72%),
     linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.14), transparent);
   box-shadow: 0 0 1.15rem rgba(83, 216, 232, 0.12);
-  opacity: 0.48;
+  opacity: 0.56;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6757,7 +6832,8 @@ h3 {
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__branch,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__root,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__thread,
-.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__mercurius {
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__mercurius,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__seed {
   opacity: 1;
 }
 
@@ -6768,9 +6844,17 @@ h3 {
   transform: translate(-50%, -50%) scale(1.12);
 }
 
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="mercurius"] .alchemical-tree-instrument__halo {
+  opacity: 0.82;
+  box-shadow:
+    inset 0 0 2rem rgba(255, 227, 156, 0.09),
+    0 0 2.9rem rgba(83, 216, 232, 0.14);
+}
+
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__wheel,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__stage,
-.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__thread {
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__thread,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="opus-wheel"] .alchemical-tree-instrument__halo {
   opacity: 1;
 }
 
@@ -6781,8 +6865,10 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__stone,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__mirror,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__reflection,
-.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__field {
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__field,
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__seed--matter {
   opacity: 1;
 }
 
@@ -6795,6 +6881,13 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__reflection {
   transform: translate(-50%, -50%) scaleX(1.18);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument[data-active-panel="lapis"] .alchemical-tree-instrument__mirror {
+  box-shadow:
+    inset 0 0 0.95rem rgba(83, 216, 232, 0.12),
+    0 0 1.9rem rgba(83, 216, 232, 0.22);
+  transform: translate(-50%, -50%) scaleX(1.14);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .chapter-stage__scrim {
@@ -10088,14 +10181,17 @@ h3 {
 			  .alchemical-vessel-instrument__particle,
 			  .alchemical-vessel-instrument__stages,
 			  .alchemical-tree-instrument__field,
+			  .alchemical-tree-instrument__halo,
 			  .alchemical-tree-instrument__root,
 			  .alchemical-tree-instrument__trunk,
 			  .alchemical-tree-instrument__branch,
 			  .alchemical-tree-instrument__thread,
 			  .alchemical-tree-instrument__mercurius,
+			  .alchemical-tree-instrument__seed,
 			  .alchemical-tree-instrument__wheel,
 			  .alchemical-tree-instrument__stage,
 			  .alchemical-tree-instrument__stone,
+			  .alchemical-tree-instrument__mirror,
 			  .alchemical-tree-instrument__reflection,
 			  .amplification-lens-instrument__field,
 			  .amplification-lens-instrument__source,
@@ -10227,14 +10323,17 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__halo,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone,
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mirror,
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection {
 		    animation: none;
 		    transition: none;
@@ -12502,7 +12601,7 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument {
-		    min-height: 6.65rem;
+		    min-height: 7.35rem;
 		    margin-top: 0.64rem;
 		  }
 
@@ -12512,7 +12611,12 @@ h3 {
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field {
 		    width: 78%;
-		    height: 2.7rem;
+		    height: 2.9rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__halo {
+		    width: 9rem;
+		    height: 4.82rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk {
@@ -12537,6 +12641,18 @@ h3 {
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius {
 		    width: 0.86rem;
 		    height: 2.28rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed {
+		    width: 0.48rem;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed--spirit {
+		    top: 22%;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed--matter {
+		    top: 75%;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel {
@@ -12569,6 +12685,12 @@ h3 {
 		    width: 1rem;
 		  }
 
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mirror {
+		    left: 22%;
+		    width: 3.65rem;
+		    height: 0.84rem;
+		  }
+
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection {
 		    left: 22%;
 		    width: 3.2rem;
@@ -12596,7 +12718,7 @@ h3 {
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback {
 		    left: 1rem;
 		    right: 1rem;
-		    top: 33.75rem;
+		    top: 34.05rem;
 		    width: auto;
 		    padding: 0.38rem 0.64rem;
 		    text-align: left;
@@ -12604,12 +12726,12 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .alchemical-tree-instrument {
-		    min-height: 4.85rem;
+		    min-height: 5.15rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .chapter-stage__reference-map {
 		    margin-top: 1.18rem;
-		    transform: translateY(3.25rem);
+		    transform: translateY(3.45rem);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {

--- a/src/visualizations/chapters/ch11/ThreeTreeViz.js
+++ b/src/visualizations/chapters/ch11/ThreeTreeViz.js
@@ -20,19 +20,19 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
 
-const ROOT_DARK = new THREE.Color('#2a0845');
-const TRUNK_BROWN = new THREE.Color('#5a3a2a');
-const BRANCH_GOLD = new THREE.Color('#c8a820');
-const WATER_BLUE = new THREE.Color('#1a4a8a');
-const WATER_GLOW = new THREE.Color('#4a8aca');
-const LAPIS_GOLD = new THREE.Color('#d4af37');
-const FIGURE_WHITE = new THREE.Color('#d0d0e0');
-const MIRROR_CYAN = new THREE.Color('#22d3ee');
-const COSMOS_PURPLE = new THREE.Color('#3a1a6a');
+const ROOT_DARK = new THREE.Color('#4b1a74');
+const TRUNK_BROWN = new THREE.Color('#9b6a3c');
+const BRANCH_GOLD = new THREE.Color('#f0c85e');
+const WATER_BLUE = new THREE.Color('#235d9a');
+const WATER_GLOW = new THREE.Color('#66e5ff');
+const LAPIS_GOLD = new THREE.Color('#ffd76a');
+const FIGURE_WHITE = new THREE.Color('#f2eee3');
+const MIRROR_CYAN = new THREE.Color('#53d8e8');
+const COSMOS_PURPLE = new THREE.Color('#5f3fa8');
 const VOID = 0x030308;
 
-const WATER_PARTICLES = 200;
-const THOUSAND_NAMES = 50;
+const WATER_PARTICLES = 320;
+const THOUSAND_NAMES = 72;
 const OPUS_STAGES = [
     { color: '#050506', y: 1.35, x: 0, scale: 1.08 },
     { color: '#e8e8f0', y: 0, x: 1.35, scale: 0.86 },
@@ -66,6 +66,7 @@ export default class ThreeTreeViz extends BaseViz {
         this.renderer.setSize(this.width, this.height);
         this.renderer.setClearColor(VOID);
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.18;
 
         this.scene = new THREE.Scene();
         this.scene.fog = new THREE.FogExp2(VOID, 0.01);
@@ -85,13 +86,14 @@ export default class ThreeTreeViz extends BaseViz {
         this._createMirrorSurface();
         this._createFigureReflection();
         this._createLapisMandala();
+        this._createOpusTreeField();
         this._createCosmicSubstance();
         this._createLights();
 
         this.composer = new EffectComposer(this.renderer);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(this.width, this.height), 1.2, 0.6, 0.4
+            new THREE.Vector2(this.width, this.height), 1.35, 0.68, 0.34
         );
         this.composer.addPass(this.bloomPass);
     }
@@ -405,6 +407,143 @@ export default class ThreeTreeViz extends BaseViz {
         this.scene.add(this.lapisMandala);
     }
 
+    _createOpusTreeField() {
+        this.opusTreeField = new THREE.Group();
+        this.opusTreeField.position.set(1.35, 0, 0.62);
+        this.opusFieldRings = [];
+        this.opusFieldSeeds = [];
+        this.opusFieldThreads = [];
+
+        this.opusAxis = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.026, 0.026, 7.35, 12),
+            new THREE.MeshBasicMaterial({
+                color: 0xf4f0e8,
+                transparent: true,
+                opacity: 0.28,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        this.opusTreeField.add(this.opusAxis);
+
+        const makeRing = (radius, y, color, opacity, scaleY = 0.42) => {
+            const ring = new THREE.Mesh(
+                new THREE.TorusGeometry(radius, 0.012, 8, 140),
+                new THREE.MeshBasicMaterial({
+                    color,
+                    transparent: true,
+                    opacity,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false,
+                })
+            );
+            ring.position.y = y;
+            ring.scale.y = scaleY;
+            this.opusTreeField.add(ring);
+            this.opusFieldRings.push(ring);
+            return ring;
+        };
+
+        makeRing(1.75, 2.2, LAPIS_GOLD, 0.18, 0.34);
+        makeRing(2.18, 0, 0xf4f0e8, 0.13, 0.56);
+        makeRing(1.72, -2.25, MIRROR_CYAN, 0.17, 0.36);
+
+        const threadMaterials = [
+            new THREE.MeshBasicMaterial({
+                color: LAPIS_GOLD,
+                transparent: true,
+                opacity: 0.18,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            }),
+            new THREE.MeshBasicMaterial({
+                color: MIRROR_CYAN,
+                transparent: true,
+                opacity: 0.16,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            }),
+        ];
+
+        for (let strand = 0; strand < 6; strand++) {
+            const phase = strand * Math.PI / 3;
+            const points = [];
+            for (let index = 0; index <= 54; index++) {
+                const progress = index / 54;
+                const y = THREE.MathUtils.lerp(3.2, -3.25, progress);
+                const radius = 0.42 + Math.sin(progress * Math.PI) * 1.18;
+                const angle = phase + progress * Math.PI * 2.4;
+                points.push(new THREE.Vector3(
+                    Math.cos(angle) * radius,
+                    y,
+                    Math.sin(angle) * radius * 0.18
+                ));
+            }
+            const tube = new THREE.Mesh(
+                new THREE.TubeGeometry(new THREE.CatmullRomCurve3(points), 72, 0.01, 6, false),
+                threadMaterials[strand % 2].clone()
+            );
+            this.opusTreeField.add(tube);
+            this.opusFieldThreads.push(tube);
+        }
+
+        this.opusCompass = new THREE.Group();
+        OPUS_STAGES.forEach((stage, index) => {
+            const node = new THREE.Mesh(
+                new THREE.DodecahedronGeometry(0.095 * stage.scale, 0),
+                new THREE.MeshBasicMaterial({
+                    color: stage.color,
+                    transparent: true,
+                    opacity: index === 0 ? 0.34 : 0.5,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false,
+                })
+            );
+            node.position.set(stage.x * 0.82, stage.y * 0.82, 0.06);
+            this.opusCompass.add(node);
+        });
+        this.opusTreeField.add(this.opusCompass);
+
+        const seedGeometry = new THREE.SphereGeometry(0.115, 16, 12);
+        [
+            { y: 3.34, color: LAPIS_GOLD, focus: 'spirit' },
+            { y: -3.34, color: MIRROR_CYAN, focus: 'matter' },
+        ].forEach(({ y, color, focus }) => {
+            const seed = new THREE.Mesh(
+                seedGeometry,
+                new THREE.MeshStandardMaterial({
+                    color,
+                    emissive: color,
+                    emissiveIntensity: 0.55,
+                    transparent: true,
+                    opacity: 0.72,
+                    metalness: 0.28,
+                    roughness: 0.22,
+                })
+            );
+            seed.position.y = y;
+            seed.userData.focus = focus;
+            this.opusTreeField.add(seed);
+            this.opusFieldSeeds.push(seed);
+        });
+
+        this.opusMirrorPool = new THREE.Mesh(
+            new THREE.CylinderGeometry(1.28, 1.42, 0.026, 96),
+            new THREE.MeshBasicMaterial({
+                color: MIRROR_CYAN,
+                transparent: true,
+                opacity: 0.12,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        this.opusMirrorPool.position.set(-1.35, -3.08, 0.05);
+        this.opusMirrorPool.scale.z = 0.3;
+        this.opusTreeField.add(this.opusMirrorPool);
+
+        this.scene.add(this.opusTreeField);
+    }
+
     _createCosmicSubstance() {
         // Arcane substance particles — both near figure AND in distant cosmos
         const count = 400;
@@ -506,6 +645,42 @@ export default class ThreeTreeViz extends BaseViz {
             node.scale.setScalar(0.85 + this.opusFocus * 0.5 + pulse * 0.14 * this.opusFocus);
             node.material.emissiveIntensity = (index === 0 ? 0.12 : 0.34) + this.opusFocus * (0.4 + pulse * 0.28);
         });
+
+        if (this.opusTreeField) {
+            const fieldFocus = Math.max(this.mercuriusFocus * 0.86, this.opusFocus, this.lapisFocus * 0.94);
+            this.opusTreeField.position.x = THREE.MathUtils.damp(this.opusTreeField.position.x, isMobile ? 2.9 : 1.35, 4, dt);
+            this.opusTreeField.position.y = THREE.MathUtils.damp(this.opusTreeField.position.y, isMobile ? 0.02 : 0, 4, dt);
+            this.opusTreeField.scale.setScalar((isMobile ? 0.68 : 0.92) + fieldFocus * (isMobile ? 0.12 : 0.16));
+            this.opusTreeField.rotation.z = Math.sin(t * 0.06 * motionScale) * 0.035;
+            this._setGroupOpacity(this.opusTreeField, 0.42 + fieldFocus * 0.58);
+        }
+        this.opusFieldRings?.forEach((ring, index) => {
+            ring.rotation.z += dt * (index % 2 === 0 ? 0.034 : -0.026) * motionScale;
+            const pulse = 1 + Math.sin(t * 0.7 * motionScale + index) * 0.025;
+            ring.scale.x = pulse;
+        });
+        this.opusFieldThreads?.forEach((thread, index) => {
+            const material = thread.material;
+            if (!material) return;
+            material.opacity = 0.08 + this.mercuriusFocus * 0.08 + this.opusFocus * 0.16 + Math.sin(t * 0.42 * motionScale + index) * 0.025;
+        });
+        this.opusFieldSeeds?.forEach((seed, index) => {
+            const targetFocus = seed.userData.focus === 'matter' ? this.lapisFocus : Math.max(this.mercuriusFocus, this.opusFocus * 0.6);
+            const pulse = 0.5 + Math.sin(t * 1.1 * motionScale + index * 2.1) * 0.5;
+            seed.scale.setScalar(0.88 + targetFocus * 0.55 + pulse * 0.1 * targetFocus);
+            seed.material.emissiveIntensity = 0.45 + targetFocus * 0.65;
+        });
+        if (this.opusCompass) {
+            this.opusCompass.rotation.z = t * 0.038 * motionScale;
+            this.opusCompass.scale.setScalar(0.7 + this.opusFocus * 0.38);
+        }
+        if (this.opusMirrorPool?.material) {
+            this.opusMirrorPool.material.opacity = 0.06 + this.lapisFocus * 0.22 + this.mercuriusFocus * 0.04;
+            this.opusMirrorPool.scale.x = 1 + this.lapisFocus * 0.2;
+        }
+        if (this.opusAxis?.material) {
+            this.opusAxis.material.opacity = 0.16 + this.mercuriusFocus * 0.2 + this.opusFocus * 0.08;
+        }
 
         // Name particles twinkle
         for (const np of this.nameParticles) {


### PR DESCRIPTION
## Summary
- restore the Chapter 11 Three.js scene by implementing the missing opus tree field that caused the scene to fall back instead of rendering a canvas
- strengthen the Chapter 11 static instrument with halo, seed, and mirror teaching marks
- update app shell and accessibility smoke coverage for the new visual parts and accessible label

## Root Cause
The local Chapter 11 branch called `this._createOpusTreeField()` during scene initialization before that method existed, so the route mounted the fallback and the scene-controls smoke shard reported `chapter 11 expected one ready canvas but found 0`.

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `npm run test:e2e:app:scene-controls`
- `npm run test:e2e:app:mobile`
- `npm run test:e2e:app:foundation`
- `npm run test:a11y:app`