### PR TITLE
[codex] Refine chapter twelve amplification observatory

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -6982,6 +6982,7 @@ h3 {
   border: 1px solid rgba(244, 240, 232, 0.12);
   border-radius: var(--radius);
   background:
+    linear-gradient(90deg, transparent 0 49.6%, rgba(255, 227, 156, 0.12) 49.8% 50.2%, transparent 50.4%),
     radial-gradient(circle at 24% 46%, rgba(83, 216, 232, 0.11), transparent 4.9rem),
     radial-gradient(circle at 50% 42%, rgba(255, 227, 156, 0.16), transparent 4.7rem),
     radial-gradient(circle at 77% 55%, rgba(132, 201, 155, 0.12), transparent 4.8rem),
@@ -7002,6 +7003,9 @@ h3 {
   inset: 0.58rem;
   border: 1px solid rgba(255, 227, 156, 0.08);
   border-radius: calc(var(--radius) - 2px);
+  background:
+    radial-gradient(circle at 50% 78%, rgba(255, 227, 156, 0.08), transparent 2.2rem),
+    linear-gradient(120deg, transparent 0 24%, rgba(83, 216, 232, 0.08) 25% 25.4%, transparent 26% 74%, rgba(132, 201, 155, 0.08) 74.6% 75%, transparent 76%);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument::after {
@@ -7078,11 +7082,13 @@ h3 {
   height: 2.3rem;
   border-bottom: 1px solid rgba(255, 227, 156, 0.23);
   border-radius: 50%;
-  opacity: 0.44;
+  filter: drop-shadow(0 0 0.36rem rgba(212, 175, 55, 0.12));
+  opacity: 0.5;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
-    border-color 0.55s var(--motion-spring);
+    border-color 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument__root--faith {
@@ -7107,11 +7113,13 @@ h3 {
   width: 12rem;
   height: 3rem;
   border-radius: 50%;
-  opacity: 0.38;
+  filter: drop-shadow(0 0 0.28rem rgba(244, 240, 232, 0.08));
+  opacity: 0.42;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
-    border-color 0.55s var(--motion-spring);
+    border-color 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument__split--faith {
@@ -7133,7 +7141,8 @@ h3 {
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
-    box-shadow 0.55s var(--motion-spring);
+    box-shadow 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument__image--faith {
@@ -7167,7 +7176,8 @@ h3 {
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
-    transform 0.55s var(--motion-spring);
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument__fish {
@@ -7199,7 +7209,8 @@ h3 {
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
-    border-color 0.55s var(--motion-spring);
+    border-color 0.55s var(--motion-spring),
+    filter 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument__lens {
@@ -7311,11 +7322,49 @@ h3 {
   transform: translate(-50%, -50%) scale(1.08);
 }
 
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="background"] .amplification-lens-instrument__projection {
+  border-color: rgba(255, 227, 156, 0.42);
+  transform: translate(-50%, -50%) scaleX(0.92);
+}
+
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__root,
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__split,
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__source,
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__image {
   opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__root {
+  filter: drop-shadow(0 0 0.58rem rgba(212, 175, 55, 0.22));
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__root--faith {
+  border-color: rgba(83, 216, 232, 0.58);
+  transform: translateX(-72%) rotate(-17deg) scale(1.04);
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__root--source {
+  border-color: rgba(255, 227, 156, 0.62);
+  transform: translateX(-50%) rotate(0deg) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__root--alchemy {
+  border-color: rgba(132, 201, 155, 0.6);
+  transform: translateX(-28%) rotate(17deg) scale(1.04);
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__split {
+  filter: drop-shadow(0 0 0.48rem rgba(244, 240, 232, 0.16));
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__split--faith {
+  border-color: rgba(83, 216, 232, 0.52);
+  transform: translate(-86%, -50%) rotate(11deg) scaleX(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__split--alchemy {
+  border-color: rgba(132, 201, 155, 0.5);
+  transform: translate(-14%, -50%) rotate(-11deg) scaleX(1.08);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__source {
@@ -7325,10 +7374,32 @@ h3 {
   transform: translateX(-50%) rotate(45deg) scale(1.12);
 }
 
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__image {
+  border-color: rgba(244, 240, 232, 0.28);
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__image--faith {
+  box-shadow: 0 0 1.5rem rgba(83, 216, 232, 0.22);
+  transform: translate(-50%, -50%) translateY(-0.08rem);
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="roots"] .amplification-lens-instrument__image--alchemy {
+  box-shadow: 0 0 1.5rem rgba(132, 201, 155, 0.22);
+  transform: translate(50%, -50%) translateY(0.08rem);
+}
+
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="bridge"] .amplification-lens-instrument__fish,
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="bridge"] .amplification-lens-instrument__bridge,
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="bridge"] .amplification-lens-instrument__field {
   opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="bridge"] .amplification-lens-instrument__field--faith {
+  transform: translateX(0.38rem) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="bridge"] .amplification-lens-instrument__field--alchemy {
+  transform: translateX(-0.38rem) scale(1.08);
 }
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="bridge"] .amplification-lens-instrument__fish {
@@ -7338,6 +7409,7 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch12"] .amplification-lens-instrument[data-active-panel="bridge"] .amplification-lens-instrument__bridge {
   border-color: rgba(143, 231, 237, 0.46);
+  filter: drop-shadow(0 0 0.64rem rgba(83, 216, 232, 0.2));
   transform: translate(-50%, -50%) scaleX(1.08);
 }
 
@@ -11440,7 +11512,7 @@ h3 {
   }
 
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__intro {
-    padding-top: 2rem;
+    padding-top: 1.3rem;
   }
 
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__scrim {
@@ -11451,16 +11523,17 @@ h3 {
   }
 
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__intro h1 {
-    max-width: 13.6ch;
-    font-size: 2.72rem;
+    max-width: 12.4ch;
+    font-size: clamp(2.1rem, 11.2vw, 2.44rem);
+    line-height: 0.9;
   }
 
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__intro p:not(.eyebrow) {
-    max-width: 21.5rem;
-    margin-top: 1.05rem;
+    max-width: 20.5rem;
+    margin-top: 0.72rem;
     color: rgba(244, 240, 232, 0.86);
-    font-size: 0.98rem;
-    line-height: 1.56;
+    font-size: 0.88rem;
+    line-height: 1.44;
     text-shadow:
       0 0.35rem 0.9rem rgba(3, 3, 7, 0.95),
       0 0 1.8rem rgba(3, 3, 7, 0.92);
@@ -12923,7 +12996,7 @@ h3 {
 
 		  .chapter-experience[data-chapter-id="ch12"][data-reduced-motion="true"] .chapter-stage__reference-map {
 		    margin-top: 1.18rem;
-		    transform: translateY(3.25rem);
+		    transform: translateY(7.6rem);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch12"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {

--- a/src/visualizations/chapters/ch12/ThreeUnusViz.js
+++ b/src/visualizations/chapters/ch12/ThreeUnusViz.js
@@ -22,6 +22,7 @@ import BaseViz from '../../../features/viz-platform/BaseViz.js';
 const GNOSIS_GOLD = new THREE.Color('#ffd700');
 const FAITH_BLUE = new THREE.Color('#4a90d9');
 const KNOWLEDGE_GREEN = new THREE.Color('#2ecc71');
+const ROOT_IVORY = new THREE.Color('#f4f0e8');
 const SNAKE_OLD = new THREE.Color('#4a4a3a');
 const SNAKE_NEW = new THREE.Color('#ffd700');
 const WITHER_GREY = new THREE.Color('#3a3a3a');
@@ -216,6 +217,46 @@ export default class ThreeUnusViz extends BaseViz {
         }));
         this.scene.add(this.rootBeads);
 
+        this.rootBraids = [];
+        const braidSpecs = [
+            { y: 0.58, z: 0.26, color: FAITH_BLUE, target: faith },
+            { y: 0, z: 0.1, color: GNOSIS_GOLD, target: new THREE.Vector3(6.4, 0, 0.1) },
+            { y: -0.58, z: 0.26, color: KNOWLEDGE_GREEN, target: knowledge },
+        ];
+        braidSpecs.forEach((spec, index) => {
+            const curve = new THREE.CatmullRomCurve3([
+                source.clone().add(new THREE.Vector3(0.02, spec.y * 0.15, spec.z)),
+                new THREE.Vector3(1.2, spec.y * 0.7, spec.z + 0.42),
+                new THREE.Vector3(3.5, spec.y * 1.2, spec.z + 0.34),
+                spec.target.clone().add(new THREE.Vector3(-0.14, spec.y * 0.2, spec.z)),
+            ]);
+            const tube = new THREE.TubeGeometry(curve, 92, index === 1 ? 0.016 : 0.014, 8, false);
+            const material = new THREE.MeshBasicMaterial({
+                color: spec.color,
+                transparent: true,
+                opacity: 0.08,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            });
+            const braid = new THREE.Mesh(tube, material);
+            this.scene.add(braid);
+            this.rootBraids.push({ mesh: braid, material, phase: index * 0.9 });
+        });
+
+        this.sourceHalo = new THREE.Mesh(
+            new THREE.TorusGeometry(0.62, 0.012, 8, 72),
+            new THREE.MeshBasicMaterial({
+                color: ROOT_IVORY,
+                transparent: true,
+                opacity: 0.18,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        this.sourceHalo.position.copy(source);
+        this.sourceHalo.rotation.y = Math.PI / 2;
+        this.scene.add(this.sourceHalo);
+
         this.sourceStone = new THREE.Mesh(
             new THREE.IcosahedronGeometry(0.36, 0),
             new THREE.MeshStandardMaterial({
@@ -236,6 +277,38 @@ export default class ThreeUnusViz extends BaseViz {
         this.lensGroup = new THREE.Group();
         this.lensGroup.position.set(1.2, 0, 1.1);
         this.lensRings = [];
+        this.lensGlass = new THREE.Mesh(
+            new THREE.CircleGeometry(1.48, 80),
+            new THREE.MeshBasicMaterial({
+                color: ROOT_IVORY,
+                transparent: true,
+                opacity: 0.08,
+                side: THREE.DoubleSide,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        this.lensGlass.rotation.y = Math.PI / 2;
+        this.lensGroup.add(this.lensGlass);
+
+        const spokePositions = [];
+        for (let i = 0; i < 12; i++) {
+            const angle = (i / 12) * Math.PI * 2;
+            spokePositions.push(
+                0, 0, 0,
+                0, Math.cos(angle) * 1.18, Math.sin(angle) * 1.18
+            );
+        }
+        const spokeGeo = new THREE.BufferGeometry();
+        spokeGeo.setAttribute('position', new THREE.Float32BufferAttribute(spokePositions, 3));
+        this.lensSpokes = new THREE.LineSegments(spokeGeo, new THREE.LineBasicMaterial({
+            color: ROOT_IVORY,
+            transparent: true,
+            opacity: 0.13,
+            blending: THREE.AdditiveBlending,
+        }));
+        this.lensGroup.add(this.lensSpokes);
+
         for (let i = 0; i < 4; i++) {
             const ring = new THREE.Mesh(
                 new THREE.TorusGeometry(0.72 + i * 0.28, 0.01, 8, 90),
@@ -371,6 +444,34 @@ export default class ThreeUnusViz extends BaseViz {
 
         this.fishGroup.position.set(-6, 0, 2);
         this.scene.add(this.fishGroup);
+
+        this.bridgeArcGroup = new THREE.Group();
+        this.bridgeArcs = [];
+        [
+            { y: 0.48, z: 0.12, color: FISH_CYAN },
+            { y: 0, z: 0.38, color: GNOSIS_GOLD },
+            { y: -0.48, z: 0.12, color: ROOT_IVORY },
+        ].forEach((spec, index) => {
+            const curve = new THREE.CatmullRomCurve3([
+                new THREE.Vector3(-5.2, spec.y, spec.z),
+                new THREE.Vector3(-1.8, spec.y * 1.6, spec.z + 0.8),
+                new THREE.Vector3(1.9, -spec.y * 0.5, spec.z + 0.86),
+                new THREE.Vector3(5.8, -spec.y * 0.2, spec.z),
+            ]);
+            const tube = new THREE.TubeGeometry(curve, 96, index === 1 ? 0.018 : 0.014, 8, false);
+            const material = new THREE.MeshBasicMaterial({
+                color: spec.color,
+                transparent: true,
+                opacity: 0.06,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            });
+            const arc = new THREE.Mesh(tube, material);
+            this.bridgeArcGroup.add(arc);
+            this.bridgeArcs.push({ mesh: arc, material, phase: index * 0.7 });
+        });
+        this.bridgeArcGroup.position.set(0.8, 0.1, 0.7);
+        this.scene.add(this.bridgeArcGroup);
     }
 
     _createAmbientParticles() {
@@ -448,6 +549,16 @@ export default class ThreeUnusViz extends BaseViz {
         this.rootBeads.material.opacity = 0.06 + this.rootsFocus * 0.44 + this.bridgeFocus * 0.14;
         this.rootBeads.rotation.copy(this.rootLattice.rotation);
         this.rootBeads.scale.copy(this.rootLattice.scale);
+        this.rootBraids?.forEach((braid, index) => {
+            braid.material.opacity = 0.05 + this.rootsFocus * (0.34 + index * 0.06) + this.bridgeFocus * 0.08;
+            braid.mesh.scale.setScalar((isMobile ? 0.86 : 1) + this.rootsFocus * 0.07);
+            braid.mesh.rotation.y = Math.sin(t * 0.1 * motionScale + braid.phase) * 0.045;
+        });
+        if (this.sourceHalo) {
+            this.sourceHalo.rotation.z = t * 0.08 * motionScale;
+            this.sourceHalo.scale.setScalar(0.82 + this.rootsFocus * 0.36 + this.backgroundFocus * 0.1);
+            this.sourceHalo.material.opacity = 0.08 + this.rootsFocus * 0.32 + this.backgroundFocus * 0.14;
+        }
         this.sourceStone.rotation.y = t * 0.14 * motionScale;
         this.sourceStone.scale.setScalar(0.76 + this.rootsFocus * 0.3 + this.backgroundFocus * 0.12);
         this.sourceStone.material.opacity = 0.26 + this.rootsFocus * 0.32 + this.backgroundFocus * 0.18;
@@ -460,6 +571,9 @@ export default class ThreeUnusViz extends BaseViz {
         this.lensRings.forEach((ring, index) => {
             ring.rotation.z = t * (0.045 + index * 0.016) * motionScale;
         });
+        if (this.lensSpokes) {
+            this.lensSpokes.rotation.x = t * 0.025 * motionScale;
+        }
 
         // ─── Snake skin shedding cycle (every 20s) ───
         const shedCycle = (t * 0.05 * motionScale) % 1;
@@ -497,6 +611,14 @@ export default class ThreeUnusViz extends BaseViz {
         this.fishTail.material.opacity = 0.2 + this.bridgeFocus * 0.46;
         this.fishTail.material.emissiveIntensity = 0.22 + this.bridgeFocus * 0.48;
         this.fishTrail.material.opacity = 0.12 + this.bridgeFocus * 0.42;
+        if (this.bridgeArcGroup) {
+            this.bridgeArcGroup.rotation.y = Math.sin(t * 0.07 * motionScale) * 0.08;
+            this.bridgeArcGroup.scale.setScalar((isMobile ? 0.82 : 1) + this.bridgeFocus * 0.08);
+            this.bridgeArcs?.forEach((arc, index) => {
+                arc.material.opacity = 0.04 + this.bridgeFocus * (0.26 + index * 0.035) + this.rootsFocus * 0.05;
+                arc.mesh.rotation.z = Math.sin(t * 0.12 * motionScale + arc.phase) * 0.028;
+            });
+        }
 
         // ─── Camera ───
         const camAngle = t * 0.012 * motionScale + this.mouseSmooth.x * 0.22;


### PR DESCRIPTION
## Summary

Refines Chapter 12 into a clearer amplification observatory: the WebGL scene now connects the shared-root genealogy, symbolic lens, and inward bridge as one visual teaching surface rather than separate glowing motifs.

## Skill stack

- Aion skill-routing playbook
- subagent scout and adversarial review
- Three.js scene polish
- accessibility/webapp smoke testing
- Control Tower visual QA
- GitHub PR workflow

## Routes changed

- `/journey/chapter/ch12`

## Visual thesis

Chapter 12 should teach amplification as disciplined symbolic optics: Christian image, alchemical image, shared roots, and psychic projection remain distinct, but a lens/bridge makes their relationship visible.

## What changed

- Added braided root tubes, a source halo, a glass/spoke interpretation lens, and bridge arcs to the Ch12 Three scene.
- Strengthened Ch12 mini-instrument states for Method, Genealogy, and Bridge without changing DOM counts, panel ids, or accessible labels.
- Tightened Ch12 mobile heading rhythm so the visual instrument appears in the first narrow viewport.

## Browser evidence

- `npm run test:visual:control-tower` generated a fresh report at `test-results/control-tower/route-scores.md`.
- Control Tower inspected 20 routes across desktop, mobile, and narrow viewports.
- Result: 0 technical blockers; `/journey/chapter/ch12` scored 100% with no mobile or narrow overflow.

## Checks

- `node --check src/visualizations/chapters/ch12/ThreeUnusViz.js`
- `npm run build`
- `npm run test:app`
- `npm run test:e2e:app:scene-controls`
- `npm run test:e2e:app:mobile`
- `npm run test:a11y:app`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm test`
- `npm run test:e2e:app:foundation`
- `npm run build:pages`
- `npm run test:pages:artifact`
- `npm run test:visual:control-tower`

## Residual debt

- Broader WebGL cleanup/performance hardening remains part of the release-hardening batch.
- The Control Tower report is still report-first for visual scoring, so manual visual taste review remains part of each route pass.
