### PR TITLE
[codex] Make Atlas field visual-first

### DIFF
--- a/src/app/components/AtlasConstellation.tsx
+++ b/src/app/components/AtlasConstellation.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
 
 import type { ChapterRecord, ConceptRecord, RelationshipRecord, SymbolRecord } from '../types';
 
@@ -10,6 +10,7 @@ interface AtlasConstellationProps {
   linkedSymbols: SymbolRecord[];
   entityLabel: (id: string) => string;
   onSelectChapter: (id: ChapterRecord['id']) => void;
+  controls?: ReactNode;
 }
 
 interface FieldNode {
@@ -75,6 +76,7 @@ export default function AtlasConstellation({
   linkedSymbols,
   entityLabel,
   onSelectChapter,
+  controls,
 }: AtlasConstellationProps) {
   const conceptNodes = placeNodes(activeConcepts.slice(0, 6), 184, 'concept', -Math.PI / 2.18);
   const symbolNodes = placeNodes(linkedSymbols.slice(0, 5), 286, 'symbol', -Math.PI / 1.14);
@@ -178,6 +180,8 @@ export default function AtlasConstellation({
           <p id="atlas-field-desc">{fieldDescription}</p>
         </div>
       </div>
+
+      {controls}
 
       <div className="atlas-constellation__chapter-rail" role="radiogroup" aria-label={chapterResultText}>
         {filteredChapters.length > 0 ? (

--- a/src/app/pages/AtlasPage.tsx
+++ b/src/app/pages/AtlasPage.tsx
@@ -137,26 +137,6 @@ export default function AtlasPage() {
 
         <div className="atlas-layout atlas-layout--hero">
           <section className="atlas-map" aria-labelledby="atlas-map-title">
-            <div className="atlas-map__controls">
-              <div>
-                <p className="eyebrow">Field Filter</p>
-                <h2 id="atlas-map-title">Concept Field</h2>
-              </div>
-              <div className="atlas-map__search">
-                <label htmlFor="atlas-search">Search Atlas Field</label>
-                <input
-                  id="atlas-search"
-                  name="atlas-search"
-                  type="search"
-                  autoComplete="off"
-                  value={query}
-                  onChange={(event) => setQuery(event.target.value)}
-                  aria-describedby="atlas-search-status"
-                  placeholder="shadow, fish, quaternity…"
-                />
-              </div>
-              <output id="atlas-search-status" role="status" aria-live="polite">{chapterResultText}</output>
-            </div>
             <AtlasConstellation
               active={active}
               activeConcepts={activeConcepts}
@@ -165,6 +145,28 @@ export default function AtlasPage() {
               linkedSymbols={linkedSymbols}
               entityLabel={entityLabel}
               onSelectChapter={setSelected}
+              controls={(
+                <div className="atlas-map__controls">
+                  <div>
+                    <p className="eyebrow">Field Filter</p>
+                    <h2 id="atlas-map-title">Concept Field</h2>
+                  </div>
+                  <div className="atlas-map__search">
+                    <label htmlFor="atlas-search">Search Atlas Field</label>
+                    <input
+                      id="atlas-search"
+                      name="atlas-search"
+                      type="search"
+                      autoComplete="off"
+                      value={query}
+                      onChange={(event) => setQuery(event.target.value)}
+                      aria-describedby="atlas-search-status"
+                      placeholder="shadow, fish, quaternity…"
+                    />
+                  </div>
+                  <output id="atlas-search-status" role="status" aria-live="polite">{chapterResultText}</output>
+                </div>
+              )}
             />
           </section>
 

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -10704,9 +10704,9 @@ h3 {
 
   .atlas-hero {
     display: grid;
-    gap: 1rem;
+    gap: 0.72rem;
     min-height: auto;
-    padding-top: 10.25rem;
+    padding-top: 9.85rem;
   }
 
   .atlas-layout--hero {
@@ -10714,24 +10714,45 @@ h3 {
   }
 
   .atlas-map {
+    display: flex;
+    flex-direction: column;
+    gap: 0.68rem;
     min-height: auto;
+    padding: 0.62rem;
   }
 
   .atlas-map__controls {
     grid-template-columns: 1fr;
     align-items: stretch;
+    padding: 0.68rem;
   }
 
   .atlas-map__controls output {
     justify-self: start;
   }
 
+  .atlas-constellation {
+    order: 1;
+    gap: 0.62rem;
+  }
+
   .atlas-constellation__stage {
-    min-height: clamp(22rem, 82vw, 30rem);
+    min-height: clamp(20rem, 74vw, 28rem);
+    border: 1px solid rgba(212, 175, 55, 0.12);
   }
 
   .atlas-constellation__chapter-rail {
-    grid-auto-columns: minmax(10.5rem, 76vw);
+    grid-auto-columns: minmax(8.4rem, 48vw);
+  }
+
+  .atlas-constellation__chapter,
+  .atlas-constellation__empty {
+    min-height: 4.25rem;
+    padding: 0.58rem;
+  }
+
+  .atlas-constellation__chapter strong {
+    font-size: 0.92rem;
   }
 
   .atlas-constellation__relation-band span {
@@ -10758,16 +10779,13 @@ h3 {
   }
 
   .atlas-hero__copy h1 {
-    max-width: 11ch;
-    font-size: clamp(2.55rem, 12.5vw, 3.6rem);
+    max-width: 10.8ch;
+    font-size: clamp(2.45rem, 12vw, 3.5rem);
     line-height: 0.95;
   }
 
   .atlas-hero__copy .lede {
-    display: block;
-    max-width: 20rem;
-    font-size: 0.9rem;
-    line-height: 1.55;
+    display: none;
   }
 
   .page-header--visual h1,
@@ -10778,11 +10796,7 @@ h3 {
   }
 
   .atlas-hero__metrics {
-    margin-top: 0.9rem;
-  }
-
-  .atlas-hero__metrics span {
-    padding-block: 0.58rem;
+    display: none;
   }
 
   .path-grid,
@@ -11834,6 +11848,40 @@ h3 {
     min-width: 0;
     justify-content: center;
     text-align: center;
+  }
+
+  .atlas-hero {
+    padding-top: 9.65rem;
+  }
+
+  .atlas-hero__copy > .eyebrow {
+    display: none;
+  }
+
+  .atlas-hero__copy h1 {
+    max-width: 100%;
+    font-size: clamp(2.2rem, 10.8vw, 2.9rem);
+  }
+
+  .atlas-map {
+    padding: 0.52rem;
+  }
+
+  .atlas-constellation__stage {
+    min-height: clamp(17.6rem, 82vw, 20.5rem);
+  }
+
+  .atlas-constellation__chapter-rail {
+    grid-auto-columns: minmax(7.3rem, 44vw);
+  }
+
+  .atlas-map__controls h2 {
+    font-size: 1.34rem;
+  }
+
+  .atlas-map__controls output {
+    min-height: 2.1rem;
+    font-size: 0.7rem;
   }
 
   .chapter-experience[data-chapter-id="ch3"] .chapter-stage__intro {


### PR DESCRIPTION
## Summary
- Renders the Atlas constellation before the filter console so the route opens with the visual teaching field.
- Keeps the search controls wired into the same Atlas state while placing them immediately after the visual stage.
- Tightens Atlas mobile/narrow spacing so the field appears in the first viewport before dense copy or metrics.

## Skill stack
- Aion skill-routing playbook
- Subagent orchestration: explorer, architect planner, test verifier, reviewer
- Browser/Playwright visual QA
- accessibility-review/webapp-testing style gates via local smoke scripts
- github:yeet publish flow

## Routes changed
- `/atlas`

## Visual thesis
Atlas should behave like a living concept field first, not a search panel first. The page now introduces the constellation immediately, then offers filtering and chapter selection as instruments around that field.

## Browser evidence
- Local Playwright screenshots at 1440x1000, 390x844, and 320x568.
- Atlas mobile field starts at about 290px; narrow field starts at about 271px.
- No horizontal overflow at 1440, 390, or 320px.
- Search interaction still filters and clears correctly.
- Regenerated Control Tower report: 20 routes, 3 viewports each, 0 blockers, `/atlas` 100%.

## Checks
- `git diff --check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `AION_SMOKE_PORT=4211 node scripts/testing/app-shell-smoke.mjs --shard=foundation`
- `AION_SMOKE_PORT=4214 node scripts/testing/app-shell-smoke.mjs --shard=mobile`
- `AION_A11Y_PORT=4212 node scripts/testing/app-accessibility-smoke.mjs`
- `AION_VISUAL_QA_PORT=4213 AION_VISUAL_MIN_SCORE=85 node scripts/testing/visual-control-tower.mjs`
- `npm run build:pages && npm run test:pages:artifact`

## Residual debt
- Atlas still uses the shared `src/app/styles.css` surface, so future route batches should avoid unrelated shared-style edits.
- Push reported existing default-branch Dependabot vulnerability alerts; this PR does not touch dependencies.
