### PR TITLE
[codex] Refine chapter fourteen synthesis endcap

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -7620,10 +7620,11 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch14"] .chapter-stage__scrim {
   background:
-    radial-gradient(circle at 54% 40%, rgba(255, 227, 156, 0.1), transparent 20rem),
-    radial-gradient(circle at 66% 58%, rgba(83, 216, 232, 0.1), transparent 22rem),
-    radial-gradient(circle at 48% 72%, rgba(91, 214, 143, 0.08), transparent 20rem),
-    linear-gradient(90deg, rgba(3, 3, 7, 0.92), rgba(3, 3, 7, 0.22) 47%, rgba(3, 3, 7, 0.64) 100%);
+    radial-gradient(circle at 54% 37%, rgba(255, 227, 156, 0.14), transparent 21rem),
+    radial-gradient(circle at 68% 57%, rgba(83, 216, 232, 0.13), transparent 23rem),
+    radial-gradient(circle at 48% 74%, rgba(91, 214, 143, 0.11), transparent 21rem),
+    radial-gradient(circle at 33% 58%, rgba(204, 109, 134, 0.07), transparent 20rem),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.94), rgba(3, 3, 7, 0.22) 47%, rgba(3, 3, 7, 0.66) 100%);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .chapter-stage__intro h1 {
@@ -7697,22 +7698,24 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument {
   position: relative;
-  width: min(32rem, 100%);
-  min-height: clamp(9.2rem, 14.2vh, 10.85rem);
+  width: min(34rem, 100%);
+  min-height: clamp(10rem, 15.2vh, 11.8rem);
   overflow: hidden;
-  margin-top: 0.82rem;
-  border: 1px solid rgba(244, 240, 232, 0.12);
+  isolation: isolate;
+  margin-top: 0.92rem;
+  border: 1px solid rgba(244, 240, 232, 0.16);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 51% 43%, rgba(255, 227, 156, 0.2), transparent 3.6rem),
-    radial-gradient(circle at 23% 57%, rgba(83, 216, 232, 0.16), transparent 5.2rem),
-    radial-gradient(circle at 75% 57%, rgba(91, 214, 143, 0.16), transparent 5rem),
-    conic-gradient(from 218deg at 52% 56%, rgba(83, 216, 232, 0.08), rgba(255, 227, 156, 0.1), rgba(204, 109, 134, 0.07), rgba(91, 214, 143, 0.08), rgba(83, 216, 232, 0.08)),
-    linear-gradient(108deg, rgba(5, 7, 12, 0.94), rgba(8, 11, 16, 0.78) 52%, rgba(3, 18, 20, 0.72));
+    radial-gradient(circle at 51% 43%, rgba(255, 227, 156, 0.27), transparent 4rem),
+    radial-gradient(circle at 22% 57%, rgba(83, 216, 232, 0.21), transparent 5.8rem),
+    radial-gradient(circle at 78% 58%, rgba(91, 214, 143, 0.21), transparent 5.8rem),
+    radial-gradient(circle at 15% 78%, rgba(255, 173, 112, 0.11), transparent 4.6rem),
+    conic-gradient(from 218deg at 52% 56%, rgba(83, 216, 232, 0.12), rgba(255, 227, 156, 0.15), rgba(204, 109, 134, 0.1), rgba(91, 214, 143, 0.12), rgba(83, 216, 232, 0.12)),
+    linear-gradient(108deg, rgba(5, 7, 12, 0.96), rgba(8, 11, 16, 0.82) 52%, rgba(3, 18, 20, 0.76));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.28),
-    0 0 2.7rem rgba(83, 216, 232, 0.08);
+    0 1.5rem 4.4rem rgba(0, 0, 0, 0.34),
+    0 0 3.2rem rgba(83, 216, 232, 0.12);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::before,
@@ -7724,25 +7727,29 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::before {
   inset: 0.58rem;
-  border: 1px solid rgba(255, 227, 156, 0.08);
+  z-index: 0;
+  border: 1px solid rgba(255, 227, 156, 0.12);
   border-radius: calc(var(--radius) - 2px);
   background:
-    linear-gradient(90deg, transparent 0 49.65%, rgba(244, 240, 232, 0.12) 49.85% 50.15%, transparent 50.35%),
-    linear-gradient(180deg, transparent 0 49.65%, rgba(244, 240, 232, 0.1) 49.85% 50.15%, transparent 50.35%);
+    radial-gradient(circle at 52% 55%, rgba(255, 227, 156, 0.12), transparent 3.2rem),
+    linear-gradient(90deg, transparent 0 49.6%, rgba(244, 240, 232, 0.18) 49.84% 50.16%, transparent 50.4%),
+    linear-gradient(180deg, transparent 0 49.6%, rgba(244, 240, 232, 0.14) 49.84% 50.16%, transparent 50.4%),
+    repeating-radial-gradient(ellipse at 52% 55%, transparent 0 2.4rem, rgba(244, 240, 232, 0.035) 2.44rem 2.48rem, transparent 2.54rem 4.8rem);
   mask-image: radial-gradient(ellipse at 50% 55%, black 0 63%, transparent 77%);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument::after {
   left: 50%;
   top: 56%;
-  width: 72%;
-  height: 42%;
-  border: 1px solid rgba(83, 216, 232, 0.1);
-  border-left-color: rgba(255, 227, 156, 0.17);
+  width: 78%;
+  height: 48%;
+  z-index: 0;
+  border: 1px solid rgba(83, 216, 232, 0.16);
+  border-left-color: rgba(255, 227, 156, 0.24);
   border-radius: 50%;
   background:
-    radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.08), transparent 58%),
-    linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.1), transparent);
+    radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.12), transparent 58%),
+    linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.16), transparent);
   transform: translate(-50%, -50%);
 }
 
@@ -7759,49 +7766,55 @@ h3 {
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark,
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label {
   position: absolute;
+  z-index: 1;
   pointer-events: none;
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field {
   top: 18%;
-  width: 35%;
-  height: 64%;
+  width: 38%;
+  height: 66%;
   border-radius: 50%;
-  opacity: 0.34;
-  filter: drop-shadow(0 0 1.3rem rgba(83, 216, 232, 0.08));
+  opacity: 0.46;
+  filter: drop-shadow(0 0 1.5rem rgba(83, 216, 232, 0.12));
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field--memory {
-  left: 7%;
-  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.13), transparent 72%);
+  left: 5.5%;
+  background:
+    radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.19), transparent 73%),
+    radial-gradient(circle at 34% 50%, rgba(255, 173, 112, 0.12), transparent 2.2rem);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__field--future {
-  right: 7%;
-  background: radial-gradient(ellipse at 50% 50%, rgba(91, 214, 143, 0.14), transparent 72%);
+  right: 5.5%;
+  background:
+    radial-gradient(ellipse at 50% 50%, rgba(91, 214, 143, 0.2), transparent 73%),
+    radial-gradient(circle at 68% 50%, rgba(83, 216, 232, 0.12), transparent 2.2rem);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis {
   left: 50%;
   top: 55%;
-  opacity: 0.34;
+  opacity: 0.48;
   transition: opacity 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis--vertical {
   width: 1px;
-  height: 5.9rem;
-  background: linear-gradient(180deg, rgba(255, 227, 156, 0.42), rgba(244, 240, 232, 0.16), rgba(83, 216, 232, 0.34));
+  height: 6.55rem;
+  background: linear-gradient(180deg, rgba(255, 227, 156, 0.58), rgba(244, 240, 232, 0.24), rgba(83, 216, 232, 0.48));
+  box-shadow: 0 0 1.3rem rgba(83, 216, 232, 0.14);
   transform: translate(-50%, -50%);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__axis--horizontal {
-  width: 12.1rem;
+  width: 13.2rem;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.28), transparent);
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.4), transparent);
   transform: translate(-50%, -50%);
 }
 
@@ -7810,7 +7823,7 @@ h3 {
   top: 55%;
   border: 1px solid rgba(83, 216, 232, 0.18);
   border-radius: 50%;
-  opacity: 0.5;
+  opacity: 0.62;
   transform: translate(-50%, -50%) rotate(-12deg);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -7820,23 +7833,23 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit--outer {
-  width: 16.6rem;
-  height: 5.5rem;
+  width: 18rem;
+  height: 6rem;
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__orbit--inner {
-  width: 10.2rem;
-  height: 3.5rem;
-  border-color: rgba(255, 227, 156, 0.18);
+  width: 11.1rem;
+  height: 3.85rem;
+  border-color: rgba(255, 227, 156, 0.26);
   transform: translate(-50%, -50%) rotate(18deg);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring {
-  left: 26%;
+  left: 25%;
   top: 55%;
-  width: 7.5rem;
+  width: 8.25rem;
   aspect-ratio: 1;
-  opacity: 0.72;
+  opacity: 0.84;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -7852,9 +7865,11 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring::before {
-  inset: 12%;
-  border: 1px solid rgba(255, 227, 156, 0.14);
-  box-shadow: inset 0 0 1.2rem rgba(83, 216, 232, 0.07);
+  inset: 10%;
+  border: 1px solid rgba(255, 227, 156, 0.22);
+  box-shadow:
+    inset 0 0 1.35rem rgba(83, 216, 232, 0.1),
+    0 0 1.1rem rgba(212, 175, 55, 0.12);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif-ring::after {
@@ -7862,15 +7877,15 @@ h3 {
   top: 50%;
   width: 72%;
   height: 1px;
-  background: linear-gradient(90deg, rgba(83, 216, 232, 0.32), rgba(255, 227, 156, 0.44), rgba(204, 109, 134, 0.3));
+  background: linear-gradient(90deg, rgba(83, 216, 232, 0.42), rgba(255, 227, 156, 0.58), rgba(204, 109, 134, 0.4));
   transform: translate(-50%, -50%) rotate(-23deg);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif {
-  width: 0.54rem;
+  width: 0.62rem;
   aspect-ratio: 1;
   border-radius: 50%;
-  opacity: 0.58;
+  opacity: 0.7;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -7899,8 +7914,8 @@ h3 {
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__motif--fish {
   left: 50%;
   top: 95%;
-  width: 0.72rem;
-  height: 0.32rem;
+  width: 0.82rem;
+  height: 0.36rem;
   background: rgba(83, 216, 232, 0.9);
 }
 
@@ -7920,14 +7935,14 @@ h3 {
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__quaternity {
   left: 52%;
   top: 55%;
-  width: 6.5rem;
+  width: 7.25rem;
   aspect-ratio: 1;
   border: 1px solid rgba(244, 240, 232, 0.18);
   border-radius: 50%;
   background:
     radial-gradient(circle at 50% 50%, rgba(255, 227, 156, 0.1), transparent 21%),
     conic-gradient(from 45deg, rgba(255, 227, 156, 0.12), rgba(83, 216, 232, 0.08), rgba(91, 214, 143, 0.08), rgba(204, 109, 134, 0.08), rgba(255, 227, 156, 0.12));
-  opacity: 0.75;
+  opacity: 0.88;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -7959,7 +7974,7 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__point {
-  width: 0.58rem;
+  width: 0.64rem;
   aspect-ratio: 1;
   border-radius: 50%;
   opacity: 0.72;
@@ -7996,14 +8011,14 @@ h3 {
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__ego {
   left: 52%;
   top: 31%;
-  width: 0.58rem;
+  width: 0.64rem;
   aspect-ratio: 1;
   border-radius: 50%;
   background: rgba(244, 240, 232, 0.96);
   box-shadow:
     0 0 0 0.44rem rgba(244, 240, 232, 0.06),
     0 0 1.3rem rgba(244, 240, 232, 0.2);
-  opacity: 0.72;
+  opacity: 0.82;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -8014,14 +8029,14 @@ h3 {
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__self {
   left: 52%;
   top: 55%;
-  width: 0.86rem;
+  width: 1rem;
   aspect-ratio: 1;
   border-radius: 50%;
   background: rgba(255, 227, 156, 0.95);
   box-shadow:
-    0 0 0 0.72rem rgba(212, 175, 55, 0.08),
-    0 0 1.65rem rgba(212, 175, 55, 0.32);
-  opacity: 0.86;
+    0 0 0 0.78rem rgba(212, 175, 55, 0.1),
+    0 0 1.9rem rgba(212, 175, 55, 0.42);
+  opacity: 0.94;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -8032,12 +8047,12 @@ h3 {
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__path {
   right: 12%;
   top: 55%;
-  width: 6.8rem;
-  height: 4rem;
-  border-top: 1px solid rgba(91, 214, 143, 0.28);
-  border-right: 1px solid rgba(83, 216, 232, 0.2);
+  width: 7.55rem;
+  height: 4.4rem;
+  border-top: 1px solid rgba(91, 214, 143, 0.42);
+  border-right: 1px solid rgba(83, 216, 232, 0.3);
   border-radius: 50%;
-  opacity: 0.5;
+  opacity: 0.64;
   transform: translateY(-50%) rotate(12deg);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -8049,16 +8064,16 @@ h3 {
   content: '';
   position: absolute;
   inset: 13% 9% 8% 14%;
-  border-top: 1px solid rgba(255, 227, 156, 0.22);
+  border-top: 1px solid rgba(255, 227, 156, 0.34);
   border-radius: 50%;
   transform: rotate(-18deg);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__mark {
-  width: 0.5rem;
+  width: 0.56rem;
   aspect-ratio: 1;
   border-radius: 50%;
-  opacity: 0.62;
+  opacity: 0.74;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -8085,6 +8100,7 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument__label {
+  z-index: 3;
   color: rgba(244, 240, 232, 0.82);
   font-family: var(--font-ui);
   font-size: 0.58rem;
@@ -8119,13 +8135,13 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__motif-ring {
-  transform: translate(-50%, -50%) scale(1.08);
+  transform: translate(-50%, -50%) scale(1.1);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="gather"] .final-synthesis-instrument__motif {
   box-shadow:
-    0 0 0 0.22rem rgba(255, 227, 156, 0.06),
-    0 0 1rem rgba(212, 175, 55, 0.26);
+    0 0 0 0.26rem rgba(255, 227, 156, 0.08),
+    0 0 1.18rem rgba(212, 175, 55, 0.32);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__axis,
@@ -8137,16 +8153,16 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__quaternity {
-  border-color: rgba(255, 227, 156, 0.34);
+  border-color: rgba(255, 227, 156, 0.46);
   box-shadow:
-    inset 0 0 1.1rem rgba(83, 216, 232, 0.08),
-    0 0 1.75rem rgba(212, 175, 55, 0.24);
-  transform: translate(-50%, -50%) scale(1.08);
+    inset 0 0 1.2rem rgba(83, 216, 232, 0.12),
+    0 0 2rem rgba(212, 175, 55, 0.32);
+  transform: translate(-50%, -50%) scale(1.1);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__orbit {
-  border-color: rgba(255, 227, 156, 0.28);
-  box-shadow: 0 0 1.4rem rgba(83, 216, 232, 0.08);
+  border-color: rgba(255, 227, 156, 0.38);
+  box-shadow: 0 0 1.55rem rgba(83, 216, 232, 0.12);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="axis"] .final-synthesis-instrument__ego {
@@ -8166,12 +8182,12 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__path {
-  border-color: rgba(91, 214, 143, 0.42);
-  transform: translateY(-50%) rotate(12deg) scale(1.08);
+  border-color: rgba(91, 214, 143, 0.62);
+  transform: translateY(-50%) rotate(12deg) scale(1.1);
 }
 
 .chapter-experience[data-chapter-id="ch14"] .final-synthesis-instrument[data-active-panel="aeon"] .final-synthesis-instrument__mark {
-  box-shadow: 0 0 1.1rem rgba(91, 214, 143, 0.24);
+  box-shadow: 0 0 1.25rem rgba(91, 214, 143, 0.32);
 }
 
 @keyframes alchemical-tree-wheel {

--- a/src/features/viz-platform/viz-manifest-v3.js
+++ b/src/features/viz-platform/viz-manifest-v3.js
@@ -14,11 +14,11 @@ export const VIZ_MANIFEST = {
     'ch7': '/src/visualizations/chapters/ch7/ThreeProphecyViz.js',
     'ch8': '/src/visualizations/chapters/ch8/ThreeHistoricalViz.js',
     'ch9': '/src/visualizations/chapters/ch9/ThreeOuroborosViz.js',
-    'ch10': '/src/visualizations/chapters/ch10/ThreeGnosticViz.js',
-    'ch11': '/src/visualizations/chapters/ch11/ThreeUnusMundusViz.js',
-    'ch12': '/src/visualizations/chapters/ch12/ThreeSacredMarriageViz.js',
+    'ch10': '/src/visualizations/chapters/ch10/ThreeAlchemyViz.js',
+    'ch11': '/src/visualizations/chapters/ch11/ThreeTreeViz.js',
+    'ch12': '/src/visualizations/chapters/ch12/ThreeUnusViz.js',
     'ch13': '/src/visualizations/chapters/ch13/ThreeQuaternioViz.js',
-    'ch14': '/src/visualizations/chapters/ch14/ThreeAeonViz.js',
+    'ch14': '/src/visualizations/chapters/ch14/ThreeAeonFinalViz.js',
 };
 
 export const getVizPath = (chapterId) => VIZ_MANIFEST[chapterId] || null;

--- a/src/visualizations/chapters/ch10/ThreeAlchemyViz.js
+++ b/src/visualizations/chapters/ch10/ThreeAlchemyViz.js
@@ -491,9 +491,13 @@ export default class ThreeAlchemyViz extends BaseViz {
     _onMouseMove(e) { this.mouse.x = (e.clientX / window.innerWidth) * 2 - 1; this.mouse.y = -(e.clientY / window.innerHeight) * 2 + 1; }
     dispose() {
         window.removeEventListener('mousemove', this._onMouseMove);
-        if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloomPass?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(o => { o.geometry?.dispose(); if (o.material) (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => m.dispose()); });
-        this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
+        if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
+        this.bloomPass = null; this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
         super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch10/ThreeGnosticViz.js
+++ b/src/visualizations/chapters/ch10/ThreeGnosticViz.js
@@ -134,8 +134,12 @@ export default class ThreeGnosticViz extends BaseViz {
     }
     dispose() {
         removeEventListener('mousemove', this._onMM);
-        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloom?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(o => { o.geometry?.dispose(); if (o.material) [].concat(o.material).forEach(m => m.dispose()); });
-        this.composer = null; this.scene = null; this.renderer = null; super.dispose();
+        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.bloom = null; this.composer = null; this.scene = null; this.renderer = null; super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch11/ThreeTreeViz.js
+++ b/src/visualizations/chapters/ch11/ThreeTreeViz.js
@@ -770,9 +770,13 @@ export default class ThreeTreeViz extends BaseViz {
     }
     dispose() {
         window.removeEventListener('mousemove', this._onMouseMove);
-        if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloomPass?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(o => { o.geometry?.dispose(); if (o.material) (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => m.dispose()); });
-        this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
+        if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
+        this.bloomPass = null; this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
         super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch11/ThreeUnusMundusViz.js
+++ b/src/visualizations/chapters/ch11/ThreeUnusMundusViz.js
@@ -135,8 +135,12 @@ export default class ThreeUnusMundusViz extends BaseViz {
     }
     dispose() {
         removeEventListener('mousemove', this._onMM); removeEventListener('wheel', this._onWheel);
-        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloom?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(o => { o.geometry?.dispose(); if (o.material) [].concat(o.material).forEach(m => m.dispose()); });
-        this.composer = null; this.scene = null; this.renderer = null; super.dispose();
+        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.bloom = null; this.composer = null; this.scene = null; this.renderer = null; super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch12/ThreeSacredMarriageViz.js
+++ b/src/visualizations/chapters/ch12/ThreeSacredMarriageViz.js
@@ -138,8 +138,12 @@ export default class ThreeSacredMarriageViz extends BaseViz {
     }
     dispose() {
         removeEventListener('mousemove', this._onMM);
-        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloom?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(o => { o.geometry?.dispose(); if (o.material) [].concat(o.material).forEach(m => m.dispose()); });
-        this.composer = null; this.scene = null; this.renderer = null; super.dispose();
+        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.bloom = null; this.composer = null; this.scene = null; this.renderer = null; super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch12/ThreeUnusViz.js
+++ b/src/visualizations/chapters/ch12/ThreeUnusViz.js
@@ -683,7 +683,10 @@ export default class ThreeUnusViz extends BaseViz {
 
     dispose() {
         window.removeEventListener('mousemove', this._onMouseMove);
-        if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloomPass?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(obj => {
             if (obj.geometry) obj.geometry.dispose();
             if (obj.material) {
@@ -691,7 +694,8 @@ export default class ThreeUnusViz extends BaseViz {
                 else obj.material.dispose();
             }
         });
-        this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
+        if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
+        this.bloomPass = null; this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
         super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch13/ThreeQuaternioViz.js
+++ b/src/visualizations/chapters/ch13/ThreeQuaternioViz.js
@@ -350,8 +350,12 @@ export default class ThreeQuaternioViz extends BaseViz {
     }
     dispose() {
         removeEventListener('mousemove', this._onMM);
-        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloom?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(o => { o.geometry?.dispose(); if (o.material) [].concat(o.material).forEach(m => m.dispose()); });
-        this.composer = null; this.scene = null; this.renderer = null; super.dispose();
+        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.bloom = null; this.composer = null; this.scene = null; this.renderer = null; super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch14/ThreeAeonFinalViz.js
+++ b/src/visualizations/chapters/ch14/ThreeAeonFinalViz.js
@@ -18,7 +18,7 @@ import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
-import { createFinalSynthesisField } from './finalSynthesisPrimitives.js';
+import { createFinalSynthesisField, updateFinalSynthesisField } from './finalSynthesisPrimitives.js';
 
 /* ─── Palette ─── */
 const ANTHROPOS_GOLD = new THREE.Color('#ffd700');
@@ -567,41 +567,14 @@ export default class ThreeAeonFinalViz extends BaseViz {
         this.phoenixHalo.scale.setScalar(1 + phoenixPulse * 1.5);
 
         // ─── Final synthesis field — temenos, bridges, and living path ───
-        this.finalSynthesisGroup.rotation.y = -t * 0.009 * motionScale + this.aeonFocus * 0.1;
-        this.finalSynthesisGroup.rotation.z = Math.sin(t * 0.035 * motionScale) * 0.025;
-        this.temenosRings?.forEach((ring, index) => {
-            const drift = this.reducedMotion ? 0 : t * (0.01 + index * 0.003) * (index % 2 ? -1 : 1);
-            ring.rotation.copy(ring.userData.baseRotation);
-            ring.rotation.z += drift + this.axisFocus * 0.08;
-            ring.scale.copy(ring.userData.baseScale);
-            ring.scale.multiplyScalar(1 + this.gatherFocus * 0.025 + this.axisFocus * 0.035 + this.aeonFocus * 0.02);
-            ring.material.opacity = 0.02 + this.gatherFocus * 0.045 + this.axisFocus * 0.035 + this.aeonFocus * 0.04;
+        updateFinalSynthesisField(this, {
+            t,
+            motionScale,
+            reducedMotion: this.reducedMotion,
+            gatherFocus: this.gatherFocus,
+            axisFocus: this.axisFocus,
+            aeonFocus: this.aeonFocus,
         });
-        this.synthesisPetals?.forEach((petal, index) => {
-            petal.material.opacity = 0.015 + this.gatherFocus * 0.055 + this.axisFocus * 0.035 + (index % 2 ? this.aeonFocus * 0.014 : 0);
-        });
-        this.axisBridgeLines?.forEach((line, index) => {
-            line.material.opacity = 0.018 + this.axisFocus * 0.18 + this.gatherFocus * 0.018 + (index === 3 ? this.aeonFocus * 0.055 : 0);
-        });
-        if (this.individuationPath) {
-            this.individuationPath.material.opacity = 0.035 + this.aeonFocus * 0.32 + this.gatherFocus * 0.035;
-        }
-        this.pathSparks?.forEach((spark, index) => {
-            const phase = this.reducedMotion ? index / Math.max(1, this.pathSparks.length - 1) : (t * 0.035 + index / this.pathSparks.length) % 1;
-            const pointIndex = Math.min(this.individuationPathPoints.length - 1, Math.floor(phase * (this.individuationPathPoints.length - 1)));
-            const pathPoint = this.individuationPathPoints[pointIndex] || this.individuationPathPoints[0];
-            if (pathPoint) spark.position.copy(pathPoint);
-            spark.rotation.y = (this.reducedMotion ? 0 : t * 0.22) + index;
-            spark.material.opacity = 0.04 + this.aeonFocus * 0.36 + (phase > 0.72 ? this.gatherFocus * 0.08 : 0);
-            const sparkPulse = this.reducedMotion ? 0 : Math.sin(t * 0.38 + index) * 0.08;
-            spark.scale.setScalar(0.78 + this.aeonFocus * 0.82 + sparkPulse);
-        });
-        if (this.selfLens) {
-            this.selfLens.rotation.y = this.reducedMotion ? 0 : t * 0.18;
-            this.selfLens.rotation.x = this.reducedMotion ? 0 : t * 0.11;
-            this.selfLens.material.opacity = 0.1 + this.axisFocus * 0.28 + this.aeonFocus * 0.12;
-            this.selfLens.scale.setScalar(0.85 + this.axisFocus * 0.42 + this.aeonFocus * 0.18);
-        }
 
         // ─── Vessel subtle shimmer ───
         this.vessel.material.opacity = 0.02 + this.gatherFocus * 0.025 + this.aeonFocus * 0.025 + Math.sin(t * 0.1 * motionScale) * 0.01;
@@ -650,7 +623,10 @@ export default class ThreeAeonFinalViz extends BaseViz {
 
     dispose() {
         window.removeEventListener('mousemove', this._onMouseMove);
-        if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloomPass?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(obj => {
             if (obj.geometry) obj.geometry.dispose();
             if (obj.material) {
@@ -658,7 +634,8 @@ export default class ThreeAeonFinalViz extends BaseViz {
                 else obj.material.dispose();
             }
         });
-        this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
+        if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
+        this.bloomPass = null; this.composer = null; this.scene = null; this.camera = null; this.renderer = null;
         super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch14/ThreeAeonViz.js
+++ b/src/visualizations/chapters/ch14/ThreeAeonViz.js
@@ -156,8 +156,12 @@ export default class ThreeAeonViz extends BaseViz {
     }
     dispose() {
         removeEventListener('mousemove', this._onMM);
-        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.stop();
+        this.resizeObserver?.disconnect();
+        this.bloom?.dispose?.();
+        this.composer?.dispose?.();
         this.scene?.traverse(o => { o.geometry?.dispose(); if (o.material) [].concat(o.material).forEach(m => m.dispose()); });
-        this.composer = null; this.scene = null; this.renderer = null; super.dispose();
+        this.renderer?.dispose(); this.renderer?.forceContextLoss();
+        this.bloom = null; this.composer = null; this.scene = null; this.renderer = null; super.dispose();
     }
 }

--- a/src/visualizations/chapters/ch14/finalSynthesisPrimitives.js
+++ b/src/visualizations/chapters/ch14/finalSynthesisPrimitives.js
@@ -19,6 +19,7 @@ export function createFinalSynthesisField(viz, { gold, cyan, green, red, white }
     viz.finalSynthesisGroup = new THREE.Group();
     viz.temenosRings = [];
     viz.synthesisPetals = [];
+    viz.memoryBridgeLines = [];
     viz.axisBridgeLines = [];
     viz.pathSparks = [];
     viz.individuationPathPoints = [];
@@ -66,6 +67,35 @@ export function createFinalSynthesisField(viz, { gold, cyan, green, red, white }
         petal.userData.index = i;
         viz.finalSynthesisGroup.add(petal);
         viz.synthesisPetals.push(petal);
+    }
+
+    const memoryColors = [white, cyan, red, gold, green, cyan];
+    for (let i = 0; i < 6; i++) {
+        const phase = i / 6;
+        const angle = phase * Math.PI * 2 - Math.PI / 2;
+        const y = THREE.MathUtils.lerp(-5.8, 5.8, phase);
+        const outer = new THREE.Vector3(
+            Math.cos(angle) * 6.35,
+            y,
+            Math.sin(angle) * 3.9
+        );
+        const mid = new THREE.Vector3(
+            Math.cos(angle + 0.38) * 2.15,
+            y * 0.34,
+            Math.sin(angle + 0.38) * 1.5
+        );
+        const curve = new THREE.CatmullRomCurve3([
+            outer,
+            mid,
+            new THREE.Vector3(0, 0, 0),
+        ]);
+        const line = new THREE.Line(
+            pointsToGeometry(curve.getPoints(44)),
+            lineMaterial(memoryColors[i], 0.05)
+        );
+        line.userData.index = i;
+        viz.finalSynthesisGroup.add(line);
+        viz.memoryBridgeLines.push(line);
     }
 
     [
@@ -137,6 +167,56 @@ export function createFinalSynthesisField(viz, { gold, cyan, green, red, white }
     viz.finalSynthesisGroup.add(viz.selfLens);
 
     viz.mainGroup.add(viz.finalSynthesisGroup);
+}
+
+export function updateFinalSynthesisField(viz, {
+    t,
+    motionScale,
+    reducedMotion,
+    gatherFocus,
+    axisFocus,
+    aeonFocus,
+}) {
+    viz.finalSynthesisGroup.rotation.y = -t * 0.009 * motionScale + aeonFocus * 0.1;
+    viz.finalSynthesisGroup.rotation.z = Math.sin(t * 0.035 * motionScale) * 0.025;
+    viz.temenosRings?.forEach((ring, index) => {
+        const drift = reducedMotion ? 0 : t * (0.01 + index * 0.003) * (index % 2 ? -1 : 1);
+        ring.rotation.copy(ring.userData.baseRotation);
+        ring.rotation.z += drift + axisFocus * 0.08;
+        ring.scale.copy(ring.userData.baseScale);
+        ring.scale.multiplyScalar(1 + gatherFocus * 0.025 + axisFocus * 0.035 + aeonFocus * 0.02);
+        ring.material.opacity = 0.02 + gatherFocus * 0.045 + axisFocus * 0.035 + aeonFocus * 0.04;
+    });
+    viz.synthesisPetals?.forEach((petal, index) => {
+        petal.material.opacity = 0.025 + gatherFocus * 0.07 + axisFocus * 0.045 + (index % 2 ? aeonFocus * 0.018 : 0);
+    });
+    viz.memoryBridgeLines?.forEach((line, index) => {
+        const phaseDrift = reducedMotion ? 0 : Math.sin(t * 0.035 * motionScale + index) * 0.012;
+        line.rotation.z = phaseDrift;
+        line.material.opacity = 0.028 + gatherFocus * 0.15 + axisFocus * 0.045 + aeonFocus * 0.04;
+    });
+    viz.axisBridgeLines?.forEach((line, index) => {
+        line.material.opacity = 0.03 + axisFocus * 0.23 + gatherFocus * 0.024 + (index === 3 ? aeonFocus * 0.07 : 0);
+    });
+    if (viz.individuationPath) {
+        viz.individuationPath.material.opacity = 0.055 + aeonFocus * 0.4 + gatherFocus * 0.04;
+    }
+    viz.pathSparks?.forEach((spark, index) => {
+        const phase = reducedMotion ? index / Math.max(1, viz.pathSparks.length - 1) : (t * 0.035 + index / viz.pathSparks.length) % 1;
+        const pointIndex = Math.min(viz.individuationPathPoints.length - 1, Math.floor(phase * (viz.individuationPathPoints.length - 1)));
+        const pathPoint = viz.individuationPathPoints[pointIndex] || viz.individuationPathPoints[0];
+        if (pathPoint) spark.position.copy(pathPoint);
+        spark.rotation.y = (reducedMotion ? 0 : t * 0.22) + index;
+        spark.material.opacity = 0.04 + aeonFocus * 0.36 + (phase > 0.72 ? gatherFocus * 0.08 : 0);
+        const sparkPulse = reducedMotion ? 0 : Math.sin(t * 0.38 + index) * 0.08;
+        spark.scale.setScalar(0.78 + aeonFocus * 0.82 + sparkPulse);
+    });
+    if (viz.selfLens) {
+        viz.selfLens.rotation.y = reducedMotion ? 0 : t * 0.18;
+        viz.selfLens.rotation.x = reducedMotion ? 0 : t * 0.11;
+        viz.selfLens.material.opacity = 0.14 + gatherFocus * 0.05 + axisFocus * 0.34 + aeonFocus * 0.16;
+        viz.selfLens.scale.setScalar(0.85 + axisFocus * 0.42 + aeonFocus * 0.18);
+    }
 }
 
 function pointsToGeometry(points) {

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -9,7 +9,8 @@ import {
   getLegacyChapterRedirect,
 } from '../../src/app/data/aionData';
 import { APP_ROUTES, resolveRoute } from '../../src/app/routes';
-import { CHAPTER_SCENES } from '../../src/app/visualization/chapterScenes';
+import { CHAPTER_SCENES, SCENE_LOADERS } from '../../src/app/visualization/chapterScenes';
+import { VIZ_MANIFEST } from '../../src/features/viz-platform/viz-manifest-v3';
 
 describe('Aion framework data contract', () => {
   test('exposes all 14 canonical chapters in reading order', () => {
@@ -66,6 +67,20 @@ describe('Aion framework data contract', () => {
       });
       expect(CHAPTER_SCENES[chapter.id].sceneModule).toMatch(/Three.*Viz\.js$/);
       expect(CHAPTER_SCENES[chapter.id].fallbackSummary.length).toBeGreaterThan(20);
+    }
+  });
+
+  test('keeps legacy immersive manifest aligned with the React scene registry', () => {
+    const sceneModuleToManifestPath = (sceneModule: string) =>
+      sceneModule.replace('../visualizations', '/src/visualizations');
+
+    for (const chapter of getChapters()) {
+      const chapterId = chapter.id as keyof typeof VIZ_MANIFEST;
+      const sceneModule = CHAPTER_SCENES[chapter.id].sceneModule;
+      const manifestPath = sceneModuleToManifestPath(sceneModule);
+
+      expect(VIZ_MANIFEST[chapterId]).toBe(manifestPath);
+      expect(String(SCENE_LOADERS[chapter.id])).toContain(manifestPath);
     }
   });
 


### PR DESCRIPTION
## Summary
- Strengthen Chapter 14's final synthesis scene and static instrument with clearer motif-gathering, ego/Self axis, and living-path visual emphasis.
- Align the legacy immersive v3 manifest with the canonical React scene registry for late-book chapters.
- Harden Ch10-Ch14 WebGL teardown by stopping RAF/observer work, disposing postprocessing, disposing scene resources, then releasing renderer contexts.
- Add a contract test that keeps the legacy manifest and React scene loaders aligned with `CHAPTER_SCENES`.

## Validation
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" . --glob "!node_modules/**" --glob "!dist/**" --glob "!tests/reports/**" --glob "!test-results/**"`
- `git diff --check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test -- --runInBand`
- `npm run build`
- `AION_SMOKE_PORT=4184 node scripts/testing/app-shell-smoke.mjs --shard=scene-controls`
- `AION_SMOKE_PORT=4185 node scripts/testing/app-shell-smoke.mjs --shard=mobile`
- `AION_A11Y_PORT=4186 npm run test:a11y:app --silent`
- `npm run perf:cleanup` against a temporary Vite preview on port 3000
- `AION_VISUAL_QA_PORT=4187 npm run test:visual:control-tower --silent`
- `npm run build:pages && AION_PAGES_ARTIFACT_PORT=4188 npm run test:pages:artifact --silent`

## Visual QA
- Control Tower scored all 20 canonical routes at 100% with zero technical blockers.
- Reviewed fresh Chapter 14 desktop, mobile, and 320px narrow screenshots from `test-results/control-tower/latest/screenshots/`.

## Notes
- Existing Vite large-chunk warning for the shared Three bundle remains report-only in this batch.
