### PR TITLE
[codex] Add alchemy transformation bridge

### DIFF
--- a/src/app/components/AlchemyTransformationInstrument.css
+++ b/src/app/components/AlchemyTransformationInstrument.css
@@ -1,0 +1,453 @@
+.alchemy-transformation-instrument {
+  --alchemy-accent: #d4af37;
+  --alchemy-secondary: #53d8e8;
+  --alchemy-red: #a6534f;
+  --alchemy-ink: rgba(3, 3, 7, 0.58);
+  position: relative;
+  width: min(30rem, 100%);
+  margin-top: 0.56rem;
+  padding: 0.32rem;
+  overflow: hidden;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: calc(var(--radius) + 0.18rem);
+  background:
+    radial-gradient(circle at 18% 4%, color-mix(in srgb, var(--alchemy-secondary) 16%, transparent), transparent 6.8rem),
+    radial-gradient(circle at 86% 15%, color-mix(in srgb, var(--alchemy-accent) 18%, transparent), transparent 7.2rem),
+    linear-gradient(180deg, rgba(244, 240, 232, 0.055), rgba(244, 240, 232, 0.018));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 1.8rem 4rem rgba(0, 0, 0, 0.24);
+}
+
+.alchemy-transformation-instrument--ch11 {
+  --alchemy-accent: #e2c96d;
+  --alchemy-secondary: #61d2d8;
+}
+
+.alchemy-transformation-instrument__header,
+.alchemy-transformation-instrument__field,
+.alchemy-transformation-instrument__rail,
+.alchemy-transformation-instrument__steps {
+  position: relative;
+  z-index: 2;
+}
+
+.alchemy-transformation-instrument__header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.04rem 0.6rem;
+  padding: 0.08rem 0.18rem 0.2rem;
+  text-align: left;
+}
+
+.alchemy-transformation-instrument__header span,
+.alchemy-transformation-instrument__header em,
+.alchemy-transformation-instrument__step span {
+  color: rgba(244, 240, 232, 0.54);
+  font-family: var(--font-ui);
+  font-size: 0.55rem;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.alchemy-transformation-instrument__header strong {
+  color: rgba(244, 240, 232, 0.94);
+  font-family: var(--font-display);
+  font-size: 0.96rem;
+  font-weight: 650;
+  line-height: 0.94;
+}
+
+.alchemy-transformation-instrument__header em {
+  align-self: end;
+  color: color-mix(in srgb, var(--alchemy-accent) 86%, rgba(244, 240, 232, 0.78));
+  text-align: right;
+}
+
+.alchemy-transformation-instrument__field {
+  min-height: clamp(6.4rem, 12vh, 8.2rem);
+  overflow: hidden;
+  border: 1px solid rgba(244, 240, 232, 0.085);
+  border-radius: calc(var(--radius) - 0.05rem);
+  background:
+    linear-gradient(90deg, rgba(83, 216, 232, 0.09), transparent 42%, rgba(166, 83, 79, 0.11)),
+    repeating-linear-gradient(0deg, transparent 0 0.66rem, rgba(244, 240, 232, 0.035) 0.68rem 0.72rem),
+    rgba(3, 3, 7, 0.34);
+}
+
+.alchemy-transformation-instrument__field > span {
+  position: absolute;
+  pointer-events: none;
+}
+
+.alchemy-transformation-instrument__horizon {
+  left: 7%;
+  right: 7%;
+  top: 54%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.16), transparent);
+}
+
+.alchemy-transformation-instrument__vessel {
+  left: 11%;
+  top: 35%;
+  width: 24%;
+  height: 35%;
+  border: 1px solid color-mix(in srgb, var(--alchemy-secondary) 48%, transparent);
+  border-radius: 50% 50% 44% 44% / 58% 58% 40% 40%;
+  background:
+    radial-gradient(circle at 54% 55%, rgba(212, 175, 55, 0.26), transparent 30%),
+    radial-gradient(circle at 34% 58%, rgba(83, 216, 232, 0.18), transparent 42%);
+  box-shadow: inset 0 -1.2rem 2.4rem rgba(83, 216, 232, 0.08);
+}
+
+.alchemy-transformation-instrument__bath {
+  left: 7%;
+  bottom: 18%;
+  width: 30%;
+  height: 10%;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, color-mix(in srgb, var(--alchemy-secondary) 40%, transparent), transparent 72%);
+}
+
+.alchemy-transformation-instrument__fish {
+  left: 12.5%;
+  top: 51%;
+  width: 15%;
+  height: 10%;
+  border: 1px solid rgba(244, 240, 232, 0.36);
+  border-radius: 52% 48% 48% 52%;
+  transform: rotate(-3deg);
+  background: rgba(212, 175, 55, 0.18);
+}
+
+.alchemy-transformation-instrument__fish::after {
+  content: '';
+  position: absolute;
+  right: -0.38rem;
+  top: 50%;
+  width: 0.62rem;
+  height: 0.62rem;
+  border: 1px solid rgba(244, 240, 232, 0.32);
+  border-width: 1px 1px 0 0;
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.alchemy-transformation-instrument__prima {
+  left: 34%;
+  top: 32%;
+  width: 22%;
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in srgb, var(--alchemy-accent) 34%, transparent);
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(244, 240, 232, 0.22), transparent 20%),
+    radial-gradient(circle at 35% 38%, rgba(83, 216, 232, 0.18), transparent 34%),
+    radial-gradient(circle at 65% 58%, rgba(166, 83, 79, 0.2), transparent 34%);
+}
+
+.alchemy-transformation-instrument__axis {
+  left: 61%;
+  top: 13%;
+  width: 1px;
+  height: 72%;
+  background: linear-gradient(180deg, transparent, color-mix(in srgb, var(--alchemy-accent) 58%, transparent), transparent);
+}
+
+.alchemy-transformation-instrument__serpent {
+  --alchemy-serpent-tilt: 19deg;
+  left: 53%;
+  top: 18%;
+  width: 16%;
+  height: 64%;
+  border: 2px solid transparent;
+  border-radius: 50%;
+  transform: rotate(var(--alchemy-serpent-tilt));
+}
+
+.alchemy-transformation-instrument__serpent--gold {
+  --alchemy-serpent-tilt: 19deg;
+  border-left-color: color-mix(in srgb, var(--alchemy-accent) 64%, transparent);
+  border-right-color: color-mix(in srgb, var(--alchemy-accent) 22%, transparent);
+  animation: alchemy-bridge-breathe 8s var(--motion-spring) infinite alternate;
+}
+
+.alchemy-transformation-instrument__serpent--cyan {
+  --alchemy-serpent-tilt: -19deg;
+  border-left-color: color-mix(in srgb, var(--alchemy-secondary) 60%, transparent);
+  border-right-color: color-mix(in srgb, var(--alchemy-secondary) 18%, transparent);
+  animation: alchemy-bridge-breathe 8s var(--motion-spring) infinite alternate-reverse;
+}
+
+.alchemy-transformation-instrument__stone {
+  right: 13%;
+  top: 35%;
+  width: 15%;
+  aspect-ratio: 1;
+  border: 1px solid rgba(244, 240, 232, 0.2);
+  transform: rotate(45deg);
+  background:
+    radial-gradient(circle at 50% 50%, rgba(244, 240, 232, 0.2), transparent 26%),
+    linear-gradient(135deg, color-mix(in srgb, var(--alchemy-accent) 34%, transparent), color-mix(in srgb, var(--alchemy-red) 28%, transparent));
+}
+
+.alchemy-transformation-instrument__mirror {
+  right: 8%;
+  bottom: 18%;
+  width: 21%;
+  height: 13%;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, color-mix(in srgb, var(--alchemy-accent) 24%, transparent), transparent 72%);
+}
+
+.alchemy-transformation-instrument__path {
+  left: 16%;
+  right: 16%;
+  bottom: 12%;
+  height: 0.3rem;
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, rgba(83, 216, 232, 0.55), rgba(244, 240, 232, 0.34), rgba(212, 175, 55, 0.66), rgba(166, 83, 79, 0.58));
+}
+
+.alchemy-transformation-instrument__path-node {
+  top: 50%;
+  left: calc(var(--alchemy-step-index) * 33.333%);
+  width: 0.62rem;
+  height: 0.62rem;
+  border: 1px solid rgba(244, 240, 232, 0.34);
+  border-radius: 50%;
+  background: var(--alchemy-ink);
+  transform: translate(-50%, -50%);
+}
+
+.alchemy-transformation-instrument[data-active-panel="vessel"] .alchemy-transformation-instrument__path-node--vessel,
+.alchemy-transformation-instrument[data-active-panel="prima"] .alchemy-transformation-instrument__path-node--prima,
+.alchemy-transformation-instrument[data-active-panel="mercurius"] .alchemy-transformation-instrument__path-node--mercurius,
+.alchemy-transformation-instrument[data-active-panel="lapis"] .alchemy-transformation-instrument__path-node--lapis {
+  background: var(--alchemy-accent);
+  box-shadow: 0 0 1.2rem color-mix(in srgb, var(--alchemy-accent) 44%, transparent);
+}
+
+.alchemy-transformation-instrument__label {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.52rem;
+  font-weight: 850;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.alchemy-transformation-instrument__label--vessel {
+  left: 8%;
+  top: 12%;
+  color: color-mix(in srgb, var(--alchemy-secondary) 82%, rgba(244, 240, 232, 0.72));
+}
+
+.alchemy-transformation-instrument__label--middle {
+  left: 52%;
+  top: 12%;
+}
+
+.alchemy-transformation-instrument__label--stone {
+  right: 6%;
+  top: 12%;
+  color: color-mix(in srgb, var(--alchemy-accent) 82%, rgba(244, 240, 232, 0.72));
+}
+
+.alchemy-transformation-instrument[data-active-panel="vessel"] .alchemy-transformation-instrument__vessel,
+.alchemy-transformation-instrument[data-active-panel="vessel"] .alchemy-transformation-instrument__fish,
+.alchemy-transformation-instrument[data-active-panel="prima"] .alchemy-transformation-instrument__prima,
+.alchemy-transformation-instrument[data-active-panel="mercurius"] .alchemy-transformation-instrument__axis,
+.alchemy-transformation-instrument[data-active-panel="mercurius"] .alchemy-transformation-instrument__serpent,
+.alchemy-transformation-instrument[data-active-panel="lapis"] .alchemy-transformation-instrument__stone,
+.alchemy-transformation-instrument[data-active-panel="lapis"] .alchemy-transformation-instrument__mirror {
+  opacity: 1;
+  filter: brightness(1.18);
+}
+
+.alchemy-transformation-instrument__rail {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.28rem;
+  margin-top: 0.28rem;
+}
+
+.alchemy-transformation-instrument__rail-link,
+.alchemy-transformation-instrument__step {
+  display: grid;
+  width: 100%;
+  min-height: 1.72rem;
+  color: rgba(244, 240, 232, 0.58);
+  text-decoration: none;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  border-radius: 0.58rem;
+  background: rgba(3, 3, 7, 0.34);
+  transition:
+    color 0.42s var(--motion-spring),
+    border-color 0.42s var(--motion-spring),
+    background 0.42s var(--motion-spring),
+    transform 0.42s var(--motion-spring);
+}
+
+button.alchemy-transformation-instrument__step {
+  appearance: none;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.alchemy-transformation-instrument__rail-link {
+  padding: 0.18rem 0.3rem;
+}
+
+.alchemy-transformation-instrument__rail-link:hover,
+.alchemy-transformation-instrument__rail-link:focus-visible,
+.alchemy-transformation-instrument__step:hover,
+.alchemy-transformation-instrument__step:focus-visible {
+  color: rgba(244, 240, 232, 0.9);
+  border-color: rgba(244, 240, 232, 0.18);
+  background: rgba(244, 240, 232, 0.06);
+  transform: translateY(-1px);
+}
+
+.alchemy-transformation-instrument__rail-link--active,
+.alchemy-transformation-instrument__step--active {
+  color: rgba(244, 240, 232, 0.96);
+  border-color: color-mix(in srgb, var(--alchemy-accent) 44%, transparent);
+  background:
+    radial-gradient(circle at 20% 20%, color-mix(in srgb, var(--alchemy-accent) 20%, transparent), transparent 2rem),
+    rgba(244, 240, 232, 0.07);
+}
+
+.alchemy-transformation-instrument__rail-link span {
+  color: color-mix(in srgb, var(--alchemy-accent) 86%, rgba(244, 240, 232, 0.72));
+  font-family: var(--font-ui);
+  font-size: 0.48rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.alchemy-transformation-instrument__rail-link strong {
+  margin-top: 0.04rem;
+  font-family: var(--font-ui);
+  font-size: 0.58rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.alchemy-transformation-instrument__steps {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.22rem;
+  margin: 0.28rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.alchemy-transformation-instrument__step {
+  align-content: center;
+  gap: 0.08rem;
+  padding: 0.22rem 0.24rem;
+}
+
+.alchemy-transformation-instrument__step strong {
+  overflow: hidden;
+  color: currentColor;
+  font-family: var(--font-ui);
+  font-size: 0.52rem;
+  font-weight: 850;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.alchemy-transformation-instrument__readout {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+@keyframes alchemy-bridge-breathe {
+  from {
+    opacity: 0.36;
+    transform: rotate(var(--alchemy-serpent-tilt)) scaleY(0.94);
+  }
+
+  to {
+    opacity: 0.78;
+    transform: rotate(var(--alchemy-serpent-tilt)) scaleY(1.04);
+  }
+}
+
+@media (max-width: 680px) {
+  .alchemy-transformation-instrument {
+    width: min(25.5rem, 100%);
+    padding: 0.36rem;
+  }
+
+  .alchemy-transformation-instrument__field {
+    min-height: 6.6rem;
+  }
+
+  .alchemy-transformation-instrument__steps {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .alchemy-transformation-instrument__step {
+    min-height: 1.76rem;
+  }
+
+  .alchemy-transformation-instrument__step strong {
+    font-size: 0.48rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .alchemy-transformation-instrument {
+    margin-top: 0.72rem;
+  }
+
+  .alchemy-transformation-instrument__header {
+    grid-template-columns: 1fr;
+  }
+
+  .alchemy-transformation-instrument__header em {
+    text-align: left;
+  }
+
+  .alchemy-transformation-instrument__label {
+    font-size: 0.46rem;
+  }
+
+  .alchemy-transformation-instrument__step {
+    padding-inline: 0.18rem;
+  }
+
+  .alchemy-transformation-instrument__step strong {
+    font-size: 0.43rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .alchemy-transformation-instrument,
+  .alchemy-transformation-instrument *,
+  .alchemy-transformation-instrument *::before,
+  .alchemy-transformation-instrument *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .alchemy-transformation-instrument__rail-link:hover,
+  .alchemy-transformation-instrument__rail-link:focus-visible,
+  .alchemy-transformation-instrument__step:hover,
+  .alchemy-transformation-instrument__step:focus-visible {
+    transform: none;
+  }
+}

--- a/src/app/components/AlchemyTransformationInstrument.tsx
+++ b/src/app/components/AlchemyTransformationInstrument.tsx
@@ -1,0 +1,145 @@
+import { Link } from 'react-router';
+
+import type { LearningPanel } from '../types';
+import './AlchemyTransformationInstrument.css';
+
+type AlchemyChapterId = 'ch10' | 'ch11';
+
+const alchemyChapters = [
+  { id: 'ch10', label: 'Vessel', route: '/journey/chapter/ch10' },
+  { id: 'ch11', label: 'Mercurius', route: '/journey/chapter/ch11' },
+] as const;
+
+const alchemySteps = [
+  { id: 'vessel', chapterId: 'ch10', panelId: 'vessel', label: 'Vessel', note: 'symbol enters' },
+  { id: 'prima', chapterId: 'ch10', panelId: 'prima', label: 'Prima materia', note: 'mixed matter' },
+  { id: 'mercurius', chapterId: 'ch11', panelId: 'mercurius', label: 'Mercurius', note: 'moving middle' },
+  { id: 'lapis', chapterId: 'ch11', panelId: 'lapis', label: 'Lapis', note: 'formed paradox' },
+] as const;
+
+const chapterFocus: Record<AlchemyChapterId, string> = {
+  ch10: 'The vessel contains symbolic pressure until the fish becomes transformation work.',
+  ch11: 'Mercurius carries the same pressure upward into opus, mirror, and stone.',
+};
+
+export default function AlchemyTransformationInstrument({
+  activePanel,
+  activePanelId,
+  chapterId,
+  onSelectPanel,
+}: {
+  activePanel?: LearningPanel;
+  activePanelId: string;
+  chapterId: AlchemyChapterId;
+  onSelectPanel: (panelId: string) => void;
+}) {
+  const activeChapter = alchemyChapters.find((chapter) => chapter.id === chapterId);
+  const activeStep = alchemySteps.find((step) => step.chapterId === chapterId && step.panelId === activePanelId)
+    || alchemySteps.find((step) => step.chapterId === chapterId)
+    || alchemySteps[0];
+  const emphasis = activePanel
+    ? `${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`
+    : `${activeStep.label}: ${activeStep.note}.`;
+
+  return (
+    <section
+      className={`alchemy-transformation-instrument alchemy-transformation-instrument--${chapterId}`}
+      data-active-panel={activeStep.id}
+      data-alchemy-chapter={chapterId}
+      role="group"
+      aria-label={`Alchemy transformation bridge for Chapter ${chapterId === 'ch10' ? '10' : '11'}. Active focus: ${emphasis}`}
+    >
+      <div className="alchemy-transformation-instrument__header">
+        <span>Alchemy bridge</span>
+        <strong>{activeStep.label}</strong>
+        <em>{activeStep.note}</em>
+      </div>
+
+      <div
+        className="alchemy-transformation-instrument__field"
+        role="img"
+        aria-label={`Transformation field: vessel, prima materia, Mercurius, and lapis form one alchemical sequence. ${chapterFocus[chapterId]} Current emphasis: ${emphasis}`}
+      >
+        <span className="alchemy-transformation-instrument__horizon" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__vessel" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__bath" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__fish" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__prima" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__axis" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__serpent alchemy-transformation-instrument__serpent--gold" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__serpent alchemy-transformation-instrument__serpent--cyan" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__stone" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__mirror" aria-hidden="true" />
+        <span className="alchemy-transformation-instrument__path" aria-hidden="true">
+          {alchemySteps.map((step, index) => (
+            <span
+              key={step.id}
+              className={`alchemy-transformation-instrument__path-node alchemy-transformation-instrument__path-node--${step.id}`}
+              style={{ ['--alchemy-step-index' as string]: index }}
+            />
+          ))}
+        </span>
+        <span className="alchemy-transformation-instrument__label alchemy-transformation-instrument__label--vessel" aria-hidden="true">vessel</span>
+        <span className="alchemy-transformation-instrument__label alchemy-transformation-instrument__label--middle" aria-hidden="true">Mercurius</span>
+        <span className="alchemy-transformation-instrument__label alchemy-transformation-instrument__label--stone" aria-hidden="true">lapis</span>
+      </div>
+
+      <nav className="alchemy-transformation-instrument__rail" aria-label="Alchemy chapter pair">
+        {alchemyChapters.map((chapter) => (
+          <Link
+            key={chapter.id}
+            className={chapter.id === chapterId ? 'alchemy-transformation-instrument__rail-link alchemy-transformation-instrument__rail-link--active' : 'alchemy-transformation-instrument__rail-link'}
+            to={chapter.route}
+            aria-current={chapter.id === chapterId ? 'page' : undefined}
+          >
+            <span>{chapter.id === 'ch10' ? '10' : '11'}</span>
+            <strong>{chapter.label}</strong>
+          </Link>
+        ))}
+      </nav>
+
+      <ol className="alchemy-transformation-instrument__steps" aria-label={`${activeChapter?.label || 'Alchemy'} transformation sequence`}>
+        {alchemySteps.map((step, index) => {
+          const active = step.id === activeStep.id;
+          const stepClassName = active
+            ? 'alchemy-transformation-instrument__step alchemy-transformation-instrument__step--active'
+            : 'alchemy-transformation-instrument__step';
+          const stepContent = (
+            <>
+              <span>{String(index + 1).padStart(2, '0')}</span>
+              <strong>{step.label}</strong>
+            </>
+          );
+          return (
+            <li key={step.id}>
+              {step.chapterId === chapterId ? (
+                <button
+                  className={stepClassName}
+                  type="button"
+                  onClick={() => onSelectPanel(step.panelId)}
+                  aria-controls={`${chapterId}-${step.panelId}`}
+                  aria-current={active ? 'step' : undefined}
+                  aria-pressed={active}
+                >
+                  {stepContent}
+                </button>
+              ) : (
+                <Link
+                  className={stepClassName}
+                  to={`/journey/chapter/${step.chapterId}#${step.chapterId}-${step.panelId}`}
+                  aria-current={active ? 'step' : undefined}
+                >
+                  {stepContent}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      <p className="alchemy-transformation-instrument__readout" aria-live="polite" aria-atomic="true">
+        {activePanel?.insight || chapterFocus[chapterId]}
+      </p>
+    </section>
+  );
+}

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 
+import AlchemyTransformationInstrument from '../components/AlchemyTransformationInstrument';
 import Chapter14FinalSynthesisInstrument from '../components/Chapter14FinalSynthesisInstrument';
 import ChapterOneReferenceInstrument from '../components/ChapterOneReferenceInstrument';
 import ChapterSigil from '../components/ChapterSigil';
@@ -452,6 +453,14 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
               </button>
             ))}
           </div>
+          {(chapter.id === 'ch10' || chapter.id === 'ch11') && (
+            <AlchemyTransformationInstrument
+              activePanel={activePanel}
+              activePanelId={activePanelId}
+              chapterId={chapter.id}
+              onSelectPanel={setActivePanelId}
+            />
+          )}
           {chapter.id === 'ch1' && (
             <ChapterOneReferenceInstrument activePanel={activePanel} activePanelId={activePanelId} />
           )}


### PR DESCRIPTION
## Summary

- Adds a scoped `AlchemyTransformationInstrument` for Chapters 10 and 11.
- Connects vessel, prima materia, Mercurius, and lapis as one compact alchemical transformation sequence.
- Lets same-chapter bridge steps update the active chapter panel while cross-chapter steps route between Chapter 10 and Chapter 11.

## Visual Thesis

The alchemy chapters now read as a connected transformation family instead of isolated chapter stages: fish enters the vessel, matter condenses, Mercurius mediates, and the lapis becomes the formed paradox.

## Routes Changed

- `/journey/chapter/ch10`
- `/journey/chapter/ch11`

## Design QA Evidence

- Browser artifact probe on `/aion-visualization/journey/chapter/ch10` and `/aion-visualization/journey/chapter/ch11` at `1440x1000`, `390x844`, and `320x568`.
- No console errors, failed requests, unexpected 404s, or horizontal overflow.
- Reduced-motion probe: chapter canvas correctly falls back while the bridge remains present.
- Focused mobile bridge probe: 358px bridge width inside a 390px viewport; 6 focusable controls; 0px overflow.
- Visual Control Tower: 20 routes inspected, desktop/mobile/narrow, 0 blockers, all desktop routes at 100% against the current automated rubric.

## Verification

- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `npm run test:e2e:app`
- `npm run test:a11y:app`
- `npm run build:pages`
- `npm run test:pages:artifact`
- `AION_VISUAL_MIN_SCORE=85 npm run test:visual:control-tower`

## Notes

- A prior local scene-controls regression was caused by placing the bridge before canonical stage controls; the bridge now sits after the reference map.
- A manual preview 404 was traced to serving the GitHub Pages build without the `/aion-visualization` base-path mapping; the Pages artifact smoke and base-aware artifact probe both pass.
- The existing large `three` chunk warning remains pre-existing and non-blocking.
