### PR TITLE
[codex] Refine chapter eleven opus wheel

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -6012,16 +6012,16 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-map {
-  width: min(26rem, 100%);
-  margin-top: 0.66rem;
+  width: min(28rem, 100%);
+  margin-top: 0.58rem;
 }
 
 .chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node {
   min-height: 3.82rem;
   background:
-    radial-gradient(circle at 42% 33%, rgba(255, 227, 156, 0.12), transparent 2.4rem),
-    radial-gradient(circle at 62% 65%, rgba(83, 216, 232, 0.11), transparent 2.5rem),
-    linear-gradient(180deg, rgba(9, 8, 13, 0.68), rgba(4, 3, 8, 0.36));
+    radial-gradient(circle at 42% 33%, rgba(255, 227, 156, 0.16), transparent 2.5rem),
+    radial-gradient(circle at 62% 65%, rgba(83, 216, 232, 0.14), transparent 2.6rem),
+    linear-gradient(180deg, rgba(9, 8, 13, 0.78), rgba(4, 3, 8, 0.48));
 }
 
 .chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-label {
@@ -6030,11 +6030,11 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .chapter-stage__scrim {
   background:
-    linear-gradient(180deg, rgba(3, 3, 7, 0.75), rgba(3, 3, 7, 0.34) 48%, rgba(3, 3, 7, 0.8)),
-    linear-gradient(90deg, rgba(3, 3, 7, 0.96), rgba(3, 3, 7, 0.52) 58%, rgba(3, 3, 7, 0.24)),
-    radial-gradient(circle at 31% 51%, rgba(212, 175, 55, 0.14), transparent 32%),
-    radial-gradient(circle at 58% 48%, rgba(83, 216, 232, 0.13), transparent 36%),
-    radial-gradient(circle at 74% 66%, rgba(181, 130, 255, 0.09), transparent 34%);
+    linear-gradient(180deg, rgba(3, 3, 7, 0.86), rgba(3, 3, 7, 0.46) 48%, rgba(3, 3, 7, 0.84)),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.98), rgba(3, 3, 7, 0.72) 56%, rgba(3, 3, 7, 0.32)),
+    radial-gradient(circle at 31% 51%, rgba(212, 175, 55, 0.17), transparent 31%),
+    radial-gradient(circle at 58% 48%, rgba(83, 216, 232, 0.11), transparent 34%),
+    radial-gradient(circle at 74% 66%, rgba(181, 130, 255, 0.08), transparent 32%);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node[data-panel-id="mercurius"] .chapter-stage__reference-mark::before {
@@ -6111,22 +6111,22 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument {
   position: relative;
-  width: min(33rem, 100%);
-  min-height: clamp(8.65rem, 13.5vh, 9.85rem);
+  width: min(35.5rem, 100%);
+  min-height: clamp(9.45rem, 15vh, 10.85rem);
   overflow: hidden;
-  margin-top: 0.78rem;
-  border: 1px solid rgba(244, 240, 232, 0.12);
+  margin-top: 0.7rem;
+  border: 1px solid rgba(244, 240, 232, 0.16);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 26% 62%, rgba(83, 216, 232, 0.18), transparent 5.8rem),
-    radial-gradient(circle at 50% 48%, rgba(212, 175, 55, 0.22), transparent 5.6rem),
-    radial-gradient(circle at 77% 56%, rgba(255, 111, 82, 0.12), transparent 5.2rem),
-    radial-gradient(circle at 72% 68%, rgba(181, 130, 255, 0.12), transparent 5rem),
-    linear-gradient(90deg, rgba(7, 8, 13, 0.9), rgba(11, 9, 12, 0.76) 48%, rgba(18, 8, 16, 0.68));
+    radial-gradient(circle at 22% 68%, rgba(83, 216, 232, 0.22), transparent 6.2rem),
+    radial-gradient(circle at 50% 46%, rgba(212, 175, 55, 0.25), transparent 6.3rem),
+    radial-gradient(circle at 78% 50%, rgba(255, 111, 82, 0.16), transparent 5.9rem),
+    radial-gradient(circle at 72% 68%, rgba(181, 130, 255, 0.11), transparent 5.2rem),
+    linear-gradient(90deg, rgba(6, 8, 13, 0.94), rgba(11, 9, 12, 0.83) 46%, rgba(18, 8, 16, 0.76));
   box-shadow:
     var(--shadow-inset),
-    0 1.5rem 4.6rem rgba(0, 0, 0, 0.28),
-    0 0 3rem rgba(212, 175, 55, 0.06);
+    0 1.6rem 4.9rem rgba(0, 0, 0, 0.34),
+    0 0 3.2rem rgba(212, 175, 55, 0.09);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::before,
@@ -6140,6 +6140,10 @@ h3 {
   inset: 0.58rem;
   border: 1px solid rgba(255, 227, 156, 0.08);
   border-radius: calc(var(--radius) - 2px);
+  background:
+    linear-gradient(90deg, transparent 30%, rgba(255, 227, 156, 0.1) 30.2%, transparent 30.8%),
+    linear-gradient(90deg, transparent 66%, rgba(83, 216, 232, 0.08) 66.2%, transparent 66.8%);
+  box-shadow: inset 0 0 2.4rem rgba(83, 216, 232, 0.04);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::after {
@@ -6172,10 +6176,10 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field {
   left: 50%;
-  width: 78%;
+  width: 82%;
   height: 3.72rem;
   border-radius: 50%;
-  opacity: 0.6;
+  opacity: 0.66;
   transform: translateX(-50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6183,23 +6187,23 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field--above {
-  top: 0.58rem;
-  background: radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.18), transparent 70%);
+  top: 0.42rem;
+  background: radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.24), transparent 68%);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field--below {
-  bottom: 0.52rem;
-  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.18), transparent 70%);
+  bottom: 0.44rem;
+  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.22), transparent 68%);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__halo {
   left: 50%;
   top: 50%;
-  width: 13.8rem;
-  height: 7.4rem;
-  border: 1px solid rgba(255, 227, 156, 0.16);
+  width: 15.2rem;
+  height: 8.25rem;
+  border: 1px solid rgba(255, 227, 156, 0.2);
   border-radius: 50%;
-  opacity: 0.52;
+  opacity: 0.62;
   box-shadow:
     inset 0 0 2rem rgba(255, 227, 156, 0.06),
     0 0 2.4rem rgba(83, 216, 232, 0.08);
@@ -6231,13 +6235,13 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root {
   left: 50%;
-  bottom: 1.03rem;
-  width: 9.3rem;
-  height: 2.8rem;
-  border-bottom: 1px solid rgba(83, 216, 232, 0.34);
+  top: 1.08rem;
+  width: 9.9rem;
+  height: 2.95rem;
+  border-top: 1px solid rgba(83, 216, 232, 0.4);
   border-radius: 50%;
-  opacity: 0.58;
-  filter: drop-shadow(0 0 0.72rem rgba(83, 216, 232, 0.14));
+  opacity: 0.64;
+  filter: drop-shadow(0 0 0.82rem rgba(83, 216, 232, 0.18));
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -6259,13 +6263,14 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch {
   left: 50%;
-  top: 27%;
-  width: 9.9rem;
-  height: 3.15rem;
-  border-top: 1px solid rgba(255, 227, 156, 0.34);
+  top: auto;
+  bottom: 0.82rem;
+  width: 10.45rem;
+  height: 3.32rem;
+  border-bottom: 1px solid rgba(255, 227, 156, 0.4);
   border-radius: 50%;
-  opacity: 0.58;
-  filter: drop-shadow(0 0 0.72rem rgba(212, 175, 55, 0.14));
+  opacity: 0.64;
+  filter: drop-shadow(0 0 0.82rem rgba(212, 175, 55, 0.18));
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -6282,10 +6287,10 @@ h3 {
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread {
   left: 50%;
   top: 50%;
-  width: 14.8rem;
-  height: 5.35rem;
+  width: 16rem;
+  height: 5.8rem;
   border-radius: 50%;
-  opacity: 0.5;
+  opacity: 0.58;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
@@ -6305,9 +6310,9 @@ h3 {
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius {
   left: 50%;
   top: 48%;
-  width: 1.16rem;
-  height: 3.34rem;
-  border: 1px solid rgba(143, 231, 237, 0.48);
+  width: 1.24rem;
+  height: 3.64rem;
+  border: 1px solid rgba(143, 231, 237, 0.58);
   border-radius: 999px;
   background:
     radial-gradient(circle at 50% 18%, rgba(255, 227, 156, 0.94) 0 0.14rem, transparent 0.16rem),
@@ -6316,7 +6321,7 @@ h3 {
   box-shadow:
     inset 0 0 0.8rem rgba(143, 231, 237, 0.08),
     0 0 1.45rem rgba(83, 216, 232, 0.16);
-  opacity: 0.84;
+  opacity: 0.9;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6326,7 +6331,7 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__seed {
   left: 50%;
-  width: 0.62rem;
+  width: 0.68rem;
   aspect-ratio: 1;
   border-radius: 50%;
   opacity: 0.72;
@@ -6350,19 +6355,19 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel {
-  right: 11%;
+  right: 8%;
   top: 50%;
-  width: 5.65rem;
+  width: 6.5rem;
   aspect-ratio: 1;
-  border: 1px solid rgba(255, 227, 156, 0.28);
+  border: 1px solid rgba(255, 227, 156, 0.36);
   border-radius: 50%;
   background:
-    radial-gradient(circle at 50% 50%, rgba(3, 3, 7, 0.94) 0 38%, transparent 40%),
-    conic-gradient(from 22deg, rgba(18, 18, 22, 0.92), rgba(232, 232, 240, 0.7), rgba(255, 215, 0, 0.72), rgba(194, 55, 43, 0.72), rgba(18, 18, 22, 0.92));
+    radial-gradient(circle at 50% 50%, rgba(3, 3, 7, 0.96) 0 34%, transparent 36%),
+    conic-gradient(from 22deg, rgba(18, 18, 22, 0.96), rgba(232, 232, 240, 0.76), rgba(255, 215, 0, 0.82), rgba(194, 55, 43, 0.78), rgba(18, 18, 22, 0.96));
   box-shadow:
     inset 0 0 1rem rgba(3, 3, 7, 0.7),
-    0 0 1.55rem rgba(212, 175, 55, 0.14);
-  opacity: 0.74;
+    0 0 1.85rem rgba(212, 175, 55, 0.2);
+  opacity: 0.82;
   transform: translateY(-50%);
   animation: alchemical-tree-wheel 18s linear infinite;
   transition:
@@ -6396,38 +6401,38 @@ h3 {
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage {
   left: 50%;
   top: 50%;
-  width: 0.48rem;
+  width: 0.54rem;
   aspect-ratio: 1;
   border-radius: 50%;
-  opacity: 0.72;
+  opacity: 0.82;
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--black {
   background: rgba(18, 18, 22, 0.96);
   box-shadow: 0 0 0.7rem rgba(244, 240, 232, 0.12);
-  transform: translate(-50%, -2.15rem);
+  transform: translate(-50%, -2.48rem);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--white {
   background: rgba(232, 232, 240, 0.78);
-  transform: translate(1.72rem, -50%);
+  transform: translate(1.98rem, -50%);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--gold {
   background: rgba(255, 215, 0, 0.78);
   box-shadow: 0 0 0.78rem rgba(212, 175, 55, 0.28);
-  transform: translate(-50%, 1.72rem);
+  transform: translate(-50%, 1.98rem);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--red {
   background: rgba(194, 55, 43, 0.78);
-  transform: translate(-2.15rem, -50%);
+  transform: translate(-2.48rem, -50%);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone {
-  left: 24%;
-  top: 58%;
-  width: 1.5rem;
+  left: 20%;
+  top: 54%;
+  width: 1.72rem;
   aspect-ratio: 1;
   border: 1px solid rgba(255, 227, 156, 0.42);
   border-radius: 34%;
@@ -6438,7 +6443,7 @@ h3 {
   box-shadow:
     0 0 0 0.5rem rgba(212, 175, 55, 0.05),
     0 0 1.35rem rgba(212, 175, 55, 0.2);
-  opacity: 0.7;
+  opacity: 0.78;
   transform: translate(-50%, -50%) rotate(45deg) scale(0.9);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6447,11 +6452,11 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mirror {
-  left: 24%;
-  top: 74%;
-  width: 5.35rem;
-  height: 1.08rem;
-  border: 1px solid rgba(83, 216, 232, 0.17);
+  left: 20%;
+  top: 73%;
+  width: 5.85rem;
+  height: 1.16rem;
+  border: 1px solid rgba(83, 216, 232, 0.23);
   border-radius: 50%;
   background:
     radial-gradient(ellipse at 50% 48%, rgba(244, 240, 232, 0.2), transparent 18%),
@@ -6459,7 +6464,7 @@ h3 {
   box-shadow:
     inset 0 0 0.8rem rgba(83, 216, 232, 0.08),
     0 0 1.25rem rgba(83, 216, 232, 0.14);
-  opacity: 0.58;
+  opacity: 0.68;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6468,16 +6473,16 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection {
-  left: 24%;
-  top: 74%;
-  width: 4.2rem;
+  left: 20%;
+  top: 73%;
+  width: 4.75rem;
   height: 0.92rem;
   border-radius: 50%;
   background:
     radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.22), transparent 72%),
     linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.14), transparent);
   box-shadow: 0 0 1.15rem rgba(83, 216, 232, 0.12);
-  opacity: 0.56;
+  opacity: 0.64;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -6487,25 +6492,25 @@ h3 {
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
   color: rgba(244, 240, 232, 0.82);
   font-family: var(--font-ui);
-  font-size: 0.58rem;
+  font-size: 0.62rem;
   font-weight: 700;
   letter-spacing: 0;
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--mercurius {
-  left: 8%;
+  left: 42%;
   top: 14%;
   color: rgba(143, 231, 237, 0.94);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--opus {
-  left: 43%;
+  right: 9%;
   top: 14%;
   color: rgba(255, 227, 156, 0.94);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--lapis {
-  right: 6%;
+  left: 8%;
   top: 14%;
   color: rgba(255, 173, 112, 0.94);
 }
@@ -12385,9 +12390,17 @@ h3 {
 
 		  .chapter-experience[data-chapter-id="ch11"] .chapter-stage__intro p:not(.eyebrow) {
 		    margin-top: 0.66rem;
-		    max-width: 29ch;
+		    max-width: 27ch;
 		    font-size: 0.88rem;
 		    line-height: 1.46;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .chapter-stage__scrim {
+		    background:
+		      linear-gradient(180deg, rgba(3, 3, 7, 0.92), rgba(3, 3, 7, 0.64) 48%, rgba(3, 3, 7, 0.88)),
+		      linear-gradient(90deg, rgba(3, 3, 7, 0.98), rgba(3, 3, 7, 0.82) 62%, rgba(3, 3, 7, 0.46)),
+		      radial-gradient(circle at 30% 48%, rgba(212, 175, 55, 0.13), transparent 28%),
+		      radial-gradient(circle at 66% 50%, rgba(83, 216, 232, 0.08), transparent 34%);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .scene-host__pause {
@@ -12407,8 +12420,8 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument {
-		    min-height: 7.35rem;
-		    margin-top: 0.64rem;
+		    min-height: 7.65rem;
+		    margin-top: 0.58rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::before {
@@ -12416,32 +12429,35 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__field {
-		    width: 78%;
-		    height: 2.9rem;
+		    width: 82%;
+		    height: 2.95rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__halo {
-		    width: 9rem;
-		    height: 4.82rem;
+		    width: 9.8rem;
+		    height: 5.05rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk {
-		    height: 61%;
+		    top: 13%;
+		    height: 67%;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__root {
-		    width: 5.4rem;
-		    height: 1.72rem;
+		    top: 0.9rem;
+		    width: 5.9rem;
+		    height: 1.9rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__branch {
-		    width: 5.85rem;
-		    height: 2.2rem;
+		    bottom: 0.72rem;
+		    width: 6.15rem;
+		    height: 2.25rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__thread {
-		    width: 6.65rem;
-		    height: 3.05rem;
+		    width: 7.15rem;
+		    height: 3.25rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mercurius {
@@ -12462,69 +12478,74 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__wheel {
-		    right: 8%;
-		    width: 3.7rem;
+		    right: 6%;
+		    width: 4.08rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage {
-		    width: 0.38rem;
+		    width: 0.4rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--black {
-		    transform: translate(-50%, -1.62rem);
+		    transform: translate(-50%, -1.78rem);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--white {
-		    transform: translate(1.25rem, -50%);
+		    transform: translate(1.42rem, -50%);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--gold {
-		    transform: translate(-50%, 1.25rem);
+		    transform: translate(-50%, 1.42rem);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stage--red {
-		    transform: translate(-1.62rem, -50%);
+		    transform: translate(-1.78rem, -50%);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__stone {
-		    left: 22%;
-		    width: 1rem;
+		    left: 19%;
+		    top: 54%;
+		    width: 1.08rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__mirror {
-		    left: 22%;
-		    width: 3.65rem;
+		    left: 19%;
+		    top: 73%;
+		    width: 3.9rem;
 		    height: 0.84rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection {
-		    left: 22%;
-		    width: 3.2rem;
+		    left: 19%;
+		    top: 73%;
+		    width: 3.38rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
-		    font-size: 0.5rem;
+		    font-size: 0.51rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--mercurius {
-		    left: 6%;
-		    top: 12%;
-		  }
-
-		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--opus {
 		    left: 39%;
 		    top: 12%;
 		  }
 
+		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--opus {
+		    left: auto;
+		    right: 5%;
+		    top: 12%;
+		  }
+
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--lapis {
-		    right: 4%;
+		    right: auto;
+		    left: 5%;
 		    top: 12%;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback {
 		    left: 1rem;
 		    right: 1rem;
-		    top: 34.05rem;
+		    top: 34.35rem;
 		    width: auto;
 		    padding: 0.38rem 0.64rem;
 		    text-align: left;
@@ -12532,12 +12553,12 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .alchemical-tree-instrument {
-		    min-height: 5.15rem;
+		    min-height: 5.45rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .chapter-stage__reference-map {
 		    margin-top: 1.18rem;
-		    transform: translateY(3.45rem);
+		    transform: translateY(3.25rem);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {

--- a/src/visualizations/chapters/ch11/ThreeTreeViz.js
+++ b/src/visualizations/chapters/ch11/ThreeTreeViz.js
@@ -66,13 +66,13 @@ export default class ThreeTreeViz extends BaseViz {
         this.renderer.setSize(this.width, this.height);
         this.renderer.setClearColor(VOID);
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 1.18;
+        this.renderer.toneMappingExposure = 1.12;
 
         this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.FogExp2(VOID, 0.01);
+        this.scene.fog = new THREE.FogExp2(VOID, 0.012);
 
         this.camera = new THREE.PerspectiveCamera(55, this.width / this.height, 0.1, 200);
-        this.camera.position.set(0, 2, 12);
+        this.camera.position.set(0, 2.2, 13.2);
 
         this.mouse = new THREE.Vector2(0, 0);
         this.mouseSmooth = new THREE.Vector2(0, 0);
@@ -93,7 +93,7 @@ export default class ThreeTreeViz extends BaseViz {
         this.composer = new EffectComposer(this.renderer);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(this.width, this.height), 1.35, 0.68, 0.34
+            new THREE.Vector2(this.width, this.height), 1.18, 0.72, 0.36
         );
         this.composer.addPass(this.bloomPass);
     }
@@ -223,14 +223,14 @@ export default class ThreeTreeViz extends BaseViz {
 
     _createOpusWheel() {
         this.opusWheel = new THREE.Group();
-        this.opusWheel.position.set(2.35, -0.05, 1.2);
+        this.opusWheel.position.set(2.75, -0.05, 1.2);
         this.opusNodes = [];
         this.opusArcs = [];
 
         const ringMat = new THREE.MeshBasicMaterial({
             color: LAPIS_GOLD,
             transparent: true,
-            opacity: 0.2,
+            opacity: 0.26,
             blending: THREE.AdditiveBlending,
             depthWrite: false,
         });
@@ -247,7 +247,7 @@ export default class ThreeTreeViz extends BaseViz {
                     emissive: stage.color,
                     emissiveIntensity: index === 0 ? 0.15 : 0.45,
                     transparent: true,
-                    opacity: 0.66,
+                    opacity: 0.74,
                     metalness: 0.4,
                     roughness: 0.3,
                 })
@@ -261,7 +261,7 @@ export default class ThreeTreeViz extends BaseViz {
                 new THREE.LineBasicMaterial({
                     color: index === 0 ? 0x443a46 : stage.color,
                     transparent: true,
-                    opacity: 0.22,
+                    opacity: 0.3,
                     blending: THREE.AdditiveBlending,
                 })
             );
@@ -285,7 +285,7 @@ export default class ThreeTreeViz extends BaseViz {
         const geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
         this.waterPts = new THREE.Points(geo, new THREE.PointsMaterial({
-            color: WATER_GLOW, size: 0.08, transparent: true, opacity: 0.5,
+            color: WATER_GLOW, size: 0.072, transparent: true, opacity: 0.42,
             blending: THREE.AdditiveBlending, depthWrite: false,
         }));
         this.scene.add(this.waterPts);
@@ -294,7 +294,7 @@ export default class ThreeTreeViz extends BaseViz {
     _createMirrorSurface() {
         const mirrorGeo = new THREE.PlaneGeometry(12, 8);
         const mirrorMat = new THREE.MeshBasicMaterial({
-            color: MIRROR_CYAN, transparent: true, opacity: 0.02,
+            color: MIRROR_CYAN, transparent: true, opacity: 0.028,
             side: THREE.DoubleSide, blending: THREE.AdditiveBlending,
         });
         this.mirror = new THREE.Mesh(mirrorGeo, mirrorMat);
@@ -345,15 +345,15 @@ export default class ThreeTreeViz extends BaseViz {
         this.reflectionLapis.position.y = -6.6;
         this.reflectionGroup.add(this.reflectionLapis);
 
-        this.figureGroup.position.x = 4;
-        this.reflectionGroup.position.x = 4;
+        this.figureGroup.position.x = 4.35;
+        this.reflectionGroup.position.x = 4.35;
         this.scene.add(this.figureGroup);
         this.scene.add(this.reflectionGroup);
     }
 
     _createLapisMandala() {
         this.lapisMandala = new THREE.Group();
-        this.lapisMandala.position.set(2.85, -2.15, 1.3);
+        this.lapisMandala.position.set(3.35, -1.95, 1.3);
         this.lapisMandalaParts = [];
 
         this.lapisStone = new THREE.Mesh(
@@ -365,7 +365,7 @@ export default class ThreeTreeViz extends BaseViz {
                 metalness: 0.74,
                 roughness: 0.22,
                 transparent: true,
-                opacity: 0.45,
+                opacity: 0.56,
             })
         );
         this.lapisMandala.add(this.lapisStone);
@@ -377,7 +377,7 @@ export default class ThreeTreeViz extends BaseViz {
                 new THREE.MeshBasicMaterial({
                     color: i === 1 ? MIRROR_CYAN : LAPIS_GOLD,
                     transparent: true,
-                    opacity: 0.12,
+                    opacity: 0.16,
                     blending: THREE.AdditiveBlending,
                     depthWrite: false,
                 })
@@ -395,7 +395,7 @@ export default class ThreeTreeViz extends BaseViz {
                 new THREE.MeshBasicMaterial({
                     color: i % 2 === 0 ? MIRROR_CYAN : LAPIS_GOLD,
                     transparent: true,
-                    opacity: 0.38,
+                    opacity: 0.46,
                     blending: THREE.AdditiveBlending,
                 })
             );
@@ -409,7 +409,7 @@ export default class ThreeTreeViz extends BaseViz {
 
     _createOpusTreeField() {
         this.opusTreeField = new THREE.Group();
-        this.opusTreeField.position.set(1.35, 0, 0.62);
+        this.opusTreeField.position.set(1.85, 0, 0.62);
         this.opusFieldRings = [];
         this.opusFieldSeeds = [];
         this.opusFieldThreads = [];
@@ -419,7 +419,7 @@ export default class ThreeTreeViz extends BaseViz {
             new THREE.MeshBasicMaterial({
                 color: 0xf4f0e8,
                 transparent: true,
-                opacity: 0.28,
+                opacity: 0.22,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
             })
@@ -444,22 +444,22 @@ export default class ThreeTreeViz extends BaseViz {
             return ring;
         };
 
-        makeRing(1.75, 2.2, LAPIS_GOLD, 0.18, 0.34);
-        makeRing(2.18, 0, 0xf4f0e8, 0.13, 0.56);
-        makeRing(1.72, -2.25, MIRROR_CYAN, 0.17, 0.36);
+        makeRing(1.75, 2.2, LAPIS_GOLD, 0.16, 0.34);
+        makeRing(2.18, 0, 0xf4f0e8, 0.11, 0.56);
+        makeRing(1.72, -2.25, MIRROR_CYAN, 0.15, 0.36);
 
         const threadMaterials = [
             new THREE.MeshBasicMaterial({
                 color: LAPIS_GOLD,
                 transparent: true,
-                opacity: 0.18,
+                opacity: 0.14,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
             }),
             new THREE.MeshBasicMaterial({
                 color: MIRROR_CYAN,
                 transparent: true,
-                opacity: 0.16,
+                opacity: 0.13,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
             }),
@@ -494,7 +494,7 @@ export default class ThreeTreeViz extends BaseViz {
                 new THREE.MeshBasicMaterial({
                     color: stage.color,
                     transparent: true,
-                    opacity: index === 0 ? 0.34 : 0.5,
+                    opacity: index === 0 ? 0.42 : 0.6,
                     blending: THREE.AdditiveBlending,
                     depthWrite: false,
                 })
@@ -516,7 +516,7 @@ export default class ThreeTreeViz extends BaseViz {
                     emissive: color,
                     emissiveIntensity: 0.55,
                     transparent: true,
-                    opacity: 0.72,
+                    opacity: 0.78,
                     metalness: 0.28,
                     roughness: 0.22,
                 })
@@ -532,7 +532,7 @@ export default class ThreeTreeViz extends BaseViz {
             new THREE.MeshBasicMaterial({
                 color: MIRROR_CYAN,
                 transparent: true,
-                opacity: 0.12,
+                opacity: 0.14,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
             })
@@ -577,7 +577,7 @@ export default class ThreeTreeViz extends BaseViz {
         geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
         geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
         this.cosmicPts = new THREE.Points(geo, new THREE.PointsMaterial({
-            vertexColors: true, size: 0.05, transparent: true, opacity: 0.3,
+            vertexColors: true, size: 0.045, transparent: true, opacity: 0.24,
             blending: THREE.AdditiveBlending, depthWrite: false,
         }));
         this.scene.add(this.cosmicPts);
@@ -611,35 +611,35 @@ export default class ThreeTreeViz extends BaseViz {
         this.mouseSmooth.lerp(this.mouse, 0.03);
 
         // Tree gentle sway
-        this.treeGroup.position.x = THREE.MathUtils.damp(this.treeGroup.position.x, isMobile ? 2.8 : 1.35, 4, dt);
-        this.treeGroup.position.y = THREE.MathUtils.damp(this.treeGroup.position.y, isMobile ? -0.45 : 0, 4, dt);
+        this.treeGroup.position.x = THREE.MathUtils.damp(this.treeGroup.position.x, isMobile ? 3.75 : 1.95, 4, dt);
+        this.treeGroup.position.y = THREE.MathUtils.damp(this.treeGroup.position.y, isMobile ? -0.32 : -0.08, 4, dt);
         this.treeGroup.rotation.z = Math.sin(t * 0.05 * motionScale) * 0.03;
         this.treeGroup.rotation.y = t * 0.005 * motionScale;
-        this.treeGroup.scale.setScalar(0.9 + this.mercuriusFocus * 0.08 + this.opusFocus * 0.05 + this.lapisFocus * 0.03);
-        this.trunkMesh.material.emissiveIntensity = 0.16 + this.mercuriusFocus * 0.18 + this.opusFocus * 0.22;
+        this.treeGroup.scale.setScalar((isMobile ? 0.72 : 0.78) + this.mercuriusFocus * 0.07 + this.opusFocus * 0.05 + this.lapisFocus * 0.03);
+        this.trunkMesh.material.emissiveIntensity = 0.12 + this.mercuriusFocus * 0.18 + this.opusFocus * 0.2;
         this.rootMeshes?.forEach((root, index) => {
-            root.material.opacity = 0.22 + this.mercuriusFocus * 0.34 + Math.sin(t * 0.16 * motionScale + index) * 0.04;
-            root.material.emissiveIntensity = 0.18 + this.mercuriusFocus * 0.28;
+            root.material.opacity = 0.16 + this.mercuriusFocus * 0.3 + Math.sin(t * 0.16 * motionScale + index) * 0.03;
+            root.material.emissiveIntensity = 0.14 + this.mercuriusFocus * 0.26;
         });
         this.branchMeshes?.forEach((branch, index) => {
-            branch.material.opacity = 0.18 + this.opusFocus * 0.38 + this.lapisFocus * 0.18 + Math.sin(t * 0.2 * motionScale + index) * 0.03;
-            branch.material.emissiveIntensity = 0.18 + this.opusFocus * 0.36 + this.lapisFocus * 0.18;
+            branch.material.opacity = 0.12 + this.opusFocus * 0.34 + this.lapisFocus * 0.18 + Math.sin(t * 0.2 * motionScale + index) * 0.025;
+            branch.material.emissiveIntensity = 0.14 + this.opusFocus * 0.34 + this.lapisFocus * 0.18;
         });
 
-        this.mercuriusGroup.position.x = THREE.MathUtils.damp(this.mercuriusGroup.position.x, isMobile ? 3.05 : 1.35, 4, dt);
-        this.mercuriusGroup.position.y = THREE.MathUtils.damp(this.mercuriusGroup.position.y, isMobile ? 0.55 : 0.15, 4, dt);
+        this.mercuriusGroup.position.x = THREE.MathUtils.damp(this.mercuriusGroup.position.x, isMobile ? 3.85 : 1.95, 4, dt);
+        this.mercuriusGroup.position.y = THREE.MathUtils.damp(this.mercuriusGroup.position.y, isMobile ? 0.42 : 0.08, 4, dt);
         this.mercuriusGroup.rotation.y = Math.sin(t * 0.12 * motionScale) * 0.35;
-        this.mercuriusGroup.scale.setScalar((isMobile ? 0.74 : 0.9) + this.mercuriusFocus * (isMobile ? 0.2 : 0.28));
-        this._setGroupOpacity(this.mercuriusGroup, 0.15 + this.mercuriusFocus * 0.78);
+        this.mercuriusGroup.scale.setScalar((isMobile ? 0.62 : 0.78) + this.mercuriusFocus * (isMobile ? 0.18 : 0.26));
+        this._setGroupOpacity(this.mercuriusGroup, 0.12 + this.mercuriusFocus * 0.8);
         this.mercuriusCore.rotation.y = t * 0.18 * motionScale;
         this.mercuriusCore.rotation.x = Math.sin(t * 0.12 * motionScale) * 0.4;
         this.mercuriusCore.material.emissiveIntensity = 0.35 + this.mercuriusFocus * 0.72;
 
-        this.opusWheel.position.x = THREE.MathUtils.damp(this.opusWheel.position.x, isMobile ? 2.8 : 2.35, 4, dt);
-        this.opusWheel.position.y = THREE.MathUtils.damp(this.opusWheel.position.y, isMobile ? 0.72 : -0.05, 4, dt);
+        this.opusWheel.position.x = THREE.MathUtils.damp(this.opusWheel.position.x, isMobile ? 4.2 : 3.05, 4, dt);
+        this.opusWheel.position.y = THREE.MathUtils.damp(this.opusWheel.position.y, isMobile ? 0.58 : -0.02, 4, dt);
         this.opusWheel.rotation.z = -t * 0.045 * motionScale;
-        this.opusWheel.scale.setScalar((isMobile ? 0.62 : 0.82) + this.opusFocus * (isMobile ? 0.18 : 0.28));
-        this._setGroupOpacity(this.opusWheel, 0.1 + this.opusFocus * 0.88);
+        this.opusWheel.scale.setScalar((isMobile ? 0.66 : 0.9) + this.opusFocus * (isMobile ? 0.22 : 0.34));
+        this._setGroupOpacity(this.opusWheel, 0.12 + this.opusFocus * 0.9);
         this.opusNodes?.forEach((node, index) => {
             const pulse = 0.5 + Math.sin(t * 1.2 * motionScale + index * 1.6) * 0.5;
             node.scale.setScalar(0.85 + this.opusFocus * 0.5 + pulse * 0.14 * this.opusFocus);
@@ -648,11 +648,11 @@ export default class ThreeTreeViz extends BaseViz {
 
         if (this.opusTreeField) {
             const fieldFocus = Math.max(this.mercuriusFocus * 0.86, this.opusFocus, this.lapisFocus * 0.94);
-            this.opusTreeField.position.x = THREE.MathUtils.damp(this.opusTreeField.position.x, isMobile ? 2.9 : 1.35, 4, dt);
+            this.opusTreeField.position.x = THREE.MathUtils.damp(this.opusTreeField.position.x, isMobile ? 3.9 : 1.95, 4, dt);
             this.opusTreeField.position.y = THREE.MathUtils.damp(this.opusTreeField.position.y, isMobile ? 0.02 : 0, 4, dt);
-            this.opusTreeField.scale.setScalar((isMobile ? 0.68 : 0.92) + fieldFocus * (isMobile ? 0.12 : 0.16));
+            this.opusTreeField.scale.setScalar((isMobile ? 0.56 : 0.78) + fieldFocus * (isMobile ? 0.1 : 0.14));
             this.opusTreeField.rotation.z = Math.sin(t * 0.06 * motionScale) * 0.035;
-            this._setGroupOpacity(this.opusTreeField, 0.42 + fieldFocus * 0.58);
+            this._setGroupOpacity(this.opusTreeField, (0.32 + fieldFocus * 0.54) * (isMobile ? 0.82 : 1));
         }
         this.opusFieldRings?.forEach((ring, index) => {
             ring.rotation.z += dt * (index % 2 === 0 ? 0.034 : -0.026) * motionScale;
@@ -662,7 +662,7 @@ export default class ThreeTreeViz extends BaseViz {
         this.opusFieldThreads?.forEach((thread, index) => {
             const material = thread.material;
             if (!material) return;
-            material.opacity = 0.08 + this.mercuriusFocus * 0.08 + this.opusFocus * 0.16 + Math.sin(t * 0.42 * motionScale + index) * 0.025;
+            material.opacity = 0.055 + this.mercuriusFocus * 0.06 + this.opusFocus * 0.15 + Math.sin(t * 0.42 * motionScale + index) * 0.02;
         });
         this.opusFieldSeeds?.forEach((seed, index) => {
             const targetFocus = seed.userData.focus === 'matter' ? this.lapisFocus : Math.max(this.mercuriusFocus, this.opusFocus * 0.6);
@@ -684,7 +684,7 @@ export default class ThreeTreeViz extends BaseViz {
 
         // Name particles twinkle
         for (const np of this.nameParticles) {
-            np.material.opacity = 0.16 + this.opusFocus * 0.34 + this.lapisFocus * 0.24 + Math.sin(t * 0.5 * motionScale + np.position.x * 2) * 0.18;
+            np.material.opacity = 0.1 + this.opusFocus * 0.3 + this.lapisFocus * 0.22 + Math.sin(t * 0.5 * motionScale + np.position.x * 2) * 0.14;
         }
 
         // Water rising
@@ -699,10 +699,10 @@ export default class ThreeTreeViz extends BaseViz {
             }
         }
         this.waterPts.geometry.attributes.position.needsUpdate = true;
-        this.waterPts.material.opacity = 0.2 + this.mercuriusFocus * 0.18 + this.lapisFocus * 0.22;
+        this.waterPts.material.opacity = 0.15 + this.mercuriusFocus * 0.16 + this.lapisFocus * 0.2;
 
         // Mirror shimmer
-        this.mirror.material.opacity = 0.01 + this.lapisFocus * 0.035 + Math.sin(t * 0.15 * motionScale) * 0.006;
+        this.mirror.material.opacity = 0.014 + this.lapisFocus * 0.046 + Math.sin(t * 0.15 * motionScale) * 0.006;
 
         // Lapis in reflection fading in
         const lapisProgress = Math.max(this.lapisFocus, Math.min(1, t / 60) * 0.25);
@@ -712,9 +712,9 @@ export default class ThreeTreeViz extends BaseViz {
         this.reflectionGroup.scale.setScalar(0.95 + this.lapisFocus * 0.16);
         this.figureGroup.scale.setScalar(0.9 + this.lapisFocus * 0.12);
 
-        this.lapisMandala.position.x = THREE.MathUtils.damp(this.lapisMandala.position.x, isMobile ? 4.2 : 3.45, 4, dt);
-        this.lapisMandala.position.y = THREE.MathUtils.damp(this.lapisMandala.position.y, isMobile ? -1.35 : -2.15, 4, dt);
-        this.lapisMandala.scale.setScalar((isMobile ? 0.44 : 0.7) + this.lapisFocus * (isMobile ? 0.26 : 0.46));
+        this.lapisMandala.position.x = THREE.MathUtils.damp(this.lapisMandala.position.x, isMobile ? 4.45 : 3.75, 4, dt);
+        this.lapisMandala.position.y = THREE.MathUtils.damp(this.lapisMandala.position.y, isMobile ? -1.1 : -1.92, 4, dt);
+        this.lapisMandala.scale.setScalar((isMobile ? 0.5 : 0.78) + this.lapisFocus * (isMobile ? 0.3 : 0.5));
         this.lapisMandala.rotation.y = t * 0.04 * motionScale;
         this.lapisStone.rotation.y = t * 0.16 * motionScale;
         this.lapisStone.rotation.x = Math.sin(t * 0.1 * motionScale) * 0.35;
@@ -730,24 +730,24 @@ export default class ThreeTreeViz extends BaseViz {
 
         // Cosmic particles slow rotation
         this.cosmicPts.rotation.y += dt * 0.002 * motionScale;
-        this.cosmicPts.material.opacity = 0.16 + this.mercuriusFocus * 0.08 + this.lapisFocus * 0.18;
+        this.cosmicPts.material.opacity = 0.1 + this.mercuriusFocus * 0.07 + this.lapisFocus * 0.16;
 
         // Camera
         const camAngle = t * 0.012 * motionScale + this.mouseSmooth.x * 0.22;
-        const baseRadius = 11.2 - this.opusFocus * 0.8 - this.lapisFocus * 1.2;
+        const baseRadius = (isMobile ? 13.8 : 12.6) - this.opusFocus * 0.72 - this.lapisFocus * 1.05;
         const targetCam = new THREE.Vector3(
-            Math.sin(camAngle) * baseRadius + this.opusFocus * 0.9 + this.lapisFocus * 1.6 + (isMobile ? 2.05 : 0.65),
-            1.4 + this.mouseSmooth.y * 2.2 - this.opusFocus * 0.6 - this.lapisFocus * 1.8,
+            Math.sin(camAngle) * baseRadius + this.opusFocus * 0.8 + this.lapisFocus * 1.35 + (isMobile ? 2.55 : 0.9),
+            1.55 + this.mouseSmooth.y * 2 - this.opusFocus * 0.46 - this.lapisFocus * 1.45,
             Math.cos(camAngle) * baseRadius
         );
         this.camera.position.lerp(targetCam, this.reducedMotion ? 1 : Math.min(1, dt * 1.8));
         this.camera.lookAt(
-            this.opusFocus * 1.8 + this.lapisFocus * 1.8 + (isMobile ? 1.45 : 0.55),
-            -0.9 - this.opusFocus * 0.35 - this.lapisFocus * 1.1,
+            this.opusFocus * 1.5 + this.lapisFocus * 1.55 + (isMobile ? 0.98 : 0.48),
+            -0.82 - this.opusFocus * 0.3 - this.lapisFocus * 0.96,
             0.5
         );
 
-        if (this.bloomPass) this.bloomPass.strength = 0.92 + Math.sin(t * 0.1 * motionScale) * 0.16 + this.mercuriusFocus * 0.2 + this.lapisFocus * 0.22;
+        if (this.bloomPass) this.bloomPass.strength = 0.76 + Math.sin(t * 0.1 * motionScale) * 0.12 + this.mercuriusFocus * 0.18 + this.lapisFocus * 0.2;
     }
 
     render() { this.composer?.render(); }


### PR DESCRIPTION
## Summary
- Strengthen Chapter 11's alchemical tree instrument so the lapis, Mercurius, and opus wheel states read clearly in the static teaching surface.
- Pull the Three.js scene back and shift Ch11 composition so the live visual supports the text instead of overpowering it, especially on mobile.
- Align the reduced-motion/static diagram with the live inverted-tree concept and fix the prior lapis-emphasis smoke failure.

## Verification
- rg -n "^(<<<<<<<|=======|>>>>>>>)" .
- git diff --check
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- AION_SMOKE_PORT=4208 npm run test:e2e:app:scene-controls
- AION_SMOKE_PORT=4209 npm run test:e2e:app:chapter-routes
- AION_SMOKE_PORT=4210 npm run test:e2e:app:mobile
- AION_A11Y_PORT=4211 npm run test:a11y:app
- npm run build:pages
- npm run test:pages:artifact
- npm run build && npm run serve, then npm run perf:cleanup

## Notes
- The earlier red CI signal was `App shell smoke (scene-controls)`: Chapter 11 did not visually emphasize lapis strongly enough. The same shard now passes locally.
- The Vite large `three` chunk warning remains pre-existing performance debt; this PR does not change the chunking strategy.
- `ThreeTreeViz.js` remains large and should be split in a later stabilization pass.
