### PR TITLE
[codex] Refine chapter thirteen emanation field

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -11193,7 +11193,7 @@ h3 {
 
   .chapter-experience[data-chapter-id="ch13"][data-reduced-motion="true"] .chapter-stage__reference-map {
     margin-top: 1.18rem;
-    transform: translateY(8.5rem);
+    transform: translateY(12.4rem);
   }
 
   .chapter-experience[data-chapter-id="ch13"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
@@ -13028,6 +13028,23 @@ h3 {
 		    -webkit-box-orient: vertical;
 		    overflow: hidden;
 		  }
+
+  .chapter-experience[data-chapter-id="ch13"] .chapter-stage__intro h1 {
+    max-width: 9.4ch;
+    font-size: clamp(2.55rem, 13.4vw, 3.25rem);
+    line-height: 0.9;
+  }
+
+  .chapter-experience[data-chapter-id="ch13"] .chapter-stage__intro p:not(.eyebrow) {
+    max-width: 20.5rem;
+    margin-top: 0.7rem;
+    color: rgba(244, 240, 232, 0.86);
+    font-size: 0.9rem;
+    line-height: 1.42;
+    text-shadow:
+      0 0.35rem 0.9rem rgba(3, 3, 7, 0.95),
+      0 0 1.8rem rgba(3, 3, 7, 0.9);
+  }
 
 		  .home-hero {
 		    padding-top: 12.4rem;

--- a/src/visualizations/chapters/ch13/ThreeQuaternioViz.js
+++ b/src/visualizations/chapters/ch13/ThreeQuaternioViz.js
@@ -8,10 +8,15 @@ import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
+import { createPleromaCrown, createQuaternioSeal, createReturnArc } from './gnosticScenePrimitives.js';
 
 const QUAD_COLORS = [new THREE.Color('#e63946'), new THREE.Color('#457b9d'), new THREE.Color('#2a9d8f'), new THREE.Color('#ff9800')];
 const AXIS_CLR = new THREE.Color('#ff9800');
 const CENTER = new THREE.Color('#ffd700');
+const PLEROMA = new THREE.Color('#ffe39c');
+const SOPHIA = new THREE.Color('#ffad70');
+const RUPTURE = new THREE.Color('#cc6d86');
+const AION_BLUE = new THREE.Color('#53d8e8');
 
 export default class ThreeQuaternioViz extends BaseViz {
     constructor(c, o = {}) {
@@ -95,8 +100,10 @@ export default class ThreeQuaternioViz extends BaseViz {
         }));
         this.quaternioGroup.add(this.centerGlow);
 
+        createPleromaCrown(this, { pleroma: PLEROMA, aionBlue: AION_BLUE });
         this._createEmanationField();
         this._createSophiaFigure();
+        createQuaternioSeal(this, { pleroma: PLEROMA, aionBlue: AION_BLUE, quadColors: QUAD_COLORS });
         this._createParadoxField();
 
         this.scene.add(new THREE.AmbientLight(0x0a0a10, 0.2));
@@ -135,7 +142,7 @@ export default class ThreeQuaternioViz extends BaseViz {
         this.sophiaBody = new THREE.Mesh(
             new THREE.OctahedronGeometry(0.36, 0),
             new THREE.MeshBasicMaterial({
-                color: 0xffe39c,
+                color: SOPHIA,
                 transparent: true,
                 opacity: 0.62,
                 blending: THREE.AdditiveBlending,
@@ -149,13 +156,25 @@ export default class ThreeQuaternioViz extends BaseViz {
         this.sophiaTrail = new THREE.Line(
             new THREE.BufferGeometry().setFromPoints(trailPts),
             new THREE.LineBasicMaterial({
-                color: 0xffe39c,
+                color: SOPHIA,
                 transparent: true,
                 opacity: 0.24,
                 blending: THREE.AdditiveBlending,
             })
         );
         this.sophiaGroup.add(this.sophiaTrail);
+        this.sophiaHalo = new THREE.Mesh(
+            new THREE.TorusGeometry(0.76, 0.008, 8, 72),
+            new THREE.MeshBasicMaterial({
+                color: SOPHIA,
+                transparent: true,
+                opacity: 0.12,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        this.sophiaHalo.rotation.x = Math.PI / 2;
+        this.sophiaGroup.add(this.sophiaHalo);
         this.sophiaGroup.position.set(0.8, 4.8, 0.8);
         this.quaternioGroup.add(this.sophiaGroup);
     }
@@ -163,7 +182,7 @@ export default class ThreeQuaternioViz extends BaseViz {
     _createParadoxField() {
         this.paradoxGroup = new THREE.Group();
         this.paradoxShards = [];
-        const shardColors = [0xff5f6d, 0x53d8e8, 0xffd37a, 0x9b5cff];
+        const shardColors = [RUPTURE, AION_BLUE, PLEROMA, 0x9b5cff];
         for (let i = 0; i < 10; i++) {
             const angle = (i / 10) * Math.PI * 2;
             const shard = new THREE.Mesh(
@@ -189,7 +208,7 @@ export default class ThreeQuaternioViz extends BaseViz {
                 new THREE.Vector3(3.2, 2.8, -0.1),
             ]),
             new THREE.LineBasicMaterial({
-                color: 0xff5f6d,
+                color: RUPTURE,
                 transparent: true,
                 opacity: 0.18,
                 blending: THREE.AdditiveBlending,
@@ -197,12 +216,13 @@ export default class ThreeQuaternioViz extends BaseViz {
         );
         this.paradoxRupture = rupture;
         this.paradoxGroup.add(rupture);
+        createReturnArc(this, { pleroma: PLEROMA, aionBlue: AION_BLUE });
         this.quaternioGroup.add(this.paradoxGroup);
     }
 
     update(dt) {
         if (!this.scene) return;
-        const t = this.time;
+        const t = this.time || 0;
         const panelId = this.panelState?.activePanelId || 'gnosis';
         const dampRate = this.reducedMotion ? 9 : 3.4;
         const motionScale = this.reducedMotion ? 0.12 : 1;
@@ -241,12 +261,39 @@ export default class ThreeQuaternioViz extends BaseViz {
             axis.material.opacity = 0.035 + this.quaternioFocus * 0.18 + this.paradoxFocus * (index % 2 === 0 ? 0.08 : 0.14);
         });
 
+        this.pleromaRings?.forEach((ring, index) => {
+            const drift = this.reducedMotion ? 0 : t * (0.018 + index * 0.006) * (index % 2 ? -1 : 1);
+            const pulse = this.reducedMotion ? 0 : Math.sin(t * 0.18 + index) * 0.015;
+            ring.rotation.z = index * Math.PI / 9 + drift;
+            ring.scale.setScalar(1 + this.gnosisFocus * 0.08 + pulse);
+            ring.material.opacity = 0.025 + this.gnosisFocus * (0.055 + index * 0.007) + this.paradoxFocus * 0.015;
+        });
+        if (this.pleromaSource) {
+            this.pleromaSource.rotation.y = this.reducedMotion ? 0 : t * 0.18;
+            this.pleromaSource.scale.setScalar(0.9 + this.gnosisFocus * 0.5 + this.quaternioFocus * 0.12);
+            this.pleromaSource.material.opacity = 0.26 + this.gnosisFocus * 0.58 + this.quaternioFocus * 0.12;
+        }
+        this.pleromaSpokes?.forEach((spoke, index) => {
+            spoke.material.opacity = 0.018 + this.gnosisFocus * 0.075 + (index % 2 ? this.quaternioFocus * 0.018 : 0);
+        });
+        this.aeonChains?.forEach((chain, index) => {
+            chain.material.opacity = 0.018 + this.gnosisFocus * 0.07 + this.quaternioFocus * 0.035 + this.paradoxFocus * (index === 3 ? 0.06 : 0.018);
+        });
+
         // Center pulse — stronger when all quadrants balanced (mouse near center)
         const centerDist = Math.sqrt(this.mouseSmooth.x ** 2 + this.mouseSmooth.y ** 2);
         const balance = Math.max(0, 1 - centerDist);
         this.center.material.opacity = 0.36 + balance * 0.28 + this.quaternioFocus * 0.22 + this.paradoxFocus * 0.12;
         this.center.scale.setScalar(0.9 + balance * 0.32 + this.quaternioFocus * 0.22 + this.paradoxFocus * 0.1);
         this.centerGlow.material.opacity = 0.025 + balance * 0.08 + this.quaternioFocus * 0.08 + this.paradoxFocus * 0.08;
+
+        this.quaternioSealGroup.rotation.z = (this.reducedMotion ? 0 : t * 0.018) - this.paradoxFocus * 0.08;
+        this.quaternioDiamonds?.forEach((diamond, index) => {
+            diamond.material.opacity = 0.035 + this.quaternioFocus * (0.17 - index * 0.04) + this.paradoxFocus * 0.035;
+        });
+        this.quaternioPetals?.forEach((petal, index) => {
+            petal.material.opacity = 0.035 + this.quaternioFocus * 0.16 + (index === dominantQ ? 0.055 : 0) + this.paradoxFocus * 0.025;
+        });
 
         this.emanationRings.forEach((ring, index) => {
             ring.rotation.z = t * (0.02 + index * 0.004) * motionScale;
@@ -259,6 +306,8 @@ export default class ThreeQuaternioViz extends BaseViz {
         this.sophiaBody.rotation.y = t * 0.22 * motionScale;
         this.sophiaBody.material.opacity = 0.16 + this.gnosisFocus * 0.55 + this.paradoxFocus * 0.16;
         this.sophiaTrail.material.opacity = 0.05 + this.gnosisFocus * 0.3 + this.paradoxFocus * 0.12;
+        this.sophiaHalo.rotation.z = this.reducedMotion ? 0 : t * 0.12;
+        this.sophiaHalo.material.opacity = 0.04 + this.gnosisFocus * 0.18 + this.paradoxFocus * 0.12;
 
         this.paradoxGroup.rotation.z = Math.sin(t * 0.12 * motionScale) * 0.08;
         this.paradoxShards.forEach(({ shard, angle }, index) => {
@@ -269,6 +318,17 @@ export default class ThreeQuaternioViz extends BaseViz {
             shard.material.opacity = 0.05 + this.paradoxFocus * 0.5;
         });
         this.paradoxRupture.material.opacity = 0.04 + this.paradoxFocus * 0.42;
+        this.returnArc.material.opacity = 0.035 + this.paradoxFocus * 0.34 + this.gnosisFocus * 0.035;
+        this.returnSparks?.forEach((spark, index) => {
+            const phase = this.reducedMotion ? index / this.returnSparks.length : (t * 0.06 + index / this.returnSparks.length) % 1;
+            const pointIndex = Math.min(this.returnCurvePoints.length - 1, Math.floor(phase * (this.returnCurvePoints.length - 1)));
+            const curvePoint = this.returnCurvePoints[pointIndex] || this.returnCurvePoints[0];
+            if (curvePoint) spark.position.copy(curvePoint);
+            spark.rotation.y = (this.reducedMotion ? 0 : t * 0.26) + index;
+            spark.material.opacity = 0.04 + this.paradoxFocus * 0.34 + (phase > 0.72 ? this.gnosisFocus * 0.1 : 0);
+            const sparkPulse = this.reducedMotion ? 0 : Math.sin(t * 0.4 + index) * 0.08;
+            spark.scale.setScalar(0.75 + this.paradoxFocus * 1.15 + sparkPulse);
+        });
 
         // Camera
         const targetCam = new THREE.Vector3(

--- a/src/visualizations/chapters/ch13/gnosticScenePrimitives.js
+++ b/src/visualizations/chapters/ch13/gnosticScenePrimitives.js
@@ -1,0 +1,187 @@
+import * as THREE from 'three';
+
+export function createPleromaCrown(viz, { pleroma, aionBlue }) {
+    viz.pleromaGroup = new THREE.Group();
+    viz.pleromaGroup.position.set(-1.15, 4.95, -0.35);
+    viz.pleromaRings = [];
+    viz.pleromaSpokes = [];
+    viz.aeonChains = [];
+
+    for (let i = 0; i < 5; i++) {
+        const ring = new THREE.Mesh(
+            new THREE.TorusGeometry(0.52 + i * 0.38, 0.006 + i * 0.0015, 8, 120),
+            new THREE.MeshBasicMaterial({
+                color: i % 2 === 0 ? pleroma : aionBlue,
+                transparent: true,
+                opacity: 0.08,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        ring.rotation.z = i * Math.PI / 9;
+        viz.pleromaGroup.add(ring);
+        viz.pleromaRings.push(ring);
+    }
+
+    viz.pleromaSource = new THREE.Mesh(
+        new THREE.IcosahedronGeometry(0.18, 1),
+        new THREE.MeshBasicMaterial({
+            color: pleroma,
+            transparent: true,
+            opacity: 0.78,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+        })
+    );
+    viz.pleromaGroup.add(viz.pleromaSource);
+
+    for (let i = 0; i < 8; i++) {
+        const angle = (i / 8) * Math.PI * 2;
+        const spoke = new THREE.Line(
+            new THREE.BufferGeometry().setFromPoints([
+                new THREE.Vector3(0, 0, 0.02),
+                new THREE.Vector3(Math.cos(angle) * 2.45, Math.sin(angle) * 1.7, -0.06),
+            ]),
+            new THREE.LineBasicMaterial({
+                color: i % 2 === 0 ? pleroma : aionBlue,
+                transparent: true,
+                opacity: 0.055,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        viz.pleromaGroup.add(spoke);
+        viz.pleromaSpokes.push(spoke);
+    }
+
+    [
+        new THREE.Vector3(-2.7, 1.1, 0.2),
+        new THREE.Vector3(-0.65, -0.25, 0.35),
+        new THREE.Vector3(1.1, 0.85, -0.15),
+        new THREE.Vector3(2.75, -1.35, 0.1),
+    ].forEach((target, index) => {
+        const points = [];
+        for (let i = 0; i <= 38; i++) {
+            const p = i / 38;
+            const wave = Math.sin(p * Math.PI * 2 + index * 0.8) * (0.35 + index * 0.03);
+            points.push(new THREE.Vector3(
+                THREE.MathUtils.lerp(-1.15, target.x, p) + wave * 0.18,
+                THREE.MathUtils.lerp(4.95, target.y, p),
+                THREE.MathUtils.lerp(-0.35, target.z, p) + Math.cos(p * Math.PI + index) * 0.12
+            ));
+        }
+        const chain = new THREE.Line(
+            new THREE.BufferGeometry().setFromPoints(points),
+            new THREE.LineBasicMaterial({
+                color: index % 2 === 0 ? pleroma : aionBlue,
+                transparent: true,
+                opacity: 0.055,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        viz.quaternioGroup.add(chain);
+        viz.aeonChains.push(chain);
+    });
+
+    viz.quaternioGroup.add(viz.pleromaGroup);
+}
+
+export function createQuaternioSeal(viz, { pleroma, aionBlue, quadColors }) {
+    viz.quaternioSealGroup = new THREE.Group();
+    viz.quaternioDiamonds = [];
+    [2.55, 1.55].forEach((radius, index) => {
+        const z = 0.05 + index * 0.04;
+        const points = [
+            new THREE.Vector3(0, radius, z),
+            new THREE.Vector3(radius, 0, z),
+            new THREE.Vector3(0, -radius, z),
+            new THREE.Vector3(-radius, 0, z),
+            new THREE.Vector3(0, radius, z),
+        ];
+        const diamond = new THREE.Line(
+            new THREE.BufferGeometry().setFromPoints(points),
+            new THREE.LineBasicMaterial({
+                color: index === 0 ? pleroma : aionBlue,
+                transparent: true,
+                opacity: 0.08,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        viz.quaternioSealGroup.add(diamond);
+        viz.quaternioDiamonds.push(diamond);
+    });
+
+    viz.quaternioPetals = [];
+    for (let i = 0; i < 4; i++) {
+        const angle = (i / 4) * Math.PI * 2 + Math.PI / 4;
+        const points = [];
+        for (let j = 0; j <= 36; j++) {
+            const p = j / 36;
+            const spread = 0.55 * Math.sin(p * Math.PI);
+            const radius = THREE.MathUtils.lerp(0.65, 2.85, p);
+            points.push(new THREE.Vector3(
+                Math.cos(angle) * radius + Math.cos(angle + Math.PI / 2) * spread,
+                Math.sin(angle) * radius + Math.sin(angle + Math.PI / 2) * spread,
+                -0.05 + p * 0.08
+            ));
+        }
+        const petal = new THREE.Line(
+            new THREE.BufferGeometry().setFromPoints(points),
+            new THREE.LineBasicMaterial({
+                color: quadColors[i],
+                transparent: true,
+                opacity: 0.09,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        viz.quaternioSealGroup.add(petal);
+        viz.quaternioPetals.push(petal);
+    }
+
+    viz.quaternioGroup.add(viz.quaternioSealGroup);
+}
+
+export function createReturnArc(viz, { pleroma, aionBlue }) {
+    viz.returnCurvePoints = [];
+    for (let i = 0; i <= 64; i++) {
+        const p = i / 64;
+        const angle = -Math.PI * 0.9 + p * Math.PI * 1.55;
+        const radius = 3.4 - Math.sin(p * Math.PI) * 0.55;
+        viz.returnCurvePoints.push(new THREE.Vector3(
+            Math.cos(angle) * radius + 0.35,
+            Math.sin(angle) * radius - 0.25,
+            -0.4 + Math.sin(p * Math.PI * 2) * 0.3
+        ));
+    }
+
+    viz.returnArc = new THREE.Line(
+        new THREE.BufferGeometry().setFromPoints(viz.returnCurvePoints),
+        new THREE.LineBasicMaterial({
+            color: aionBlue,
+            transparent: true,
+            opacity: 0.08,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+        })
+    );
+    viz.paradoxGroup.add(viz.returnArc);
+
+    viz.returnSparks = [];
+    for (let i = 0; i < 9; i++) {
+        const spark = new THREE.Mesh(
+            new THREE.IcosahedronGeometry(0.055 + (i % 3) * 0.018, 0),
+            new THREE.MeshBasicMaterial({
+                color: i % 2 === 0 ? pleroma : aionBlue,
+                transparent: true,
+                opacity: 0.16,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        viz.paradoxGroup.add(spark);
+        viz.returnSparks.push(spark);
+    }
+}


### PR DESCRIPTION
## Summary

Refines Chapter 13 into a more explicit Gnostic emanation field: the scene now teaches pleroma, Sophia descent, quaternary seal, rupture, and return as one visual-first symbolic system.

## Skill stack

- Orchestration Autopilot with reviewer and verifier subagents
- Aion skill-routing playbook
- Three.js scene polish
- Playwright/app-shell smoke testing
- Control Tower visual QA
- GitHub PR workflow

## Routes changed

- `/journey/chapter/ch13`

## Visual thesis

Chapter 13 should feel less like generic quaternity orbits and more like a Gnostic symbolic instrument: source fullness above, Sophia descending into form, the fourfold seal stabilizing the field, and paradox returning toward integration.

## What changed

- Added a pleroma crown, aeon chains, Sophia halo, quaternary seal, and return arc/sparks to the Ch13 WebGL scene.
- Extracted Ch13-only primitive construction into `gnosticScenePrimitives.js` so the main scene stays under the project file-size guideline.
- Tightened Ch13 mobile intro typography and adjusted reduced-motion map spacing so the fallback and reference map do not overlap.
- Froze the new ornamental primitive motion when reduced motion is active while preserving panel-state visual emphasis.

## Browser evidence

- `npm run test:visual:control-tower` generated a fresh report at `test-results/control-tower/route-scores.md`.
- Control Tower inspected 20 routes across desktop, mobile, and narrow viewports.
- Result: 0 technical blockers; `/journey/chapter/ch13` scored 100% with no mobile or narrow overflow.
- Evidence screenshots are in `test-results/control-tower/latest/screenshots/`.

## Checks

- `node --check src/visualizations/chapters/ch13/ThreeQuaternioViz.js`
- `node --check src/visualizations/chapters/ch13/gnosticScenePrimitives.js`
- `git diff --check`
- `npm run build`
- `AION_SMOKE_PORT=4191 npm run test:e2e:app:mobile`
- `AION_SMOKE_PORT=4192 npm run test:e2e:app:scene-controls`
- `npm run test:app`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm test`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages && npm run test:pages:artifact`
- `npm run test:visual:control-tower`

## Residual debt

- Shared `src/app/styles.css` remains oversized existing debt; extracting chapter-scoped styles should be handled in a separate visual-system hardening batch.
- Scholarly source anchors remain deferred to the source-integrity batch; this PR does not add new prose claims.