### PR TITLE
[codex] Refine Chapter 2 shadow instrument

### DIFF
--- a/src/app/components/PsycheArcInstrument.css
+++ b/src/app/components/PsycheArcInstrument.css
@@ -21,6 +21,15 @@
 .psyche-arc-instrument--ch2 {
   --psyche-accent: #c4a6f6;
   --psyche-secondary: #d4af37;
+  width: min(33.5rem, 100%);
+  background:
+    radial-gradient(circle at 16% 0%, rgba(212, 175, 55, 0.18), transparent 6.2rem),
+    radial-gradient(circle at 88% 18%, rgba(196, 166, 246, 0.2), transparent 6.8rem),
+    linear-gradient(180deg, rgba(244, 240, 232, 0.06), rgba(244, 240, 232, 0.018));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.09),
+    inset 0 0 0 1px rgba(196, 166, 246, 0.035),
+    0 1.9rem 4.4rem rgba(0, 0, 0, 0.26);
 }
 
 .psyche-arc-instrument--ch3 {

--- a/src/app/components/PsycheArcInstrument.tsx
+++ b/src/app/components/PsycheArcInstrument.tsx
@@ -121,13 +121,24 @@ function ShadowProjectionField({ activePanelId, label }: { activePanelId: string
       role="img"
       aria-label={label}
     >
+      <span className="shadow-projection-instrument__veil shadow-projection-instrument__veil--left" aria-hidden="true" />
+      <span className="shadow-projection-instrument__veil shadow-projection-instrument__veil--right" aria-hidden="true" />
       <span className="shadow-projection-instrument__vessel" aria-hidden="true" />
       <span className="shadow-projection-instrument__mirror" aria-hidden="true" />
+      <span className="shadow-projection-instrument__mirror-core" aria-hidden="true" />
+      <span className="shadow-projection-instrument__mirror-glint shadow-projection-instrument__mirror-glint--one" aria-hidden="true" />
+      <span className="shadow-projection-instrument__mirror-glint shadow-projection-instrument__mirror-glint--two" aria-hidden="true" />
+      <span className="shadow-projection-instrument__persona" aria-hidden="true" />
       <span className="shadow-projection-instrument__ego" aria-hidden="true" />
       <span className="shadow-projection-instrument__shadow" aria-hidden="true" />
+      <span className="shadow-projection-instrument__shadow-double" aria-hidden="true" />
       <span className="shadow-projection-instrument__arc shadow-projection-instrument__arc--projection" aria-hidden="true" />
       <span className="shadow-projection-instrument__arc shadow-projection-instrument__arc--return" aria-hidden="true" />
+      <span className="shadow-projection-instrument__target shadow-projection-instrument__target--one" aria-hidden="true" />
+      <span className="shadow-projection-instrument__target shadow-projection-instrument__target--two" aria-hidden="true" />
+      <span className="shadow-projection-instrument__target shadow-projection-instrument__target--three" aria-hidden="true" />
       <span className="shadow-projection-instrument__bridge" aria-hidden="true" />
+      <span className="shadow-projection-instrument__return-seed" aria-hidden="true" />
       <span className="shadow-projection-instrument__label shadow-projection-instrument__label--ego" aria-hidden="true">ego</span>
       <span className="shadow-projection-instrument__label shadow-projection-instrument__label--mirror" aria-hidden="true">mirror</span>
       <span className="shadow-projection-instrument__label shadow-projection-instrument__label--shadow" aria-hidden="true">shadow</span>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2935,18 +2935,20 @@ h3 {
 .shadow-projection-instrument {
   position: relative;
   width: min(30rem, 100%);
-  min-height: clamp(9.7rem, 23vh, 12.6rem);
+  min-height: clamp(10.25rem, 23vh, 13rem);
   overflow: hidden;
   margin-top: 0.95rem;
   border: 1px solid rgba(244, 240, 232, 0.1);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 30% 46%, rgba(232, 216, 192, 0.15), transparent 4.9rem),
-    radial-gradient(circle at 72% 43%, rgba(168, 112, 236, 0.17), transparent 5.9rem),
-    linear-gradient(90deg, rgba(3, 3, 7, 0.72), rgba(3, 3, 7, 0.42) 49%, rgba(22, 12, 33, 0.5) 51%, rgba(3, 3, 7, 0.36));
+    radial-gradient(circle at 30% 46%, rgba(232, 216, 192, 0.17), transparent 5.3rem),
+    radial-gradient(circle at 72% 43%, rgba(168, 112, 236, 0.21), transparent 6.2rem),
+    radial-gradient(ellipse at 50% 50%, rgba(196, 166, 246, 0.09), transparent 52%),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.78), rgba(3, 3, 7, 0.42) 47%, rgba(30, 17, 44, 0.58) 53%, rgba(3, 3, 7, 0.42));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.22);
+    0 1.4rem 4rem rgba(0, 0, 0, 0.24),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.032);
 }
 
 .shadow-projection-instrument::before,
@@ -2958,8 +2960,11 @@ h3 {
 
 .shadow-projection-instrument::before {
   inset: 0.72rem;
-  border: 1px solid rgba(212, 175, 55, 0.075);
+  border: 1px solid rgba(244, 240, 232, 0.075);
   border-radius: calc(var(--radius) - 2px);
+  box-shadow:
+    inset 0 0 2rem rgba(196, 166, 246, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.045);
 }
 
 .shadow-projection-instrument::after {
@@ -2971,14 +2976,45 @@ h3 {
 }
 
 .shadow-projection-instrument__vessel,
+.shadow-projection-instrument__veil,
 .shadow-projection-instrument__mirror,
+.shadow-projection-instrument__mirror-core,
+.shadow-projection-instrument__mirror-glint,
+.shadow-projection-instrument__persona,
 .shadow-projection-instrument__ego,
 .shadow-projection-instrument__shadow,
+.shadow-projection-instrument__shadow-double,
 .shadow-projection-instrument__arc,
+.shadow-projection-instrument__target,
 .shadow-projection-instrument__bridge,
+.shadow-projection-instrument__return-seed,
 .shadow-projection-instrument__label {
   position: absolute;
   pointer-events: none;
+}
+
+.shadow-projection-instrument__veil {
+  top: 11%;
+  bottom: 12%;
+  width: 33%;
+  border-radius: 50%;
+  opacity: 0.46;
+  filter: blur(0.12rem);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.shadow-projection-instrument__veil--left {
+  left: 12%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(212, 175, 55, 0.11), transparent 68%);
+  transform: rotate(-8deg);
+}
+
+.shadow-projection-instrument__veil--right {
+  right: 9%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(168, 112, 236, 0.16), transparent 70%);
+  transform: rotate(8deg);
 }
 
 .shadow-projection-instrument__vessel {
@@ -2992,9 +3028,9 @@ h3 {
 
 .shadow-projection-instrument__mirror {
   left: 50%;
-  top: 15%;
+  top: 11%;
   width: 1px;
-  height: 70%;
+  height: 78%;
   background: linear-gradient(180deg, transparent, rgba(196, 166, 246, 0.72), rgba(232, 216, 192, 0.42), transparent);
   box-shadow:
     0 0 1.2rem rgba(196, 166, 246, 0.34),
@@ -3005,6 +3041,61 @@ h3 {
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
     box-shadow 0.55s var(--motion-spring);
+}
+
+.shadow-projection-instrument__mirror-core {
+  left: 50%;
+  top: 50%;
+  width: 0.58rem;
+  height: 88%;
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, transparent, rgba(196, 166, 246, 0.12) 16%, rgba(244, 240, 232, 0.18) 49%, rgba(126, 74, 181, 0.14) 82%, transparent),
+    repeating-linear-gradient(180deg, transparent 0 0.94rem, rgba(244, 240, 232, 0.08) 0.97rem, transparent 1.04rem);
+  opacity: 0.58;
+  transform: translate(-50%, -50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.shadow-projection-instrument__mirror-glint {
+  left: 50%;
+  width: 2.2rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.62), transparent);
+  opacity: 0.36;
+  transform: translateX(-50%) rotate(-12deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.shadow-projection-instrument__mirror-glint--one {
+  top: 28%;
+}
+
+.shadow-projection-instrument__mirror-glint--two {
+  top: 66%;
+  transform: translateX(-50%) rotate(16deg);
+}
+
+.shadow-projection-instrument__persona {
+  left: 31%;
+  top: 51%;
+  width: 2.5rem;
+  height: 2rem;
+  border: 1px solid rgba(212, 175, 55, 0.18);
+  border-radius: 50%;
+  box-shadow:
+    inset 0 0 1.2rem rgba(212, 175, 55, 0.045),
+    0 0 1.4rem rgba(212, 175, 55, 0.08);
+  opacity: 0.72;
+  transform: translate(-50%, -50%) rotate(-12deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
 }
 
 .shadow-projection-instrument__ego {
@@ -3043,6 +3134,24 @@ h3 {
     box-shadow 0.55s var(--motion-spring);
 }
 
+.shadow-projection-instrument__shadow-double {
+  left: 70.5%;
+  top: 51.5%;
+  width: 3.25rem;
+  height: 3.95rem;
+  border: 1px solid rgba(196, 166, 246, 0.13);
+  border-radius: 54% 46% 52% 48%;
+  background:
+    radial-gradient(ellipse at 48% 42%, rgba(168, 112, 236, 0.14), transparent 54%),
+    radial-gradient(ellipse at 52% 58%, rgba(3, 3, 7, 0.26), transparent 68%);
+  opacity: 0.5;
+  transform: translate(-50%, -50%) rotate(8deg) scale(0.88);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
+}
+
 .shadow-projection-instrument__arc {
   width: 38%;
   height: 48%;
@@ -3060,6 +3169,35 @@ h3 {
   border-top: 1px solid rgba(214, 122, 255, 0.52);
   border-right: 1px solid rgba(214, 122, 255, 0.34);
   transform: rotate(-18deg);
+}
+
+.shadow-projection-instrument__target {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  background: rgba(214, 122, 255, 0.68);
+  box-shadow: 0 0 1.35rem rgba(214, 122, 255, 0.34);
+  opacity: 0.34;
+  transform: translate(-50%, -50%) scale(0.82);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.shadow-projection-instrument__target--one {
+  left: 84%;
+  top: 33%;
+}
+
+.shadow-projection-instrument__target--two {
+  left: 89%;
+  top: 52%;
+}
+
+.shadow-projection-instrument__target--three {
+  left: 80%;
+  top: 69%;
 }
 
 .shadow-projection-instrument__arc--return {
@@ -3084,13 +3222,30 @@ h3 {
     box-shadow 0.55s var(--motion-spring);
 }
 
+.shadow-projection-instrument__return-seed {
+  left: 47%;
+  top: 64%;
+  width: 0.52rem;
+  height: 0.52rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 227, 156, 0.9), rgba(224, 192, 255, 0.38) 54%, transparent);
+  box-shadow: 0 0 1.4rem rgba(255, 227, 156, 0.22);
+  opacity: 0.26;
+  transform: translate(-50%, -50%) scale(0.72);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
 .shadow-projection-instrument__label {
-  color: rgba(244, 240, 232, 0.58);
+  color: rgba(244, 240, 232, 0.62);
   font-family: var(--font-ui);
-  font-size: 0.58rem;
+  font-size: 0.55rem;
   font-weight: 700;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
+  text-shadow: 0 0 1rem rgba(3, 3, 7, 0.72);
 }
 
 .shadow-projection-instrument__label--ego {
@@ -3131,9 +3286,29 @@ h3 {
   transform: translateX(-50%) scaleY(1.08);
 }
 
+.shadow-projection-instrument[data-active-panel="mirror"] .shadow-projection-instrument__mirror-core {
+  opacity: 0.88;
+  transform: translate(-50%, -50%) scaleY(1.04);
+}
+
+.shadow-projection-instrument[data-active-panel="mirror"] .shadow-projection-instrument__mirror-glint {
+  opacity: 0.72;
+}
+
+.shadow-projection-instrument[data-active-panel="mirror"] .shadow-projection-instrument__persona {
+  border-color: rgba(255, 227, 156, 0.28);
+  opacity: 0.92;
+  transform: translate(-50%, -50%) rotate(-8deg) scale(1.05);
+}
+
 .shadow-projection-instrument[data-active-panel="mirror"] .shadow-projection-instrument__ego,
 .shadow-projection-instrument[data-active-panel="mirror"] .shadow-projection-instrument__shadow {
   transform: translate(-50%, -50%) scale(1.03);
+}
+
+.shadow-projection-instrument[data-active-panel="mirror"] .shadow-projection-instrument__shadow-double {
+  opacity: 0.74;
+  transform: translate(-50%, -50%) rotate(5deg) scale(0.98);
 }
 
 .shadow-projection-instrument[data-active-panel="projection"] .shadow-projection-instrument__arc--projection {
@@ -3143,11 +3318,30 @@ h3 {
   transform: rotate(-18deg) translateX(0.35rem);
 }
 
+.shadow-projection-instrument[data-active-panel="projection"] .shadow-projection-instrument__target {
+  opacity: 0.92;
+  transform: translate(-50%, -50%) scale(1.12);
+  box-shadow:
+    0 0 0 0.32rem rgba(214, 122, 255, 0.08),
+    0 0 1.65rem rgba(214, 122, 255, 0.54);
+}
+
 .shadow-projection-instrument[data-active-panel="projection"] .shadow-projection-instrument__shadow {
   box-shadow:
     0 0 3.2rem rgba(168, 112, 236, 0.38),
     inset 0 0 1.5rem rgba(5, 5, 8, 0.58);
   transform: translate(-48%, -52%) scale(1.08);
+}
+
+.shadow-projection-instrument[data-active-panel="projection"] .shadow-projection-instrument__shadow-double {
+  opacity: 0.82;
+  border-color: rgba(214, 122, 255, 0.22);
+  transform: translate(-46%, -52%) rotate(10deg) scale(1.06);
+}
+
+.shadow-projection-instrument[data-active-panel="projection"] .shadow-projection-instrument__veil--right {
+  opacity: 0.7;
+  transform: rotate(8deg) scale(1.06);
 }
 
 .shadow-projection-instrument[data-active-panel="integration"] .shadow-projection-instrument__arc--return {
@@ -3169,6 +3363,32 @@ h3 {
     0 0 2.4rem rgba(224, 192, 255, 0.36),
     inset 0 0 1.1rem rgba(5, 5, 8, 0.34);
   transform: translate(-50%, -50%) scale(1.02);
+}
+
+.shadow-projection-instrument[data-active-panel="integration"] .shadow-projection-instrument__ego {
+  transform: translate(-28%, -50%) scale(1.04);
+}
+
+.shadow-projection-instrument[data-active-panel="integration"] .shadow-projection-instrument__shadow {
+  transform: translate(-72%, -50%) scale(1.04);
+}
+
+.shadow-projection-instrument[data-active-panel="integration"] .shadow-projection-instrument__shadow-double {
+  opacity: 0.58;
+  transform: translate(-69%, -50%) rotate(2deg) scale(0.96);
+}
+
+.shadow-projection-instrument[data-active-panel="integration"] .shadow-projection-instrument__return-seed {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1.18);
+  box-shadow:
+    0 0 0 0.42rem rgba(255, 227, 156, 0.08),
+    0 0 1.8rem rgba(255, 227, 156, 0.42);
+}
+
+.shadow-projection-instrument[data-active-panel="integration"] .shadow-projection-instrument__persona {
+  opacity: 0.66;
+  transform: translate(-24%, -50%) rotate(-3deg) scale(0.92);
 }
 
 .syzygy-relation-instrument {

--- a/src/visualizations/chapters/ch2/ThreeShadowViz.js
+++ b/src/visualizations/chapters/ch2/ThreeShadowViz.js
@@ -155,7 +155,7 @@ export default class ThreeShadowViz extends BaseViz {
         S.add(this.egoLight);
 
         // Shadow dim light
-        this.shadowLight = new THREE.PointLight(0x200040, 0.6, 12);
+        this.shadowLight = new THREE.PointLight(0x2a0b55, 0.78, 13);
         this.shadowLight.position.set(3, -1, 3);
         S.add(this.shadowLight);
 
@@ -1010,20 +1010,20 @@ export default class ThreeShadowViz extends BaseViz {
         // Shadow scale distortion — squashes/stretches autonomously
         const distort = 1 + Math.sin(t * 0.6) * (0.24 + this.projectionFocus * 0.16);
         this.shadowCore.scale.set(distort, 1 / distort, distort);
-        this.shadowAura.material.opacity = 0.06 + Math.sin(t * 0.35) * 0.04 + this.projectionFocus * 0.08 + this.integrationFocus * 0.04;
+        this.shadowAura.material.opacity = 0.08 + Math.sin(t * 0.35) * 0.045 + this.projectionFocus * 0.1 + this.integrationFocus * 0.05;
 
         // Tendrils pulse
         for (const td of this.tendrils) {
-            td.line.material.opacity = 0.08 + Math.sin(t * 0.5 + td.ph) * 0.08 + this.projectionFocus * 0.08;
+            td.line.material.opacity = 0.1 + Math.sin(t * 0.5 + td.ph) * 0.08 + this.projectionFocus * 0.1;
         }
 
         /* ── Mirror shimmer ── */
-        this.mirrorPlane.material.opacity = 0.15 + Math.sin(t * 0.25) * 0.08 + this.mirrorFocus * 0.18 - this.integrationFocus * 0.08;
+        this.mirrorPlane.material.opacity = 0.2 + Math.sin(t * 0.25) * 0.07 + this.mirrorFocus * 0.2 - this.integrationFocus * 0.08;
         if (this.mirrorHalo) {
-            this.mirrorHalo.material.opacity = 0.05 + this.mirrorFocus * 0.11 - this.integrationFocus * 0.04;
+            this.mirrorHalo.material.opacity = 0.07 + this.mirrorFocus * 0.12 - this.integrationFocus * 0.04;
         }
         for (const md of this.mirrorDots) {
-            md.dot.material.opacity = 0.08 + Math.sin(t * 0.6 + md.ph) * 0.1 + this.mirrorFocus * 0.1;
+            md.dot.material.opacity = 0.11 + Math.sin(t * 0.6 + md.ph) * 0.09 + this.mirrorFocus * 0.1;
         }
 
         /* ── Projection arcs — periodic visibility ── */
@@ -1035,10 +1035,10 @@ export default class ThreeShadowViz extends BaseViz {
         const projFade = Math.max(cycleProjFade, this.projectionFocus * 0.95);
         for (const arc of this.projArcs) {
             const pulse = Math.sin(t * arc.speed + arc.ph) * 0.5 + 0.5;
-            arc.line.material.opacity = projFade * 0.25;
-            arc.dot.material.opacity = projFade * 0.5 * pulse;
-            arc.targetGlow.material.opacity = projFade * 0.1 * pulse;
-            arc.returnLine.material.opacity = Math.max(this.projectionFocus * 0.18, this.integrationFocus * 0.24) * (0.45 + pulse * 0.55);
+            arc.line.material.opacity = 0.018 + projFade * 0.28;
+            arc.dot.material.opacity = projFade * 0.56 * pulse;
+            arc.targetGlow.material.opacity = projFade * 0.14 * pulse;
+            arc.returnLine.material.opacity = Math.max(this.projectionFocus * 0.2, this.integrationFocus * 0.3) * (0.45 + pulse * 0.55);
         }
 
         /* ── Cocoon wraps ego during projection ── */


### PR DESCRIPTION
## Summary
- Refines Chapter 2's Shadow psyche-arc instrument into a richer split-mirror visual field.
- Adds visual-only mirror/persona/shadow/target/return layers while preserving panel IDs and accessible labels.
- Brightens the Chapter 2 WebGL mirror/shadow/projection emphasis without changing route/data contracts.

## Skill Stack
orchestration-autopilot, frontend-design, design-taste-frontend, high-end-visual-design, storytelling-web, accessibility-review, webapp-testing, github:yeet

## Routes Changed
/journey/chapter/ch2

## Visual Thesis
Chapter 2 should feel like an obsidian mirror chamber: warm ego-light on the left, larger violet shadow mass on the right, projection arcs cast outward, and a restrained return path that becomes readable during integration.

## Browser Evidence
- Control Tower: /journey/chapter/ch2 desktop 100%, no blockers.
- Mobile 390x844: 0px overflow, no blockers.
- Narrow 320x568: 0px overflow, no blockers.
- Screenshots regenerated under test-results/control-tower/latest/screenshots/.

## Checks
- git diff --check
- npm run lint --silent
- npx tsc --noEmit
- npm run validate:consistency --silent
- npm run ci:chapter-shell --silent
- npm run test:app --silent
- npm test -- --runInBand
- npm run build --silent
- AION_SMOKE_PORT=4191 node scripts/testing/app-shell-smoke.mjs --shard=chapter-routes
- AION_SMOKE_PORT=4192 node scripts/testing/app-shell-smoke.mjs --shard=scene-controls
- AION_SMOKE_PORT=4193 node scripts/testing/app-shell-smoke.mjs --shard=mobile
- AION_SMOKE_PORT=4194 node scripts/testing/app-shell-smoke.mjs --shard=foundation
- npm run test:a11y:app --silent
- AION_VISUAL_MIN_SCORE=0 npm run test:visual:control-tower --silent
- npm run build:pages --silent
- npm run test:pages:artifact --silent

## Residual Debt
- Chapter 2 can still receive a deeper full-scene choreography pass later.
- Source-anchor migration remains separate from this visual polish batch.
