### PR TITLE
[codex] Refine chapter fourteen final synthesis field

### DIFF
--- a/scripts/performance/verify-viz-cleanup.js
+++ b/scripts/performance/verify-viz-cleanup.js
@@ -1,62 +1,186 @@
 import { chromium } from 'playwright';
 
 const BASE_URL = process.env.PERF_BASE_URL || 'http://localhost:3000';
+const ROUTES = [
+  '/journey/chapter/ch1',
+  '/journey/chapter/ch14',
+  '/journey/chapter/ch13',
+  '/journey/chapter/ch14',
+  '/journey/chapter/ch12',
+];
+const TRACKED_WINDOW_EVENTS = ['mousemove', 'pointermove', 'wheel'];
+
+function getChapterId(route) {
+  const match = route.match(/\/journey\/chapter\/(ch\d+)$/);
+  if (!match) {
+    throw new Error(`Route ${route} does not contain a chapter id.`);
+  }
+  return match[1];
+}
+
+async function waitForScene(page, route) {
+  const expectedChapterId = getChapterId(route);
+  const chapterLocator = page.locator(`.chapter-experience[data-chapter-id="${expectedChapterId}"]`);
+  await chapterLocator.waitFor({ state: 'visible', timeout: 15_000 });
+  await chapterLocator.locator('.scene-host__mount[data-state="ready"]')
+    .waitFor({ state: 'visible', timeout: 15_000 });
+
+  const result = await page.evaluate(({ expectedRoute, expectedChapterId }) => {
+    const chapter = document.querySelector(`.chapter-experience[data-chapter-id="${expectedChapterId}"]`);
+    const canvasCount = chapter?.querySelectorAll('.scene-host canvas').length || 0;
+    const totalCanvasCount = document.querySelectorAll('.scene-host canvas').length;
+    const mountState = chapter?.querySelector('.scene-host__mount')?.getAttribute('data-state') || null;
+    const fallbackVisible = Boolean(chapter?.querySelector('.scene-host__fallback'));
+    const reduced = chapter?.getAttribute('data-reduced-motion') || null;
+    return {
+      route: window.location.pathname,
+      expectedRoute,
+      expectedChapterId,
+      canvasCount,
+      totalCanvasCount,
+      mountState,
+      fallbackVisible,
+      reduced,
+    };
+  }, { expectedRoute: route, expectedChapterId });
+
+  if (result.route !== route) {
+    throw new Error(`Expected route ${route} but browser is at ${result.route}`);
+  }
+
+  if (result.reduced === 'true') {
+    throw new Error(`Expected animated scene on ${route}, but reduced-motion fallback is active.`);
+  }
+
+  if (result.mountState !== 'ready') {
+    throw new Error(`Expected ready scene mount on ${route}, found ${result.mountState}.`);
+  }
+
+  if (result.fallbackVisible) {
+    throw new Error(`Expected no fallback scene on ${route} during cleanup verification.`);
+  }
+
+  if (result.canvasCount !== 1) {
+    throw new Error(`Expected exactly one scoped canvas on ${route}, found ${result.canvasCount}.`);
+  }
+
+  if (result.totalCanvasCount !== 1) {
+    throw new Error(`Expected exactly one active canvas after ${route}, found ${result.totalCanvasCount}.`);
+  }
+
+  return result;
+}
+
+async function routeTo(page, route) {
+  await page.evaluate((nextRoute) => {
+    window.history.pushState({}, '', nextRoute);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, route);
+  return waitForScene(page, route);
+}
 
 async function main() {
   const browser = await chromium.launch({ headless: true });
   const page = await browser.newPage();
 
-  await page.goto(`${BASE_URL}/`, { waitUntil: 'domcontentloaded' });
-
-  const result = await page.evaluate(async () => {
-    window.__AION_VIZ_MAP__ = {
-      'chapter-2': {
-        path: '/src/visualizations/testing/MockViz.js',
-        className: 'MockViz'
-      }
+  await page.addInitScript(() => {
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    const originalAddEventListener = EventTarget.prototype.addEventListener;
+    const originalRemoveEventListener = EventTarget.prototype.removeEventListener;
+    const trackedEvents = new Set(['mousemove', 'pointermove', 'wheel']);
+    window.__aionCleanupProbe = {
+      webglContextsCreated: 0,
+      webglContextsLost: 0,
+      windowEventAdds: {},
+      windowEventRemovals: {},
     };
 
-    const module = await import('/src/core/simple-viz-loader.js');
-
-    const container = document.createElement('div');
-    document.body.appendChild(container);
-
-    module.setupVisualizationIntent('chapter-2', container);
-
-    const trigger = container.querySelector('.viz-intent-trigger');
-    trigger.click();
-
-    await new Promise(resolve => setTimeout(resolve, 50));
-
-    document.dispatchEvent(new CustomEvent('aion:routeChange', {
-      detail: {
-        route: { path: '/chapter3.html' },
-        previousRoute: { path: '/chapter2.html' }
+    EventTarget.prototype.addEventListener = function patchedAddEventListener(type, listener, options) {
+      if (this === window && trackedEvents.has(type)) {
+        window.__aionCleanupProbe.windowEventAdds[type] =
+          (window.__aionCleanupProbe.windowEventAdds[type] || 0) + 1;
       }
-    }));
+      return originalAddEventListener.call(this, type, listener, options);
+    };
 
-    return {
-      lifecycle: window.__aionVizLifecycle,
-      disposeCalls: window.__mockVizDisposeCalls || 0,
-      listenerRemovals: window.__mockListenerRemovals || 0
+    EventTarget.prototype.removeEventListener = function patchedRemoveEventListener(type, listener, options) {
+      if (this === window && trackedEvents.has(type)) {
+        window.__aionCleanupProbe.windowEventRemovals[type] =
+          (window.__aionCleanupProbe.windowEventRemovals[type] || 0) + 1;
+      }
+      return originalRemoveEventListener.call(this, type, listener, options);
+    };
+
+    HTMLCanvasElement.prototype.getContext = function patchedGetContext(type, ...args) {
+      const context = originalGetContext.call(this, type, ...args);
+      if (!context || !String(type).startsWith('webgl') || context.__aionCleanupPatched) {
+        return context;
+      }
+
+      context.__aionCleanupPatched = true;
+      window.__aionCleanupProbe.webglContextsCreated += 1;
+
+      const originalGetExtension = context.getExtension.bind(context);
+      context.getExtension = function patchedGetExtension(name) {
+        const extension = originalGetExtension(name);
+        if (name === 'WEBGL_lose_context' && extension && !extension.__aionCleanupPatched) {
+          extension.__aionCleanupPatched = true;
+          const originalLoseContext = extension.loseContext.bind(extension);
+          extension.loseContext = function patchedLoseContext(...loseArgs) {
+            window.__aionCleanupProbe.webglContextsLost += 1;
+            return originalLoseContext(...loseArgs);
+          };
+        }
+        return extension;
+      };
+
+      return context;
     };
   });
 
+  await page.goto(`${BASE_URL}${ROUTES[0]}`, { waitUntil: 'domcontentloaded' });
+  const snapshots = [await waitForScene(page, ROUTES[0])];
+
+  for (const route of ROUTES.slice(1)) {
+    snapshots.push(await routeTo(page, route));
+  }
+
+  const result = await page.evaluate(() => ({
+    ...window.__aionCleanupProbe,
+    canvasCount: document.querySelectorAll('.scene-host canvas').length,
+  }));
+
   await browser.close();
 
-  if (!result.lifecycle || result.lifecycle.disposeCalls < 1) {
-    throw new Error('Expected visualization dispose() to be called on route change.');
+  if (result.webglContextsCreated < 2) {
+    throw new Error(`Expected multiple WebGL contexts during route cycling, saw ${result.webglContextsCreated}.`);
   }
 
-  if (result.listenerRemovals < 1) {
-    throw new Error('Expected listener cleanup to run on route change.');
+  if (result.webglContextsLost < ROUTES.length - 1) {
+    throw new Error(`Expected context loss on route cleanup. Lost ${result.webglContextsLost} of ${ROUTES.length - 1} transitions.`);
   }
 
-  if (result.lifecycle.routeCleanupCalls < 1) {
-    throw new Error('Expected route cleanup lifecycle counter to increment.');
+  if (result.canvasCount > 1) {
+    throw new Error(`Expected no more than one canvas after route cycling, found ${result.canvasCount}.`);
   }
 
-  console.log('Visualization cleanup verification passed:', result);
+  for (const eventType of TRACKED_WINDOW_EVENTS) {
+    const additions = result.windowEventAdds[eventType] || 0;
+    const removals = result.windowEventRemovals[eventType] || 0;
+    const activeListeners = additions - removals;
+    if (activeListeners > 1) {
+      throw new Error(
+        `Expected at most one active ${eventType} listener after route cycling, ` +
+        `found ${activeListeners} (${additions} added, ${removals} removed).`
+      );
+    }
+  }
+
+  console.log('Visualization cleanup verification passed:', {
+    routes: snapshots.map((snapshot) => snapshot.route),
+    chapters: snapshots.map((snapshot) => snapshot.expectedChapterId),
+    ...result,
+  });
 }
 
 main().catch(error => {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -7992,20 +7992,22 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument {
   position: relative;
-  width: min(31rem, 100%);
-  min-height: clamp(8.3rem, 12.4vh, 9.6rem);
+  width: min(32rem, 100%);
+  min-height: clamp(9.2rem, 14.2vh, 10.85rem);
   overflow: hidden;
   margin-top: 0.82rem;
   border: 1px solid rgba(244, 240, 232, 0.12);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 50% 20%, rgba(255, 227, 156, 0.16), transparent 4.8rem),
-    radial-gradient(circle at 28% 58%, rgba(83, 216, 232, 0.1), transparent 5rem),
-    radial-gradient(circle at 74% 58%, rgba(91, 214, 143, 0.12), transparent 4.8rem),
-    linear-gradient(108deg, rgba(5, 7, 12, 0.9), rgba(8, 11, 16, 0.74) 52%, rgba(3, 18, 20, 0.68));
+    radial-gradient(circle at 51% 43%, rgba(255, 227, 156, 0.2), transparent 3.6rem),
+    radial-gradient(circle at 23% 57%, rgba(83, 216, 232, 0.16), transparent 5.2rem),
+    radial-gradient(circle at 75% 57%, rgba(91, 214, 143, 0.16), transparent 5rem),
+    conic-gradient(from 218deg at 52% 56%, rgba(83, 216, 232, 0.08), rgba(255, 227, 156, 0.1), rgba(204, 109, 134, 0.07), rgba(91, 214, 143, 0.08), rgba(83, 216, 232, 0.08)),
+    linear-gradient(108deg, rgba(5, 7, 12, 0.94), rgba(8, 11, 16, 0.78) 52%, rgba(3, 18, 20, 0.72));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.25);
+    0 1.4rem 4rem rgba(0, 0, 0, 0.28),
+    0 0 2.7rem rgba(83, 216, 232, 0.08);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::before,
@@ -8019,14 +8021,23 @@ h3 {
   inset: 0.58rem;
   border: 1px solid rgba(255, 227, 156, 0.08);
   border-radius: calc(var(--radius) - 2px);
+  background:
+    linear-gradient(90deg, transparent 0 49.65%, rgba(244, 240, 232, 0.12) 49.85% 50.15%, transparent 50.35%),
+    linear-gradient(180deg, transparent 0 49.65%, rgba(244, 240, 232, 0.1) 49.85% 50.15%, transparent 50.35%);
+  mask-image: radial-gradient(ellipse at 50% 55%, black 0 63%, transparent 77%);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::after {
   left: 50%;
   top: 56%;
-  width: 78%;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.16), transparent);
+  width: 72%;
+  height: 42%;
+  border: 1px solid rgba(83, 216, 232, 0.1);
+  border-left-color: rgba(255, 227, 156, 0.17);
+  border-radius: 50%;
+  background:
+    radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.08), transparent 58%),
+    linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.1), transparent);
   transform: translate(-50%, -50%);
 }
 
@@ -8052,6 +8063,7 @@ h3 {
   height: 64%;
   border-radius: 50%;
   opacity: 0.34;
+  filter: drop-shadow(0 0 1.3rem rgba(83, 216, 232, 0.08));
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -8098,6 +8110,7 @@ h3 {
   transition:
     opacity 0.55s var(--motion-spring),
     border-color 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
 }
 
@@ -8123,6 +8136,29 @@ h3 {
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring::before,
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring::before {
+  inset: 12%;
+  border: 1px solid rgba(255, 227, 156, 0.14);
+  box-shadow: inset 0 0 1.2rem rgba(83, 216, 232, 0.07);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring::after {
+  left: 50%;
+  top: 50%;
+  width: 72%;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(83, 216, 232, 0.32), rgba(255, 227, 156, 0.44), rgba(204, 109, 134, 0.3));
+  transform: translate(-50%, -50%) rotate(-23deg);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif {
@@ -8183,6 +8219,9 @@ h3 {
   aspect-ratio: 1;
   border: 1px solid rgba(244, 240, 232, 0.18);
   border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(255, 227, 156, 0.1), transparent 21%),
+    conic-gradient(from 45deg, rgba(255, 227, 156, 0.12), rgba(83, 216, 232, 0.08), rgba(91, 214, 143, 0.08), rgba(204, 109, 134, 0.08), rgba(255, 227, 156, 0.12));
   opacity: 0.75;
   transform: translate(-50%, -50%);
   transition:
@@ -8301,6 +8340,15 @@ h3 {
     border-color 0.55s var(--motion-spring);
 }
 
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__path::before {
+  content: '';
+  position: absolute;
+  inset: 13% 9% 8% 14%;
+  border-top: 1px solid rgba(255, 227, 156, 0.22);
+  border-radius: 50%;
+  transform: rotate(-18deg);
+}
+
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark {
   width: 0.5rem;
   aspect-ratio: 1;
@@ -8337,6 +8385,7 @@ h3 {
   font-size: 0.58rem;
   font-weight: 700;
   letter-spacing: 0;
+  text-shadow: 0 0 0.85rem rgba(0, 0, 0, 0.6);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label--gather {
@@ -8369,7 +8418,9 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__motif {
-  box-shadow: 0 0 1rem rgba(212, 175, 55, 0.2);
+  box-shadow:
+    0 0 0 0.22rem rgba(255, 227, 156, 0.06),
+    0 0 1rem rgba(212, 175, 55, 0.26);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__axis,
@@ -8384,8 +8435,13 @@ h3 {
   border-color: rgba(255, 227, 156, 0.34);
   box-shadow:
     inset 0 0 1.1rem rgba(83, 216, 232, 0.08),
-    0 0 1.75rem rgba(212, 175, 55, 0.2);
+    0 0 1.75rem rgba(212, 175, 55, 0.24);
   transform: translate(-50%, -50%) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__orbit {
+  border-color: rgba(255, 227, 156, 0.28);
+  box-shadow: 0 0 1.4rem rgba(83, 216, 232, 0.08);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__ego {

--- a/src/visualizations/chapters/ch14/ThreeAeonFinalViz.js
+++ b/src/visualizations/chapters/ch14/ThreeAeonFinalViz.js
@@ -18,6 +18,7 @@ import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
+import { createFinalSynthesisField } from './finalSynthesisPrimitives.js';
 
 /* ─── Palette ─── */
 const ANTHROPOS_GOLD = new THREE.Color('#ffd700');
@@ -86,6 +87,13 @@ export default class ThreeAeonFinalViz extends BaseViz {
         this._createCoagulaField();
         this._createHermeticVessel();
         this._createPhoenixCore();
+        createFinalSynthesisField(this, {
+            gold: ANTHROPOS_GOLD,
+            cyan: VESSEL_CYAN,
+            green: PARADISE_GREEN,
+            red: LAPIS_RED,
+            white: ARROW_WHITE,
+        });
         this._createCosmicField();
         this._createLights();
 
@@ -557,6 +565,43 @@ export default class ThreeAeonFinalViz extends BaseViz {
         this.phoenixCore.scale.setScalar(0.5 + phoenixPulse * 0.5);
         this.phoenixHalo.material.opacity = phoenixProgress * phoenixPulse * 0.08;
         this.phoenixHalo.scale.setScalar(1 + phoenixPulse * 1.5);
+
+        // ─── Final synthesis field — temenos, bridges, and living path ───
+        this.finalSynthesisGroup.rotation.y = -t * 0.009 * motionScale + this.aeonFocus * 0.1;
+        this.finalSynthesisGroup.rotation.z = Math.sin(t * 0.035 * motionScale) * 0.025;
+        this.temenosRings?.forEach((ring, index) => {
+            const drift = this.reducedMotion ? 0 : t * (0.01 + index * 0.003) * (index % 2 ? -1 : 1);
+            ring.rotation.copy(ring.userData.baseRotation);
+            ring.rotation.z += drift + this.axisFocus * 0.08;
+            ring.scale.copy(ring.userData.baseScale);
+            ring.scale.multiplyScalar(1 + this.gatherFocus * 0.025 + this.axisFocus * 0.035 + this.aeonFocus * 0.02);
+            ring.material.opacity = 0.02 + this.gatherFocus * 0.045 + this.axisFocus * 0.035 + this.aeonFocus * 0.04;
+        });
+        this.synthesisPetals?.forEach((petal, index) => {
+            petal.material.opacity = 0.015 + this.gatherFocus * 0.055 + this.axisFocus * 0.035 + (index % 2 ? this.aeonFocus * 0.014 : 0);
+        });
+        this.axisBridgeLines?.forEach((line, index) => {
+            line.material.opacity = 0.018 + this.axisFocus * 0.18 + this.gatherFocus * 0.018 + (index === 3 ? this.aeonFocus * 0.055 : 0);
+        });
+        if (this.individuationPath) {
+            this.individuationPath.material.opacity = 0.035 + this.aeonFocus * 0.32 + this.gatherFocus * 0.035;
+        }
+        this.pathSparks?.forEach((spark, index) => {
+            const phase = this.reducedMotion ? index / Math.max(1, this.pathSparks.length - 1) : (t * 0.035 + index / this.pathSparks.length) % 1;
+            const pointIndex = Math.min(this.individuationPathPoints.length - 1, Math.floor(phase * (this.individuationPathPoints.length - 1)));
+            const pathPoint = this.individuationPathPoints[pointIndex] || this.individuationPathPoints[0];
+            if (pathPoint) spark.position.copy(pathPoint);
+            spark.rotation.y = (this.reducedMotion ? 0 : t * 0.22) + index;
+            spark.material.opacity = 0.04 + this.aeonFocus * 0.36 + (phase > 0.72 ? this.gatherFocus * 0.08 : 0);
+            const sparkPulse = this.reducedMotion ? 0 : Math.sin(t * 0.38 + index) * 0.08;
+            spark.scale.setScalar(0.78 + this.aeonFocus * 0.82 + sparkPulse);
+        });
+        if (this.selfLens) {
+            this.selfLens.rotation.y = this.reducedMotion ? 0 : t * 0.18;
+            this.selfLens.rotation.x = this.reducedMotion ? 0 : t * 0.11;
+            this.selfLens.material.opacity = 0.1 + this.axisFocus * 0.28 + this.aeonFocus * 0.12;
+            this.selfLens.scale.setScalar(0.85 + this.axisFocus * 0.42 + this.aeonFocus * 0.18);
+        }
 
         // ─── Vessel subtle shimmer ───
         this.vessel.material.opacity = 0.02 + this.gatherFocus * 0.025 + this.aeonFocus * 0.025 + Math.sin(t * 0.1 * motionScale) * 0.01;

--- a/src/visualizations/chapters/ch14/finalSynthesisPrimitives.js
+++ b/src/visualizations/chapters/ch14/finalSynthesisPrimitives.js
@@ -1,0 +1,144 @@
+import * as THREE from 'three';
+
+function lineMaterial(color, opacity) {
+    return new THREE.LineBasicMaterial({
+        color,
+        transparent: true,
+        opacity,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+    });
+}
+
+function pointOnPath(points, phase) {
+    const index = Math.min(points.length - 1, Math.max(0, Math.floor(phase * (points.length - 1))));
+    return points[index] || points[0];
+}
+
+export function createFinalSynthesisField(viz, { gold, cyan, green, red, white }) {
+    viz.finalSynthesisGroup = new THREE.Group();
+    viz.temenosRings = [];
+    viz.synthesisPetals = [];
+    viz.axisBridgeLines = [];
+    viz.pathSparks = [];
+    viz.individuationPathPoints = [];
+
+    const ringSpecs = [
+        { radius: 7.8, tube: 0.014, color: gold, opacity: 0.06, rotation: [Math.PI / 2, 0, 0], scale: [1, 0.46, 1] },
+        { radius: 6.2, tube: 0.012, color: cyan, opacity: 0.055, rotation: [Math.PI / 2, Math.PI / 4, 0], scale: [1, 0.34, 1] },
+        { radius: 4.8, tube: 0.01, color: green, opacity: 0.048, rotation: [Math.PI / 2, -Math.PI / 4, 0], scale: [1, 0.52, 1] },
+        { radius: 3.35, tube: 0.009, color: white, opacity: 0.038, rotation: [Math.PI / 2, 0, Math.PI / 2], scale: [1, 0.38, 1] },
+    ];
+
+    ringSpecs.forEach((spec, index) => {
+        const ring = new THREE.Mesh(
+            new THREE.TorusGeometry(spec.radius, spec.tube, 8, 160),
+            new THREE.MeshBasicMaterial({
+                color: spec.color,
+                transparent: true,
+                opacity: spec.opacity,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        ring.rotation.set(...spec.rotation);
+        ring.scale.set(...spec.scale);
+        ring.userData.baseRotation = ring.rotation.clone();
+        ring.userData.baseScale = ring.scale.clone();
+        ring.userData.index = index;
+        viz.finalSynthesisGroup.add(ring);
+        viz.temenosRings.push(ring);
+    });
+
+    for (let i = 0; i < 8; i++) {
+        const angle = (i / 8) * Math.PI * 2;
+        const points = [];
+        for (let step = 0; step <= 44; step++) {
+            const p = step / 44;
+            const spread = Math.sin(p * Math.PI) * (2.4 + (i % 2) * 0.65);
+            points.push(new THREE.Vector3(
+                Math.cos(angle) * spread,
+                THREE.MathUtils.lerp(-7.2, 7.2, p),
+                Math.sin(angle) * spread * 0.62
+            ));
+        }
+        const petal = new THREE.Line(pointsToGeometry(points), lineMaterial(i % 2 ? cyan : gold, 0.045));
+        petal.userData.index = i;
+        viz.finalSynthesisGroup.add(petal);
+        viz.synthesisPetals.push(petal);
+    }
+
+    [
+        { from: 6, to: 2, color: gold },
+        { from: 2, to: -2, color: cyan },
+        { from: -2, to: -6, color: red },
+        { from: -6, to: 6, color: green },
+    ].forEach((bridge, index) => {
+        const side = index % 2 === 0 ? -1 : 1;
+        const points = [
+            new THREE.Vector3(side * 2.9, bridge.from, -0.2),
+            new THREE.Vector3(side * 0.85, (bridge.from + bridge.to) / 2, 0.62),
+            new THREE.Vector3(-side * 2.9, bridge.to, -0.2),
+        ];
+        const curve = new THREE.CatmullRomCurve3(points);
+        const line = new THREE.Line(
+            pointsToGeometry(curve.getPoints(36)),
+            lineMaterial(bridge.color, 0.055)
+        );
+        line.userData.index = index;
+        viz.finalSynthesisGroup.add(line);
+        viz.axisBridgeLines.push(line);
+    });
+
+    for (let i = 0; i <= 140; i++) {
+        const p = i / 140;
+        const angle = -Math.PI * 0.82 + p * Math.PI * 3.35;
+        const radius = 5.6 + Math.sin(p * Math.PI) * 1.35;
+        viz.individuationPathPoints.push(new THREE.Vector3(
+            Math.cos(angle) * radius,
+            THREE.MathUtils.lerp(-6.85, 6.85, p),
+            Math.sin(angle) * radius * 0.7
+        ));
+    }
+
+    viz.individuationPath = new THREE.Line(
+        pointsToGeometry(viz.individuationPathPoints),
+        lineMaterial(green, 0.065)
+    );
+    viz.finalSynthesisGroup.add(viz.individuationPath);
+
+    for (let i = 0; i < 12; i++) {
+        const spark = new THREE.Mesh(
+            new THREE.IcosahedronGeometry(0.07 + (i % 3) * 0.018, 0),
+            new THREE.MeshBasicMaterial({
+                color: i % 3 === 0 ? gold : i % 3 === 1 ? green : cyan,
+                transparent: true,
+                opacity: 0.16,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false,
+            })
+        );
+        const point = pointOnPath(viz.individuationPathPoints, i / 11);
+        if (point) spark.position.copy(point);
+        viz.finalSynthesisGroup.add(spark);
+        viz.pathSparks.push(spark);
+    }
+
+    viz.selfLens = new THREE.Mesh(
+        new THREE.IcosahedronGeometry(0.54, 2),
+        new THREE.MeshBasicMaterial({
+            color: gold,
+            transparent: true,
+            opacity: 0.18,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+        })
+    );
+    viz.finalSynthesisGroup.add(viz.selfLens);
+
+    viz.mainGroup.add(viz.finalSynthesisGroup);
+}
+
+function pointsToGeometry(points) {
+    return new THREE.BufferGeometry().setFromPoints(points);
+}


### PR DESCRIPTION
## Summary

Refines Chapter 14 into a stronger final synthesis field: the WebGL scene now layers a temenos ring system, axis bridges, petal logic, path sparks, and a Self lens over the existing quaternio/uroboros structure, while the static instrument gets a richer visual-first final mandala treatment.

## Skill stack

- orchestration-autopilot reviewer lane
- GitHub publish workflow
- Three.js scene polish
- accessibility/webapp smoke testing
- Control Tower visual QA
- performance cleanup verification

## Routes changed

- `/journey/chapter/ch14`

## What changed

- Added a split-out `finalSynthesisPrimitives.js` helper for Ch14 synthesis primitives.
- Mounted the final synthesis primitive layer into `ThreeAeonFinalViz.js` with panel-aware, reduced-motion-aware animation states.
- Strengthened the Chapter 14 final synthesis instrument styling without changing the tested DOM contract.
- Replaced the stale cleanup verifier with a current React/Vite route-cycling probe that checks chapter-scoped ready scenes, WebGL context loss, final canvas count, and tracked window listener balance.

## Browser and QA evidence

- `npm run test:visual:control-tower` generated `test-results/control-tower/route-scores.md`.
- Control Tower inspected 20 routes across desktop, mobile, and narrow viewports.
- `/journey/chapter/ch14` scored 100% with no technical blockers and 0px mobile/narrow overflow.
- `npm run perf:cleanup` passed against Vite preview with 5 WebGL contexts created, 4 lost, and one final active canvas/listener.
- `npm run perf:runtime` reported `/journey/chapter/ch14` at 60.44 fps and 9.54MB memory in the local runtime probe.

## Checks

- `node --check scripts/performance/verify-viz-cleanup.js`
- `node --check src/visualizations/chapters/ch14/finalSynthesisPrimitives.js`
- `node --check src/visualizations/chapters/ch14/ThreeAeonFinalViz.js`
- `git diff --check`
- `npm run build`
- `PERF_BASE_URL=http://127.0.0.1:4199 npm run perf:cleanup`
- `PERF_BASE_URL=http://127.0.0.1:4199 npm run perf:runtime`
- `npm run test:app`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm test`
- `npm run build:pages`
- `npm run test:pages:artifact`
- `AION_SMOKE_PORT=4200 npm run test:e2e:app`
- `AION_SMOKE_PORT=4201 npm run test:e2e:app:scene-controls`
- `AION_SMOKE_PORT=4202 npm run test:e2e:app:mobile`
- `AION_A11Y_PORT=4203 npm run test:a11y:app`
- `AION_VISUAL_PORT=4204 npm run test:visual:control-tower`

## Residual debt

- The Ch14 scene class remains longer than the preferred 500 LOC limit because this batch stayed focused on visual polish and pulled only the new synthesis primitive layer into a helper.
- Broader Three chunk strategy and dependency security upgrades remain release-hardening work outside this route polish batch.
