### PR TITLE
[codex] Refine Chapter 7 prophecy field

### DIFF
--- a/src/app/components/ChapterSevenProphecyField.css
+++ b/src/app/components/ChapterSevenProphecyField.css
@@ -1,0 +1,394 @@
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument {
+  width: 100%;
+  min-height: clamp(8rem, 14vh, 9.7rem);
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid rgba(244, 240, 232, 0.095);
+  border-radius: calc(var(--radius) - 0.04rem);
+  background:
+    radial-gradient(circle at 28% 55%, rgba(215, 154, 53, 0.28), transparent 5.7rem),
+    radial-gradient(circle at 57% 48%, rgba(185, 149, 255, 0.25), transparent 6.2rem),
+    radial-gradient(circle at 86% 50%, rgba(83, 216, 232, 0.19), transparent 5.8rem),
+    linear-gradient(90deg, rgba(17, 8, 11, 0.86), rgba(13, 8, 25, 0.62) 50%, rgba(4, 18, 22, 0.58));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), inset 0 -1px 0 rgba(244, 240, 232, 0.035);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument::before {
+  inset: 0.58rem;
+  border-color: rgba(244, 240, 232, 0.12);
+  background:
+    linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.08), transparent),
+    repeating-linear-gradient(0deg, transparent 0 0.88rem, rgba(244, 240, 232, 0.032) 0.9rem 0.94rem);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument::after {
+  left: 53%;
+  width: 12.4rem;
+  height: 6.4rem;
+  border-color: rgba(244, 240, 232, 0.1);
+  box-shadow: inset 0 0 1.8rem rgba(185, 149, 255, 0.12), 0 0 2.4rem rgba(215, 154, 53, 0.08);
+}
+
+.chapter-seven-prophecy__field > span {
+  position: absolute;
+  pointer-events: none;
+}
+
+.chapter-seven-prophecy__grain {
+  inset: 0;
+  z-index: 1;
+  opacity: 0.42;
+  background:
+    radial-gradient(circle at 18% 32%, rgba(255, 255, 255, 0.14) 0 1px, transparent 1.5px),
+    radial-gradient(circle at 62% 62%, rgba(255, 255, 255, 0.12) 0 1px, transparent 1.5px),
+    radial-gradient(circle at 88% 40%, rgba(255, 255, 255, 0.1) 0 1px, transparent 1.5px);
+  background-size: 3.8rem 3.8rem, 4.9rem 4.9rem, 5.6rem 5.6rem;
+  mix-blend-mode: screen;
+}
+
+.chapter-seven-prophecy__chamber {
+  left: 14%;
+  right: 9%;
+  top: 22%;
+  height: 58%;
+  z-index: 1;
+  border: 1px solid rgba(244, 240, 232, 0.07);
+  border-radius: 50%;
+  transform: rotate(-4deg);
+}
+
+.chapter-seven-prophecy__wave {
+  left: 17%;
+  top: 28%;
+  z-index: 1;
+  width: 33%;
+  height: 45%;
+  border: 1px solid transparent;
+  border-left-color: rgba(215, 154, 53, 0.32);
+  border-top-color: rgba(215, 154, 53, 0.16);
+  border-radius: 50%;
+  opacity: 0.72;
+  transform: rotate(-10deg);
+  animation: ch7-prophecy-breathe 7.4s var(--motion-spring) infinite alternate;
+}
+
+.chapter-seven-prophecy__wave--two {
+  left: 39%;
+  top: 18%;
+  width: 34%;
+  height: 60%;
+  border-left-color: rgba(185, 149, 255, 0.25);
+  border-right-color: rgba(83, 216, 232, 0.18);
+  transform: rotate(13deg);
+  animation-direction: alternate-reverse;
+}
+
+.chapter-seven-prophecy__signal {
+  top: 25%;
+  bottom: 22%;
+  z-index: 1;
+  width: 1px;
+  opacity: 0.56;
+  background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.3), transparent);
+}
+
+.chapter-seven-prophecy__signal--past {
+  left: 28%;
+  box-shadow: 0 0 1.6rem rgba(215, 154, 53, 0.25);
+}
+
+.chapter-seven-prophecy__signal--future {
+  right: 19%;
+  box-shadow: 0 0 1.6rem rgba(83, 216, 232, 0.22);
+}
+
+.chapter-seven-prophecy__constellation {
+  left: 50%;
+  top: 25%;
+  z-index: 1;
+  width: 27%;
+  height: 48%;
+  opacity: 0.66;
+  background:
+    radial-gradient(circle at 20% 22%, rgba(244, 240, 232, 0.9) 0 0.08rem, transparent 0.1rem),
+    radial-gradient(circle at 58% 16%, rgba(185, 149, 255, 0.85) 0 0.1rem, transparent 0.12rem),
+    radial-gradient(circle at 82% 50%, rgba(244, 240, 232, 0.75) 0 0.08rem, transparent 0.1rem),
+    radial-gradient(circle at 38% 80%, rgba(185, 149, 255, 0.9) 0 0.1rem, transparent 0.12rem);
+  filter: drop-shadow(0 0 0.6rem rgba(185, 149, 255, 0.2));
+}
+
+.chapter-seven-prophecy__lens {
+  right: 6%;
+  top: 32%;
+  z-index: 1;
+  width: 17%;
+  height: 34%;
+  opacity: 0.52;
+  border: 1px solid rgba(83, 216, 232, 0.22);
+  border-radius: 50%;
+  background:
+    linear-gradient(122deg, transparent 47%, rgba(83, 216, 232, 0.2) 49%, transparent 51%),
+    radial-gradient(circle at 38% 48%, rgba(83, 216, 232, 0.16), transparent 70%);
+  transform: rotate(-13deg);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__field {
+  z-index: 0;
+  opacity: 0.64;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__field--past {
+  background: radial-gradient(circle at 38% 54%, rgba(215, 154, 53, 0.2), transparent 4.9rem), linear-gradient(90deg, rgba(215, 154, 53, 0.1), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__field--future {
+  background: radial-gradient(circle at 64% 50%, rgba(83, 216, 232, 0.18), transparent 5rem), linear-gradient(270deg, rgba(83, 216, 232, 0.1), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__axis {
+  left: 7%;
+  right: 7%;
+  top: 62%;
+  z-index: 3;
+  background: linear-gradient(90deg, rgba(215, 154, 53, 0.12), rgba(244, 240, 232, 0.58), rgba(83, 216, 232, 0.16));
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__tick {
+  top: 67%;
+  z-index: 4;
+  color: rgba(244, 240, 232, 0.68);
+  font-size: 0.52rem;
+  letter-spacing: 0.05em;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__tick::before {
+  bottom: 1.25rem;
+  height: 0.78rem;
+  background: rgba(244, 240, 232, 0.25);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__pressure {
+  left: 27%;
+  top: 52%;
+  z-index: 4;
+  width: 7.4rem;
+  height: 3.08rem;
+  border-color: rgba(215, 154, 53, 0.4);
+  background:
+    radial-gradient(circle at 52% 52%, rgba(255, 227, 156, 0.36), rgba(215, 154, 53, 0.1) 44%, transparent 72%),
+    radial-gradient(ellipse, rgba(215, 154, 53, 0.2), transparent 72%);
+  box-shadow: inset 0 0 1.5rem rgba(215, 154, 53, 0.13), 0 0 1.8rem rgba(215, 154, 53, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__date {
+  left: 42%;
+  top: 62%;
+  z-index: 6;
+  width: 0.78rem;
+  background: rgba(255, 227, 156, 0.96);
+  box-shadow: 0 0 0 0.42rem rgba(215, 154, 53, 0.13), 0 0 1.55rem rgba(215, 154, 53, 0.42);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__image {
+  z-index: 5;
+  width: 0.8rem;
+  background: rgba(185, 149, 255, 0.76);
+  border-color: rgba(244, 240, 232, 0.22);
+  box-shadow: 0 0 0 0.28rem rgba(185, 149, 255, 0.08), 0 0 1rem rgba(185, 149, 255, 0.26);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__image--one {
+  left: 54%;
+  top: 33%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__image--two {
+  left: 66%;
+  top: 48%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__image--three {
+  left: 58%;
+  top: 72%;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__arc {
+  left: 49%;
+  top: 54%;
+  z-index: 4;
+  width: 9.2rem;
+  height: 4.9rem;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__arc--projection {
+  border-top-color: rgba(185, 149, 255, 0.42);
+  border-left-color: rgba(185, 149, 255, 0.28);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__arc--return {
+  border-bottom-color: rgba(83, 216, 232, 0.34);
+  border-right-color: rgba(83, 216, 232, 0.24);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__threshold {
+  right: 17%;
+  top: 14%;
+  bottom: 14%;
+  z-index: 6;
+  width: 2px;
+  background: linear-gradient(180deg, transparent, rgba(83, 216, 232, 0.72), rgba(215, 154, 53, 0.28), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__mirror {
+  right: 5%;
+  top: 53%;
+  z-index: 5;
+  width: 3.85rem;
+  height: 2.55rem;
+  border-color: rgba(83, 216, 232, 0.32);
+  background:
+    linear-gradient(128deg, transparent 48%, rgba(83, 216, 232, 0.32) 49%, transparent 51%),
+    radial-gradient(circle at 42% 48%, rgba(83, 216, 232, 0.18), transparent 70%);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__label {
+  z-index: 7;
+  font-size: 0.54rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__label--pressure {
+  left: 5%;
+  top: 10%;
+  color: color-mix(in srgb, var(--ch7-pressure) 82%, rgba(244, 240, 232, 0.82));
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__label--collective {
+  left: 48%;
+  top: 10%;
+  color: color-mix(in srgb, var(--ch7-collective) 84%, rgba(244, 240, 232, 0.82));
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__label--threshold {
+  right: 4%;
+  top: 10%;
+  color: color-mix(in srgb, var(--ch7-threshold) 86%, rgba(244, 240, 232, 0.82));
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="prophecy"] :is(.chapter-seven-prophecy__wave--one, .chapter-seven-prophecy__signal--past),
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="threshold"] :is(.chapter-seven-prophecy__lens, .chapter-seven-prophecy__signal--future) {
+  opacity: 1;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="prophecy"] :is(.prophecy-field-instrument__pressure, .prophecy-field-instrument__date) {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1.14) rotate(-7deg);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="prophecy"] .prophecy-field-instrument__date {
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="prophecy"] .prophecy-field-instrument__tick--2 {
+  color: rgba(255, 227, 156, 0.98);
+  opacity: 1;
+  transform: translateX(-50%) translateY(-0.08rem) scale(1.1);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="collective"] :is(.chapter-seven-prophecy__constellation, .chapter-seven-prophecy__wave--two) {
+  opacity: 1;
+  filter: drop-shadow(0 0 0.9rem rgba(185, 149, 255, 0.28));
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="collective"] .prophecy-field-instrument__image {
+  background: rgba(216, 196, 255, 0.92);
+  box-shadow: 0 0 0 0.34rem rgba(185, 149, 255, 0.12), 0 0 1.4rem rgba(185, 149, 255, 0.42);
+  opacity: 1;
+  transform: scale(1.24);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="collective"] .prophecy-field-instrument__arc {
+  border-color: rgba(216, 196, 255, 0.5);
+  opacity: 0.95;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="collective"] :is(.prophecy-field-instrument__pressure, .prophecy-field-instrument__date) {
+  opacity: 0.62;
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__field--future {
+  opacity: 0.94;
+  transform: scaleX(1.06);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="threshold"] :is(.prophecy-field-instrument__threshold, .prophecy-field-instrument__mirror) {
+  opacity: 1;
+  transform: translateY(-50%) rotate(-12deg) scale(1.1);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__threshold {
+  transform: scaleY(1.12);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__tick--4 {
+  color: rgba(143, 231, 237, 0.98);
+  opacity: 1;
+  transform: translateX(-50%) translateY(-0.08rem) scale(1.1);
+}
+
+.chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument[data-active-panel="threshold"] .prophecy-field-instrument__image {
+  opacity: 0.66;
+}
+
+@keyframes ch7-prophecy-breathe {
+  from {
+    opacity: 0.42;
+    transform: rotate(-10deg) scale(0.96);
+  }
+
+  to {
+    opacity: 0.82;
+    transform: rotate(-7deg) scale(1.03);
+  }
+}
+
+@media (max-width: 760px) {
+  .chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument {
+    min-height: 7.55rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument::after {
+    width: 7.4rem;
+    height: 4.35rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__pressure {
+    left: 27%;
+    width: 5.1rem;
+    height: 2.2rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy :is(.prophecy-field-instrument__tick, .prophecy-field-instrument__label) {
+    font-size: 0.46rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__tick {
+    min-width: 1.75rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__image {
+    width: 0.64rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__arc {
+    width: 5.95rem;
+    height: 3.2rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"] .chapter-seven-prophecy .prophecy-field-instrument__mirror {
+    right: 4.5%;
+    width: 2.65rem;
+    height: 1.84rem;
+  }
+}

--- a/src/app/components/ChapterSevenProphecyInstrument.css
+++ b/src/app/components/ChapterSevenProphecyInstrument.css
@@ -1,0 +1,204 @@
+.chapter-seven-prophecy {
+  --ch7-pressure: #d79a35;
+  --ch7-collective: #b995ff;
+  --ch7-threshold: #53d8e8;
+  position: relative;
+  width: min(31rem, 100%);
+  margin-top: 0.92rem;
+  padding: 0.34rem;
+  overflow: hidden;
+  border: 1px solid rgba(244, 240, 232, 0.13);
+  border-radius: calc(var(--radius) + 0.18rem);
+  background:
+    radial-gradient(circle at 20% 0%, rgba(215, 154, 53, 0.14), transparent 7.2rem),
+    radial-gradient(circle at 64% 7%, rgba(185, 149, 255, 0.12), transparent 7.6rem),
+    radial-gradient(circle at 93% 13%, rgba(83, 216, 232, 0.12), transparent 6.4rem),
+    linear-gradient(180deg, rgba(244, 240, 232, 0.055), rgba(244, 240, 232, 0.016));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.075), 0 1.6rem 4.6rem rgba(0, 0, 0, 0.24);
+}
+
+.chapter-seven-prophecy::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.56;
+  background:
+    linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.07), transparent),
+    repeating-linear-gradient(90deg, transparent 0 2.7rem, rgba(244, 240, 232, 0.035) 2.74rem 2.78rem);
+  mask-image: linear-gradient(180deg, #000, transparent 78%);
+}
+
+.chapter-seven-prophecy__header,
+.chapter-seven-prophecy__legend {
+  position: relative;
+  z-index: 2;
+}
+
+.chapter-seven-prophecy__header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.05rem 0.7rem;
+  align-items: end;
+  padding: 0.1rem 0.18rem 0.28rem;
+}
+
+.chapter-seven-prophecy__header span,
+.chapter-seven-prophecy__header em,
+.chapter-seven-prophecy__step span,
+.chapter-seven-prophecy__step em {
+  color: rgba(244, 240, 232, 0.52);
+  font-family: var(--font-ui);
+  font-size: 0.54rem;
+  font-style: normal;
+  font-weight: 850;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.chapter-seven-prophecy__header strong {
+  color: rgba(244, 240, 232, 0.94);
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 650;
+  line-height: 0.95;
+}
+
+.chapter-seven-prophecy__header em {
+  color: color-mix(in srgb, var(--ch7-pressure) 78%, rgba(244, 240, 232, 0.7));
+  text-align: right;
+}
+
+.chapter-seven-prophecy[data-active-panel="collective"] .chapter-seven-prophecy__header em {
+  color: color-mix(in srgb, var(--ch7-collective) 82%, rgba(244, 240, 232, 0.72));
+}
+
+.chapter-seven-prophecy[data-active-panel="threshold"] .chapter-seven-prophecy__header em {
+  color: color-mix(in srgb, var(--ch7-threshold) 84%, rgba(244, 240, 232, 0.72));
+}
+
+.chapter-seven-prophecy__legend {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.28rem;
+  margin: 0;
+  padding: 0.38rem 0 0;
+  list-style: none;
+}
+
+.chapter-seven-prophecy__step {
+  display: grid;
+  gap: 0.08rem;
+  min-width: 0;
+  padding: 0.38rem 0.42rem;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  border-radius: calc(var(--radius) - 2px);
+  background: rgba(244, 240, 232, 0.032);
+  color: rgba(244, 240, 232, 0.62);
+}
+
+.chapter-seven-prophecy__step :is(span, em, strong) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chapter-seven-prophecy__step strong {
+  color: rgba(244, 240, 232, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.66rem;
+  font-weight: 850;
+  line-height: 1.05;
+}
+
+.chapter-seven-prophecy__step--active {
+  border-color: rgba(212, 175, 55, 0.36);
+  background: linear-gradient(180deg, rgba(212, 175, 55, 0.13), rgba(244, 240, 232, 0.035));
+  color: rgba(255, 227, 156, 0.86);
+  box-shadow: 0 0 1.25rem rgba(212, 175, 55, 0.12);
+}
+
+.chapter-seven-prophecy[data-active-panel="collective"] .chapter-seven-prophecy__step--active {
+  border-color: rgba(185, 149, 255, 0.4);
+  background: linear-gradient(180deg, rgba(185, 149, 255, 0.13), rgba(244, 240, 232, 0.035));
+  box-shadow: 0 0 1.25rem rgba(185, 149, 255, 0.12);
+}
+
+.chapter-seven-prophecy[data-active-panel="threshold"] .chapter-seven-prophecy__step--active {
+  border-color: rgba(83, 216, 232, 0.38);
+  background: linear-gradient(180deg, rgba(83, 216, 232, 0.12), rgba(244, 240, 232, 0.035));
+  box-shadow: 0 0 1.25rem rgba(83, 216, 232, 0.12);
+}
+
+.chapter-seven-prophecy__readout {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .chapter-seven-prophecy {
+    width: min(100%, 25rem);
+    margin-inline: auto;
+    padding: 0.28rem;
+  }
+
+  .chapter-seven-prophecy__header {
+    gap: 0.04rem 0.46rem;
+  }
+
+  .chapter-seven-prophecy__header strong {
+    font-size: 0.92rem;
+  }
+
+  .chapter-seven-prophecy__step {
+    padding: 0.34rem 0.36rem;
+  }
+
+  .chapter-seven-prophecy__step strong {
+    font-size: 0.6rem;
+  }
+
+  .chapter-seven-prophecy__step em {
+    font-size: 0.48rem;
+  }
+
+  .chapter-experience[data-chapter-id="ch7"][data-reduced-motion="true"] .chapter-stage .scene-host__fallback {
+    top: 22.65rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .chapter-seven-prophecy__header {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .chapter-seven-prophecy__header em {
+    text-align: left;
+  }
+
+  .chapter-seven-prophecy__step em {
+    display: none;
+  }
+
+  .chapter-seven-prophecy__step strong {
+    font-size: 0.58rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chapter-seven-prophecy *,
+  .chapter-seven-prophecy *::before,
+  .chapter-seven-prophecy *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/app/components/ChapterSevenProphecyInstrument.tsx
+++ b/src/app/components/ChapterSevenProphecyInstrument.tsx
@@ -1,0 +1,98 @@
+import type { LearningPanel } from '../types';
+import './ChapterSevenProphecyInstrument.css';
+import './ChapterSevenProphecyField.css';
+
+const prophecyTicks = ['0', '1000', '1555', '2000'] as const;
+
+const prophecySteps = [
+  { id: 'prophecy', index: '01', label: 'Prophecy', note: 'pressure gathers' },
+  { id: 'collective', index: '02', label: 'Collective', note: 'image spreads' },
+  { id: 'threshold', index: '03', label: 'Threshold', note: 'future mirrors' },
+] as const;
+
+export default function ChapterSevenProphecyInstrument({
+  activePanel,
+  activePanelId,
+}: {
+  activePanel?: LearningPanel;
+  activePanelId: string;
+}) {
+  const currentStep = prophecySteps.find((step) => step.id === activePanelId) || prophecySteps[0];
+  const emphasis = activePanel
+    ? `${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`
+    : `${currentStep.label}: ${currentStep.note}.`;
+
+  return (
+    <section
+      className="chapter-seven-prophecy"
+      data-active-panel={currentStep.id}
+      role="group"
+      aria-label={`Chapter 7 prophecy field instrument. Active focus: ${emphasis}`}
+    >
+      <div className="chapter-seven-prophecy__header">
+        <span>Pressure chamber</span>
+        <strong>{currentStep.label}</strong>
+        <em>{currentStep.note}</em>
+      </div>
+
+      <div
+        className="prophecy-field-instrument chapter-seven-prophecy__field"
+        data-active-panel={activePanelId}
+        role="img"
+        aria-label={`Prophecy field model: historical pressure gathers around a time axis, private fear projects into a shared symbolic image-field, and the threshold mirror shows the future looking backward into older archetypal forms. Current emphasis: ${emphasis}`}
+      >
+        <span className="chapter-seven-prophecy__grain" aria-hidden="true" />
+        <span className="chapter-seven-prophecy__chamber" aria-hidden="true" />
+        <span className="chapter-seven-prophecy__wave chapter-seven-prophecy__wave--one" aria-hidden="true" />
+        <span className="chapter-seven-prophecy__wave chapter-seven-prophecy__wave--two" aria-hidden="true" />
+        <span className="chapter-seven-prophecy__signal chapter-seven-prophecy__signal--past" aria-hidden="true" />
+        <span className="chapter-seven-prophecy__signal chapter-seven-prophecy__signal--future" aria-hidden="true" />
+        <span className="chapter-seven-prophecy__constellation" aria-hidden="true" />
+        <span className="chapter-seven-prophecy__lens" aria-hidden="true" />
+
+        <span className="prophecy-field-instrument__field prophecy-field-instrument__field--past" aria-hidden="true" />
+        <span className="prophecy-field-instrument__field prophecy-field-instrument__field--future" aria-hidden="true" />
+        <span className="prophecy-field-instrument__axis" aria-hidden="true" />
+        {prophecyTicks.map((tick, index) => (
+          <span
+            key={tick}
+            className={`prophecy-field-instrument__tick prophecy-field-instrument__tick--${index + 1}`}
+            aria-hidden="true"
+          >
+            {tick}
+          </span>
+        ))}
+        <span className="prophecy-field-instrument__pressure" aria-hidden="true" />
+        <span className="prophecy-field-instrument__date" aria-hidden="true" />
+        <span className="prophecy-field-instrument__image prophecy-field-instrument__image--one" aria-hidden="true" />
+        <span className="prophecy-field-instrument__image prophecy-field-instrument__image--two" aria-hidden="true" />
+        <span className="prophecy-field-instrument__image prophecy-field-instrument__image--three" aria-hidden="true" />
+        <span className="prophecy-field-instrument__arc prophecy-field-instrument__arc--projection" aria-hidden="true" />
+        <span className="prophecy-field-instrument__arc prophecy-field-instrument__arc--return" aria-hidden="true" />
+        <span className="prophecy-field-instrument__threshold" aria-hidden="true" />
+        <span className="prophecy-field-instrument__mirror" aria-hidden="true" />
+        <span className="prophecy-field-instrument__label prophecy-field-instrument__label--pressure" aria-hidden="true">pressure</span>
+        <span className="prophecy-field-instrument__label prophecy-field-instrument__label--collective" aria-hidden="true">shared image</span>
+        <span className="prophecy-field-instrument__label prophecy-field-instrument__label--threshold" aria-hidden="true">threshold</span>
+      </div>
+
+      <ol className="chapter-seven-prophecy__legend" aria-label="Prophecy field sequence">
+        {prophecySteps.map((step) => (
+          <li
+            key={step.id}
+            className={step.id === currentStep.id ? 'chapter-seven-prophecy__step chapter-seven-prophecy__step--active' : 'chapter-seven-prophecy__step'}
+            aria-current={step.id === currentStep.id ? 'step' : undefined}
+          >
+            <span>{step.index}</span>
+            <strong>{step.label}</strong>
+            <em>{step.note}</em>
+          </li>
+        ))}
+      </ol>
+
+      <p className="chapter-seven-prophecy__readout" aria-live="polite" aria-atomic="true">
+        {activePanel?.insight || currentStep.note}
+      </p>
+    </section>
+  );
+}

--- a/src/app/pages/ChapterPage.tsx
+++ b/src/app/pages/ChapterPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import AlchemyTransformationInstrument from '../components/AlchemyTransformationInstrument';
 import Chapter14FinalSynthesisInstrument from '../components/Chapter14FinalSynthesisInstrument';
 import ChapterOneReferenceInstrument from '../components/ChapterOneReferenceInstrument';
+import ChapterSevenProphecyInstrument from '../components/ChapterSevenProphecyInstrument';
 import ChapterSigil from '../components/ChapterSigil';
 import PsycheArcInstrument from '../components/PsycheArcInstrument';
 import SceneHost from '../components/SceneHost';
@@ -22,7 +23,6 @@ const quaternityDirections = ['north', 'east', 'south', 'west'] as const;
 const mandalaBands = ['outer', 'middle', 'inner'] as const;
 const rootLines = ['left', 'center', 'right'] as const;
 const zodiacMarkers = ['AR', 'TA', 'GE', 'CN', 'LE', 'VI', 'LI', 'SC', 'SG', 'CP', 'AQ', 'PI'] as const;
-const prophecyTicks = ['0', '1000', '1555', '2000'] as const;
 const historicalStrataLayers = ['vision', 'carrier', 'healing', 'aeon', 'depth'] as const;
 const alchemicalOpusStages = ['nigredo', 'albedo', 'citrinitas', 'rubedo'] as const;
 const alchemicalTreeStages = ['black', 'white', 'gold', 'red'] as const;
@@ -74,7 +74,6 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
   const activePanel = experience.panels[activePanelIndex] || experience.panels[0];
   const christSymbolInstrumentLabel = `Christ symbol model: a luminous cross carries a powerful Self image, three bright points form a one-sided field, the excluded fourth remains dark but necessary, and roots descend toward the counter-pole. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const aeonFishInstrumentLabel = `Sign of the Fishes model: two Pisces fish swim in opposite directions inside a zodiac wheel, the spring point precesses through symbolic time, and Aquarius marks the slow threshold of a changing aeon. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
-  const prophecyFieldInstrumentLabel = `Prophecy field model: historical pressure gathers around a time axis, private fear projects into a shared symbolic image-field, and the threshold mirror shows the future looking backward into older archetypal forms. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const historicalStrataInstrumentLabel = `Historical strata model: five translucent layers accumulate around the fish motif, an early Christian carrier image gathers the symbol into a readable form, and older meanings keep speaking below later interpretation. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const ambivalentFishInstrumentLabel = `Ambivalent fish model: one fish-symbol carries blessing and threat across a split field, an ouroboric return shows opposition circling back into itself, and the shadow fish keeps the Antichrist counter-pole inside the total image. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
   const alchemicalVesselInstrumentLabel = `Alchemical vessel model: the fish-symbol enters a sealed vessel, prima materia gathers as unsettled particles, heat presses the image through four opus stages, and a lapis point appears as transformation takes form. Current emphasis: ${activePanel.kicker}: ${activePanel.title}. ${activePanel.insight}`;
@@ -193,37 +192,7 @@ function ChapterPageContent({ chapter }: { chapter: ChapterRecord }) {
             </div>
           )}
           {chapter.id === 'ch7' && (
-            <div
-              className="prophecy-field-instrument"
-              data-active-panel={activePanelId}
-              role="img"
-              aria-label={prophecyFieldInstrumentLabel}
-            >
-              <span className="prophecy-field-instrument__field prophecy-field-instrument__field--past" aria-hidden="true" />
-              <span className="prophecy-field-instrument__field prophecy-field-instrument__field--future" aria-hidden="true" />
-              <span className="prophecy-field-instrument__axis" aria-hidden="true" />
-              {prophecyTicks.map((tick, index) => (
-                <span
-                  key={tick}
-                  className={`prophecy-field-instrument__tick prophecy-field-instrument__tick--${index + 1}`}
-                  aria-hidden="true"
-                >
-                  {tick}
-                </span>
-              ))}
-              <span className="prophecy-field-instrument__pressure" aria-hidden="true" />
-              <span className="prophecy-field-instrument__date" aria-hidden="true" />
-              <span className="prophecy-field-instrument__image prophecy-field-instrument__image--one" aria-hidden="true" />
-              <span className="prophecy-field-instrument__image prophecy-field-instrument__image--two" aria-hidden="true" />
-              <span className="prophecy-field-instrument__image prophecy-field-instrument__image--three" aria-hidden="true" />
-              <span className="prophecy-field-instrument__arc prophecy-field-instrument__arc--projection" aria-hidden="true" />
-              <span className="prophecy-field-instrument__arc prophecy-field-instrument__arc--return" aria-hidden="true" />
-              <span className="prophecy-field-instrument__threshold" aria-hidden="true" />
-              <span className="prophecy-field-instrument__mirror" aria-hidden="true" />
-              <span className="prophecy-field-instrument__label prophecy-field-instrument__label--pressure" aria-hidden="true">pressure</span>
-              <span className="prophecy-field-instrument__label prophecy-field-instrument__label--collective" aria-hidden="true">shared image</span>
-              <span className="prophecy-field-instrument__label prophecy-field-instrument__label--threshold" aria-hidden="true">threshold</span>
-            </div>
+            <ChapterSevenProphecyInstrument activePanel={activePanel} activePanelId={activePanelId} />
           )}
           {chapter.id === 'ch8' && (
             <div


### PR DESCRIPTION
## Summary

Refines Chapter 7 into a more visual-first prophecy pressure chamber while preserving the canonical chapter shell, scene host, panel ids, and smoke-test contracts.

## What Changed

- Extracted the Chapter 7 prophecy instrument from `ChapterPage.tsx` into a dedicated React component.
- Added a layered amber/violet/cyan field for historical pressure, shared collective image, and threshold mirror logic.
- Added a compact three-step legend and accessible group/img labels so the visual state remains understandable without relying only on motion or color.
- Kept the existing tested class contract for Chapter 7 scene-control assertions.

## Skill stack

Aion skill-routing playbook, orchestration-autopilot subagent review/verification lanes, design-taste/frontend route polish, accessibility review, webapp-testing, Browser/Playwright visual QA, github:yeet publish flow.

## Routes changed

- `/journey/chapter/ch7`

## Visual thesis

Chapter 7 should read as a symbolic pressure chamber: amber historical anxiety compresses around the time axis, violet collective images radiate outward, and a cool cyan threshold mirror shows the future reflecting older archetypal forms.

## Browser evidence

- `npm run test:visual:control-tower` passed.
- Control tower inspected 20 routes across desktop/mobile/narrow with 0 technical blockers.
- `/journey/chapter/ch7` scored 100%; mobile and narrow overflow were 0px.
- Visual inspection checked generated Chapter 7 desktop, mobile, and narrow screenshots in `test-results/control-tower/latest/screenshots/`.

## Checks

- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .` -> no matches
- `npm run lint` -> pass
- `npx tsc --noEmit` -> pass
- `npm run validate:consistency` -> pass
- `npm run ci:chapter-shell` -> pass
- `npm run test:app` -> pass, 22 tests
- `npm test` -> pass, 157 tests
- `npm run test:e2e:app:mobile` -> pass
- `npm run test:a11y:app` -> pass
- `npm run build:pages` -> pass
- `npm run test:pages:artifact` -> pass
- `npm run test:e2e:app -- --shard=chapter-routes` -> pass
- `npm run test:e2e:app` -> pass on rerun

## Notes

One full-smoke run initially timed out waiting for a chapter canvas; targeted reruns passed, the verifier subagent reproduced an intermittent pre-Chapter-7 timeout on Chapter 6 and then passed on rerun, and the final full-smoke rerun passed. The Vite large chunk warning remains existing Three/react bundle debt and is not introduced by this batch.

## Residual debt

- Deeper source anchors remain in the later scholarly integrity batch.
- Three/react chunk budget work remains in the release-hardening batch.