### PR TITLE
[codex] Refine chapter ten alchemical vessel

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -5334,8 +5334,8 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro h1 {
-  max-width: 13.75ch;
-  font-size: clamp(3.5rem, 5.7vw, 5.15rem);
+  max-width: 13.25ch;
+  font-size: clamp(3.55rem, 5.85vw, 5.35rem);
   line-height: 0.92;
 }
 
@@ -5367,11 +5367,11 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .chapter-stage__scrim {
   background:
-    linear-gradient(180deg, rgba(3, 3, 7, 0.75), rgba(3, 3, 7, 0.38) 48%, rgba(3, 3, 7, 0.82)),
-    linear-gradient(90deg, rgba(3, 3, 7, 0.96), rgba(3, 3, 7, 0.52) 58%, rgba(3, 3, 7, 0.28)),
-    radial-gradient(circle at 30% 51%, rgba(212, 175, 55, 0.16), transparent 32%),
-    radial-gradient(circle at 60% 60%, rgba(83, 216, 232, 0.12), transparent 38%),
-    radial-gradient(circle at 74% 72%, rgba(194, 55, 43, 0.1), transparent 33%);
+    linear-gradient(180deg, rgba(3, 3, 7, 0.72), rgba(3, 3, 7, 0.34) 45%, rgba(3, 3, 7, 0.86)),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.97), rgba(3, 3, 7, 0.5) 54%, rgba(3, 3, 7, 0.24)),
+    radial-gradient(circle at 31% 50%, rgba(212, 175, 55, 0.2), transparent 30%),
+    radial-gradient(circle at 58% 58%, rgba(83, 216, 232, 0.16), transparent 36%),
+    radial-gradient(circle at 75% 72%, rgba(194, 55, 43, 0.14), transparent 33%);
 }
 
 .chapter-experience[data-chapter-id="ch10"] .chapter-stage__reference-node[data-panel-id="vessel"] .chapter-stage__reference-mark::before {
@@ -5442,21 +5442,21 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument {
   position: relative;
-  width: min(31rem, 100%);
-  min-height: clamp(7.75rem, 11.4vh, 8.85rem);
+  width: min(32.5rem, 100%);
+  min-height: clamp(8.15rem, 12.2vh, 9.35rem);
   overflow: hidden;
   margin-top: 0.78rem;
   border: 1px solid rgba(244, 240, 232, 0.12);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 26% 52%, rgba(83, 216, 232, 0.18), transparent 5.2rem),
-    radial-gradient(circle at 51% 53%, rgba(212, 175, 55, 0.24), transparent 5.6rem),
-    radial-gradient(circle at 74% 68%, rgba(194, 55, 43, 0.17), transparent 5.2rem),
-    linear-gradient(90deg, rgba(7, 9, 13, 0.9), rgba(12, 9, 10, 0.78) 46%, rgba(24, 8, 6, 0.68));
+    radial-gradient(circle at 24% 50%, rgba(83, 216, 232, 0.22), transparent 5.4rem),
+    radial-gradient(circle at 49% 55%, rgba(212, 175, 55, 0.3), transparent 5.9rem),
+    radial-gradient(circle at 75% 66%, rgba(194, 55, 43, 0.22), transparent 5.4rem),
+    linear-gradient(90deg, rgba(7, 12, 15, 0.92), rgba(13, 10, 10, 0.82) 45%, rgba(29, 9, 7, 0.72));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.24),
-    0 0 3.6rem rgba(212, 175, 55, 0.06);
+    0 1.45rem 4.2rem rgba(0, 0, 0, 0.28),
+    0 0 3.8rem rgba(212, 175, 55, 0.1);
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::before,
@@ -5468,17 +5468,20 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::before {
   inset: 0.58rem;
-  border: 1px solid rgba(255, 227, 156, 0.08);
+  border: 1px solid rgba(255, 227, 156, 0.12);
   border-radius: calc(var(--radius) - 2px);
+  background:
+    linear-gradient(90deg, transparent 0 31%, rgba(143, 231, 237, 0.1) 32%, transparent 34% 64%, rgba(255, 173, 112, 0.1) 66%, transparent 68%),
+    radial-gradient(ellipse at 50% 57%, rgba(244, 240, 232, 0.08), transparent 55%);
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::after {
   left: 50%;
   bottom: 1.16rem;
-  width: 64%;
+  width: 70%;
   height: 0.06rem;
-  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.28), transparent);
-  box-shadow: 0 0 1.2rem rgba(244, 240, 232, 0.1);
+  background: linear-gradient(90deg, transparent, rgba(83, 216, 232, 0.36), rgba(255, 227, 156, 0.46), rgba(194, 55, 43, 0.42), transparent);
+  box-shadow: 0 0 1.3rem rgba(244, 240, 232, 0.13);
   transform: translateX(-50%);
 }
 
@@ -5505,9 +5508,9 @@ h3 {
   inset: 0.62rem;
   border-radius: calc(var(--radius) - 4px);
   background:
-    linear-gradient(90deg, rgba(83, 216, 232, 0.08), transparent 48%, rgba(194, 55, 43, 0.09)),
-    radial-gradient(circle at 50% 68%, rgba(212, 175, 55, 0.1), transparent 52%);
-  opacity: 0.68;
+    linear-gradient(90deg, rgba(83, 216, 232, 0.12), transparent 44%, rgba(212, 175, 55, 0.08) 54%, rgba(194, 55, 43, 0.12)),
+    radial-gradient(circle at 50% 68%, rgba(212, 175, 55, 0.14), transparent 52%);
+  opacity: 0.76;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -5516,10 +5519,10 @@ h3 {
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura {
   left: 50%;
   top: 54%;
-  width: 11.6rem;
-  height: 5.8rem;
+  width: 12.45rem;
+  height: 6.15rem;
   border-radius: 50%;
-  opacity: 0.44;
+  opacity: 0.5;
   transform: translate(-50%, -50%) rotate(-8deg);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5545,20 +5548,20 @@ h3 {
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel {
   left: 50%;
   top: 50%;
-  width: 7.05rem;
-  height: 5.95rem;
-  border: 1px solid rgba(143, 231, 237, 0.46);
-  border-top-color: rgba(244, 240, 232, 0.26);
+  width: 7.45rem;
+  height: 6.28rem;
+  border: 1px solid rgba(143, 231, 237, 0.54);
+  border-top-color: rgba(244, 240, 232, 0.34);
   border-radius: 45% 45% 52% 52%;
   background:
     linear-gradient(90deg, transparent 45%, rgba(244, 240, 232, 0.22) 49%, transparent 53%),
     radial-gradient(ellipse at 50% 58%, rgba(83, 216, 232, 0.12), transparent 42%),
     radial-gradient(ellipse at 50% 66%, rgba(255, 227, 156, 0.18), transparent 72%);
   box-shadow:
-    inset 0 0 1.45rem rgba(143, 231, 237, 0.13),
-    0 0 2.1rem rgba(83, 216, 232, 0.18),
-    0 0 2.6rem rgba(212, 175, 55, 0.08);
-  opacity: 0.82;
+    inset 0 0 1.65rem rgba(143, 231, 237, 0.16),
+    0 0 2.25rem rgba(83, 216, 232, 0.22),
+    0 0 2.8rem rgba(212, 175, 55, 0.12);
+  opacity: 0.9;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5613,14 +5616,14 @@ h3 {
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__bath {
   left: 50%;
   top: 59%;
-  width: 5.4rem;
-  height: 1.28rem;
+  width: 5.7rem;
+  height: 1.38rem;
   border-radius: 50%;
   background:
     radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.34), transparent 68%),
     linear-gradient(90deg, rgba(83, 216, 232, 0.18), rgba(212, 175, 55, 0.14), rgba(194, 55, 43, 0.12));
   box-shadow: 0 0 1.55rem rgba(83, 216, 232, 0.18);
-  opacity: 0.72;
+  opacity: 0.8;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5629,10 +5632,10 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish {
-  left: 26%;
+  left: 24%;
   top: 51%;
-  width: 3.58rem;
-  height: 1.06rem;
+  width: 3.86rem;
+  height: 1.12rem;
   border-radius: 50%;
   border-top: 1px solid rgba(255, 227, 156, 0.58);
   border-bottom: 1px solid rgba(143, 231, 237, 0.34);
@@ -5640,7 +5643,7 @@ h3 {
     radial-gradient(circle at 31% 50%, rgba(255, 227, 156, 0.78) 0 0.14rem, transparent 0.16rem),
     radial-gradient(ellipse at 52% 50%, rgba(212, 175, 55, 0.18), rgba(83, 216, 232, 0.08) 64%, transparent 72%);
   box-shadow: 0 0 1.35rem rgba(212, 175, 55, 0.2);
-  opacity: 0.86;
+  opacity: 0.92;
   transform: translate(-50%, -50%) rotate(-7deg);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5662,9 +5665,9 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet {
-  left: 64%;
-  top: 43%;
-  width: 1.05rem;
+  left: 63%;
+  top: 42%;
+  width: 1.18rem;
   aspect-ratio: 1;
   border: 1px solid rgba(181, 130, 255, 0.34);
   border-radius: 0.2rem;
@@ -5672,7 +5675,7 @@ h3 {
   box-shadow:
     0 0 0 0.48rem rgba(181, 130, 255, 0.04),
     0 0 1.35rem rgba(181, 130, 255, 0.18);
-  opacity: 0.62;
+  opacity: 0.72;
   transform: translate(-50%, -50%) rotate(45deg);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5681,9 +5684,9 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis {
-  left: 72%;
+  left: 73%;
   top: 62%;
-  width: 1.1rem;
+  width: 1.22rem;
   aspect-ratio: 1;
   border: 1px solid rgba(255, 227, 156, 0.38);
   border-radius: 35%;
@@ -5692,7 +5695,7 @@ h3 {
   box-shadow:
     0 0 0 0.48rem rgba(212, 175, 55, 0.05),
     0 0 1.35rem rgba(212, 175, 55, 0.2);
-  opacity: 0.58;
+  opacity: 0.7;
   transform: translate(-50%, -50%) rotate(18deg) scale(0.86);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5702,14 +5705,14 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__heat {
   left: 50%;
-  bottom: 1.34rem;
-  width: 5.8rem;
-  height: 1.36rem;
+  bottom: 1.3rem;
+  width: 6.65rem;
+  height: 1.52rem;
   border-radius: 50%;
   background:
     radial-gradient(ellipse at 50% 70%, rgba(194, 55, 43, 0.46), rgba(212, 175, 55, 0.24) 46%, transparent 72%);
   filter: blur(0.08rem);
-  opacity: 0.66;
+  opacity: 0.76;
   transform: translateX(-50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5719,14 +5722,14 @@ h3 {
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__flame {
   left: 50%;
   bottom: 1.42rem;
-  width: 2.65rem;
-  height: 2.8rem;
+  width: 2.88rem;
+  height: 3.06rem;
   border-radius: 50% 50% 46% 46%;
   background:
     radial-gradient(ellipse at 50% 72%, rgba(255, 227, 156, 0.42), transparent 54%),
     radial-gradient(ellipse at 50% 35%, rgba(194, 55, 43, 0.34), transparent 68%);
   filter: blur(0.03rem);
-  opacity: 0.52;
+  opacity: 0.62;
   transform: translateX(-50%) scaleY(0.74);
   transform-origin: 50% 100%;
   transition:
@@ -5738,8 +5741,8 @@ h3 {
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread {
   left: 50%;
   top: 50%;
-  width: 9.2rem;
-  height: 3.4rem;
+  width: 9.95rem;
+  height: 3.7rem;
   border-radius: 50%;
   opacity: 0.38;
   transition:
@@ -5843,14 +5846,14 @@ h3 {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.18rem;
-  width: 13.2rem;
-  max-width: 64%;
+  width: 14.2rem;
+  max-width: 68%;
   height: 0.54rem;
   padding: 0.08rem;
   border: 1px solid rgba(244, 240, 232, 0.12);
   border-radius: 999px;
   background: rgba(3, 3, 7, 0.48);
-  opacity: 0.72;
+  opacity: 0.84;
   transform: translateX(-50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -5860,7 +5863,7 @@ h3 {
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stage {
   min-width: 0;
   border-radius: 999px;
-  opacity: 0.66;
+  opacity: 0.82;
 }
 
 .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stage--nigredo {
@@ -12198,16 +12201,16 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro h1 {
-	    max-width: 9.4ch;
-	    font-size: clamp(2.05rem, 10.5vw, 2.8rem);
-	    line-height: 0.92;
+	    max-width: 8.7ch;
+	    font-size: clamp(2rem, 10vw, 2.72rem);
+	    line-height: 0.91;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .chapter-stage__intro p:not(.eyebrow) {
-	    margin-top: 0.68rem;
-	    max-width: 29ch;
-	    font-size: 0.9rem;
-	    line-height: 1.47;
+	    margin-top: 0.56rem;
+	    max-width: 28ch;
+	    font-size: 0.88rem;
+	    line-height: 1.42;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .scene-host__pause {
@@ -12227,8 +12230,8 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument {
-	    min-height: 7.1rem;
-	    margin-top: 0.66rem;
+	    min-height: 6.95rem;
+	    margin-top: 0.58rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument::before {
@@ -12236,18 +12239,18 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__vessel {
-	    width: 5.3rem;
-	    height: 4.55rem;
+	    width: 5.18rem;
+	    height: 4.42rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura {
-	    width: 8.3rem;
-	    height: 4.5rem;
+	    width: 8.05rem;
+	    height: 4.32rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__aura--coagula {
-	    width: 6.9rem;
-	    height: 3.85rem;
+	    width: 6.65rem;
+	    height: 3.62rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__retort {
@@ -12261,24 +12264,24 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__fish {
-	    left: 24%;
-	    width: 2.95rem;
+	    left: 23%;
+	    width: 3rem;
 	    height: 0.92rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__magnet {
-	    left: 65%;
-	    width: 0.88rem;
+	    left: 64%;
+	    width: 0.9rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__lapis {
 	    left: 74%;
-	    width: 0.92rem;
+	    width: 0.94rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__flame {
-	    width: 2rem;
-	    height: 2.12rem;
+	    width: 1.92rem;
+	    height: 2rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__plough {
@@ -12288,17 +12291,17 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__thread {
-	    width: 6.35rem;
-	    height: 2.9rem;
+	    width: 6.25rem;
+	    height: 2.72rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__stages {
-	    width: 10.1rem;
-	    max-width: 62%;
+	    width: 9.75rem;
+	    max-width: 61%;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label {
-	    font-size: 0.5rem;
+	    font-size: 0.48rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"] .alchemical-vessel-instrument__label--fish {
@@ -12332,7 +12335,7 @@ h3 {
 
 	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .chapter-stage__reference-map {
 	    margin-top: 0.75rem;
-	    transform: translateY(0.5rem);
+	    transform: translateY(1.35rem);
 	  }
 
 	  .chapter-experience[data-chapter-id="ch10"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {

--- a/src/visualizations/chapters/ch10/ThreeAlchemyViz.js
+++ b/src/visualizations/chapters/ch10/ThreeAlchemyViz.js
@@ -61,10 +61,10 @@ export default class ThreeAlchemyViz extends BaseViz {
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
 
         this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.FogExp2(VOID, 0.012);
+        this.scene.fog = new THREE.FogExp2(VOID, 0.01);
 
         this.camera = new THREE.PerspectiveCamera(55, this.width / this.height, 0.1, 200);
-        this.camera.position.set(0, 3, 14);
+        this.camera.position.set(0, 2.8, 14.5);
 
         this.mouse = new THREE.Vector2(0, 0);
         this.mouseSmooth = new THREE.Vector2(0, 0);
@@ -83,7 +83,7 @@ export default class ThreeAlchemyViz extends BaseViz {
         this.composer = new EffectComposer(this.renderer);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(this.width, this.height), 1.35, 0.48, 0.32
+            new THREE.Vector2(this.width, this.height), 1.42, 0.5, 0.28
         );
         this.composer.addPass(this.bloomPass);
     }
@@ -113,7 +113,6 @@ export default class ThreeAlchemyViz extends BaseViz {
         this.echeneisBody = new THREE.Mesh(bodyGeo, bodyMat);
         this.echeneisGroup.add(this.echeneisBody);
 
-        // Aura of stopping power
         const auraGeo = new THREE.SphereGeometry(0.5, 12, 12);
         this.echeneisAura = new THREE.Mesh(auraGeo, new THREE.MeshBasicMaterial({
             color: ECHENEIS_CYAN, transparent: true, opacity: 0.09,
@@ -187,7 +186,6 @@ export default class ThreeAlchemyViz extends BaseViz {
         }));
         this.scene.add(this.magnetField);
 
-        // Magnet core
         const magnetGeo = new THREE.OctahedronGeometry(0.3, 0);
         this.magnetCore = new THREE.Mesh(magnetGeo, new THREE.MeshStandardMaterial({
             color: MAGNET_PURPLE, emissive: MAGNET_PURPLE, emissiveIntensity: 0.9,
@@ -370,6 +368,7 @@ export default class ThreeAlchemyViz extends BaseViz {
         if (!this.scene) return;
         const t = this.time;
         const panelId = this.panelState?.activePanelId || 'vessel';
+        const isMobile = this.width < 720;
         const dampRate = this.reducedMotion ? 9 : 3.5;
         const motionScale = this.reducedMotion ? 0.12 : 1;
         this.vesselFocus = THREE.MathUtils.damp(this.vesselFocus, panelId === 'vessel' ? 1 : 0.22, dampRate, dt);
@@ -378,18 +377,18 @@ export default class ThreeAlchemyViz extends BaseViz {
         this.mouseSmooth.lerp(this.mouse, 0.03);
 
         // Echeneis hovering near ship
-        this.echeneisGroup.position.x = -3 + Math.sin(t * 0.08 * motionScale) * 0.3;
-        this.echeneisGroup.position.y = 2 + Math.sin(t * 0.15 * motionScale) * 0.2;
-        this.echeneisGroup.scale.setScalar(0.88 + this.vesselFocus * 0.28);
-        this.echeneisBody.material.opacity = 0.42 + this.vesselFocus * 0.5;
-        this.echeneisAura.material.opacity = (0.06 + Math.sin(t * 0.6 * motionScale) * 0.02) + this.vesselFocus * 0.15;
+        this.echeneisGroup.position.x = -3.25 + Math.sin(t * 0.08 * motionScale) * 0.28 - this.vesselFocus * 0.16;
+        this.echeneisGroup.position.y = 2.05 + Math.sin(t * 0.15 * motionScale) * 0.18;
+        this.echeneisGroup.scale.setScalar(0.9 + this.vesselFocus * 0.34);
+        this.echeneisBody.material.opacity = 0.48 + this.vesselFocus * 0.5;
+        this.echeneisAura.material.opacity = (0.07 + Math.sin(t * 0.6 * motionScale) * 0.018) + this.vesselFocus * 0.18;
 
         // Ship halted — only rocking
         this.shipGroup.rotation.z = Math.sin(t * 0.12 * motionScale) * 0.03;
         this.shipGroup.position.y = 2 + Math.sin(t * 0.08 * motionScale) * 0.05;
         this.shipGroup.scale.setScalar(0.94 + this.vesselFocus * 0.08);
         this.shipParts?.forEach((part) => {
-            part.material.opacity = (part === this.shipParts[2] ? 0.1 : 0.14) + this.vesselFocus * (part === this.shipParts[2] ? 0.16 : 0.18);
+            part.material.opacity = (part === this.shipParts[2] ? 0.13 : 0.18) + this.vesselFocus * (part === this.shipParts[2] ? 0.2 : 0.22);
         });
 
         // Magnet drawing particles upward
@@ -413,21 +412,22 @@ export default class ThreeAlchemyViz extends BaseViz {
             }
         }
         this.magnetField.geometry.attributes.position.needsUpdate = true;
-        this.magnetField.material.opacity = 0.2 + this.primaFocus * 0.58;
+        this.magnetField.material.opacity = 0.24 + this.primaFocus * 0.62;
+        this.magnetField.material.size = 0.085 + this.primaFocus * 0.045;
         this.magnetCore.rotation.y = t * 0.1 * motionScale;
-        this.magnetCore.scale.setScalar(0.72 + this.primaFocus * 0.5);
-        this.magnetCore.material.opacity = 0.32 + this.primaFocus * 0.58;
+        this.magnetCore.scale.setScalar(0.76 + this.primaFocus * 0.58);
+        this.magnetCore.material.opacity = 0.38 + this.primaFocus * 0.58;
 
         // Lapis heartbeat — systole/diastole
         const heartbeat = Math.sin(t * 2 * motionScale); // Fast pulse
         const pulse = heartbeat > 0.7 ? 1 : 0; // Sharp beat
         this.lapisStone.scale.setScalar(0.82 + this.primaFocus * 0.16 + this.opusFocus * 0.22 + pulse * 0.15);
-        this.lapisStone.material.opacity = 0.44 + this.primaFocus * 0.2 + this.opusFocus * 0.34;
-        this.lapisStone.material.emissiveIntensity = 0.38 + this.opusFocus * 0.46 + pulse * 0.5;
-        this.heartAura.material.opacity = pulse * (0.06 + this.opusFocus * 0.1);
-        this.heartAura.scale.setScalar(1 + pulse * 0.5 + this.opusFocus * 0.2);
+        this.lapisStone.material.opacity = 0.46 + this.primaFocus * 0.22 + this.opusFocus * 0.38;
+        this.lapisStone.material.emissiveIntensity = 0.42 + this.opusFocus * 0.54 + pulse * 0.5;
+        this.heartAura.material.opacity = pulse * (0.07 + this.opusFocus * 0.13);
+        this.heartAura.scale.setScalar(1 + pulse * 0.55 + this.opusFocus * 0.24);
         this.lapisStone.rotation.y = t * 0.05 * motionScale;
-        this.vesselGlass.material.opacity = 0.04 + this.vesselFocus * 0.055 + this.primaFocus * 0.045 + this.opusFocus * 0.055;
+        this.vesselGlass.material.opacity = 0.035 + this.vesselFocus * 0.05 + this.primaFocus * 0.034 + this.opusFocus * 0.045;
         this.vesselGlass.rotation.y = -t * 0.025 * motionScale;
 
         if (this.labField) {
@@ -447,10 +447,10 @@ export default class ThreeAlchemyViz extends BaseViz {
         }
         if (this.alembicFlame) {
             this.alembicFlame.scale.set(1 + this.opusFocus * 0.1, 0.74 + this.opusFocus * 0.44 + Math.sin(t * 1.3 * motionScale) * 0.04, 1);
-            this.alembicFlame.material.opacity = 0.12 + this.opusFocus * 0.22;
+            this.alembicFlame.material.opacity = 0.13 + this.opusFocus * 0.32;
         }
         if (this.labThreads) {
-            this.labThreads.material.opacity = 0.18 + this.vesselFocus * 0.08 + this.opusFocus * 0.16;
+            this.labThreads.material.opacity = 0.18 + this.vesselFocus * 0.1 + this.opusFocus * 0.2;
         }
         this.labStageStones?.forEach((stage, index) => {
             const stageLift = index / Math.max(this.labStageStones.length - 1, 1);
@@ -466,20 +466,20 @@ export default class ThreeAlchemyViz extends BaseViz {
         this.yokeGroup.position.y = -3.5 + Math.sin(t * 0.3 * motionScale) * 0.1;
         this.yokeGroup.scale.setScalar(0.78 + this.opusFocus * 0.36);
         this.yokedFishParts?.forEach((part) => {
-            part.material.opacity = 0.22 + this.opusFocus * 0.5;
+            part.material.opacity = 0.24 + this.opusFocus * 0.58;
         });
         this.groundStrips?.forEach((strip, index) => {
-            strip.material.opacity = 0.035 + this.opusFocus * (0.07 + index * 0.015);
+            strip.material.opacity = 0.04 + this.opusFocus * (0.085 + index * 0.018);
         });
 
         // Camera
         const camAngle = t * 0.015 * motionScale + this.mouseSmooth.x * 0.3;
-        const camH = 1.65 + this.mouseSmooth.y * 2.4 - this.opusFocus * 0.45;
-        const camRadius = 12.3 - this.vesselFocus * 0.95 - this.primaFocus * 0.46 + this.opusFocus * 0.7;
+        const camH = 1.75 + this.mouseSmooth.y * 2.25 - this.opusFocus * 0.42 + (isMobile ? 0.55 : 0);
+        const camRadius = 12.9 - this.vesselFocus * 0.45 - this.primaFocus * 0.22 + this.opusFocus * 0.58 + (isMobile ? 2.35 : 0);
         this.camera.position.set(Math.sin(camAngle) * camRadius, camH, Math.cos(camAngle) * camRadius);
-        this.camera.lookAt(this.primaFocus * 0.74 - this.vesselFocus * 0.34, -0.86 - this.opusFocus * 0.58, 0.2);
+        this.camera.lookAt(this.primaFocus * 0.7 - this.vesselFocus * 0.28, -0.78 - this.opusFocus * 0.54, 0.2);
 
-        if (this.bloomPass) this.bloomPass.strength = 1.08 + Math.sin(t * 0.1 * motionScale) * 0.18 + this.vesselFocus * 0.18 + this.opusFocus * 0.24;
+        if (this.bloomPass) this.bloomPass.strength = 1.08 + Math.sin(t * 0.1 * motionScale) * 0.16 + this.vesselFocus * 0.18 + this.opusFocus * 0.28;
     }
 
     render() { this.composer?.render(); }


### PR DESCRIPTION
## Summary
- refines Chapter 10 as a clearer alchemical vessel theatre without changing route/content contracts
- strengthens the inline vessel instrument so fish, prima materia, heat, stages, and lapis read as one transformation process
- tunes the Chapter 10 Three scene focus weights and mobile camera distance for clearer vessel/prima/opus emphasis
- preserves reduced-motion behavior and fixes the reduced-motion mobile fallback/reference-map spacing caught by smoke

## Skill stack
- Aion skill routing playbook
- orchestration-autopilot scout wave: explorer, architect planner, devil advocate
- Browser/Playwright Control Tower evidence
- accessibility-review and webapp-testing gates via local smoke scripts
- github publish flow

## Routes changed
- `/journey/chapter/ch10`

## Visual thesis
Chapter 10 should read as an alchemical vessel theatre: the fish enters a sealed process, prima materia gathers as charged matter, and the opus path resolves through heat, stages, and lapis. This pass clarifies that sequence without adding another teaching layer.

## Browser evidence
- `npm run test:visual:control-tower` passed with 0 technical blockers
- Chapter 10 screenshots refreshed at:
  - `test-results/control-tower/latest/screenshots/journey-chapter-ch10-desktop.png`
  - `test-results/control-tower/latest/screenshots/journey-chapter-ch10-mobile.png`
  - `test-results/control-tower/latest/screenshots/journey-chapter-ch10-narrow.png`
- Chapter 10 and Chapter 11 both remained 100% in the Control Tower report, with 0px mobile/narrow overflow

## Checks
- `git diff --check`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .` returned no markers
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `AION_SMOKE_PORT=4195 npm run test:e2e:app:scene-controls`
- `AION_SMOKE_PORT=4196 npm run test:e2e:app:mobile`
- `AION_SMOKE_PORT=4199 npm run test:e2e:app:chapter-routes`
- `AION_SMOKE_PORT=4202 npm run test:e2e:app:foundation`
- `AION_A11Y_PORT=4197 npm run test:a11y:app`
- `npm run build:pages && npm run test:pages:artifact`

Note: the first `chapter-routes` attempt failed while I was concurrently running `build:pages`, which rewrote `dist`; the standalone rerun passed.

## Residual debt
- Known Vite warning: shared `three` chunk remains above 500 kB.
- Default-branch Dependabot vulnerability notice is pre-existing and outside this visual batch.
