### PR TITLE
[codex] Refine About route mobile orientation

### DIFF
--- a/src/app/pages/AboutPage.css
+++ b/src/app/pages/AboutPage.css
@@ -42,6 +42,18 @@
   max-width: 35rem;
 }
 
+.about-hero__cue {
+  width: fit-content;
+  max-width: 28rem;
+  margin: 1.15rem 0 0;
+  border-left: 1px solid rgba(212, 175, 55, 0.46);
+  color: rgba(255, 227, 156, 0.82);
+  font: 700 0.76rem/1.45 var(--font-ui);
+  letter-spacing: 0.1em;
+  padding-left: 0.9rem;
+  text-transform: uppercase;
+}
+
 .about-mode-controls {
   display: flex;
   flex-wrap: wrap;
@@ -395,19 +407,35 @@
 @media (max-width: 720px) {
   .about-hero {
     min-height: auto;
-    padding-top: 9.6rem;
+    align-items: start;
+    gap: 1.35rem;
+    padding-top: 9.35rem;
   }
 
   .about-hero::before {
     inset: 9.2rem 1rem 1rem;
   }
 
+  .about-hero__copy {
+    order: -1;
+  }
+
   .about-hero__copy h1 {
-    font-size: 3.45rem;
+    max-width: 8.5ch;
+    font-size: 3.35rem;
+    line-height: 0.9;
   }
 
   .about-hero__copy .lede {
+    max-width: 28rem;
     font-size: 1rem;
+    line-height: 1.55;
+  }
+
+  .about-hero__cue {
+    margin-top: 0.9rem;
+    font-size: 0.68rem;
+    line-height: 1.35;
   }
 
   .about-mode-controls {
@@ -420,17 +448,17 @@
   }
 
   .about-orientation {
-    order: -1;
-    margin-top: 1.2rem;
+    order: 0;
+    margin-top: 0;
   }
 
   .about-north-star-field {
-    width: min(100%, 24rem);
+    width: min(100%, 22.75rem);
   }
 
   .about-orientation__detail {
     width: 100%;
-    margin-top: -2.6rem;
+    margin-top: -2.25rem;
   }
 
   .about-orientation__detail h2 {
@@ -456,11 +484,15 @@
 
 @media (max-width: 360px) {
   .about-hero__copy h1 {
-    font-size: 3rem;
+    font-size: 2.82rem;
   }
 
   .about-hero__copy .lede {
     font-size: 0.95rem;
+  }
+
+  .about-hero__cue {
+    font-size: 0.62rem;
   }
 
   .about-mode-controls__button {

--- a/src/app/pages/AboutPage.tsx
+++ b/src/app/pages/AboutPage.tsx
@@ -91,6 +91,7 @@ export default function AboutPage() {
           <p className="lede">
             A visual learning instrument for reading Aion through chapters, concepts, symbols, and disciplined verification.
           </p>
+          <p className="about-hero__cue">Pick a path in the field: study, map, symbolize, or verify.</p>
           <div className="about-hero__metrics" aria-label="Aion atlas data model">
             <span>
               <strong>{chapters.length}</strong>

--- a/src/app/pages/AboutPageInstrument.css
+++ b/src/app/pages/AboutPageInstrument.css
@@ -273,10 +273,23 @@
 @media (max-width: 720px) {
   .about-hero__metrics {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.45rem;
+    margin-top: 1rem;
+  }
+
+  .about-hero__metrics span {
+    min-width: 0;
+    padding: 0.58rem 0.52rem;
+    font-size: 0.58rem;
+    letter-spacing: 0.08em;
+  }
+
+  .about-hero__metrics strong {
+    font-size: 1.58rem;
   }
 
   .about-orientation__stage {
-    width: min(100%, 22.25rem);
+    width: min(100%, 21.75rem);
   }
 
   .about-orientation-node {
@@ -320,7 +333,17 @@
 
 @media (max-width: 360px) {
   .about-hero__metrics {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.38rem;
+  }
+
+  .about-hero__metrics span {
+    padding: 0.5rem 0.4rem;
+    font-size: 0.52rem;
+  }
+
+  .about-hero__metrics strong {
+    font-size: 1.38rem;
   }
 
   .about-orientation__stage {


### PR DESCRIPTION
## Summary

Refines the `/about` route as the atlas orientation gateway on mobile and narrow viewports.

## What changed

- Adds a concise hero cue that teaches the orientation field interaction: study, map, symbolize, verify.
- Restores copy-first mobile hierarchy so `Aion visual atlas`, the lede, and the cue appear before the diagram.
- Compresses About hero metrics on mobile/narrow so the orientation instrument peeks into the first viewport without horizontal overflow.

## Skill stack

- `redesign-existing-projects`: scoped upgrade to existing React/CSS surfaces.
- `frontend-design` + `high-end-visual-design`: stronger route identity and first-viewport hierarchy.
- `accessibility-review`: preserved named controls, focusable mode buttons, touch target coverage, and reduced-motion constraints.
- Playwright/Control Tower: desktop/mobile/narrow visual evidence.
- `github:yeet`: branch, commit, push, PR workflow.

## Routes changed

- `/about`

## Visual thesis

About should orient the learner before asking them to interpret the instrument. On mobile, the route now presents the title, short purpose, and one interaction cue first, then lets the orientation diagram enter the viewport as the next visual act.

## Browser evidence

- Local screenshot probe at `1440x1000`, `390x844`, and `320x568` confirmed title, lede, cue, and orientation stage appear in the first viewport for mobile/narrow.
- `npm run test:visual:control-tower` regenerated all canonical route screenshots and reported 0 technical blockers.

## Checks

- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test -- --runInBand`
- `npm run build`
- `npm run test:e2e:app:foundation`
- `npm run test:e2e:app:mobile`
- `npm run test:a11y:app`
- `npm run build:pages`
- `npm run test:pages:artifact`
- `npm run test:visual:control-tower`
- `npm run test:e2e:app`

## Residual debt

- Timeline and Symbols still deserve their own visual hierarchy pass; this PR intentionally keeps the batch focused on the About gateway.
- Large Three.js chunk warning remains existing performance debt, not introduced here.
