### PR TITLE
[codex] Refine Chapter 3 syzygy instrument

### DIFF
--- a/src/app/components/PsycheArcInstrument.css
+++ b/src/app/components/PsycheArcInstrument.css
@@ -35,6 +35,16 @@
 .psyche-arc-instrument--ch3 {
   --psyche-accent: #ffd060;
   --psyche-secondary: #53d8e8;
+  width: min(33.5rem, 100%);
+  background:
+    radial-gradient(circle at 18% 4%, rgba(83, 216, 232, 0.18), transparent 6.4rem),
+    radial-gradient(circle at 84% 16%, rgba(255, 208, 96, 0.19), transparent 6.6rem),
+    radial-gradient(ellipse at 50% 50%, rgba(255, 224, 240, 0.08), transparent 64%),
+    linear-gradient(180deg, rgba(244, 240, 232, 0.06), rgba(244, 240, 232, 0.018));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.09),
+    inset 0 0 0 1px rgba(255, 224, 240, 0.035),
+    0 1.9rem 4.4rem rgba(0, 0, 0, 0.25);
 }
 
 .psyche-arc-instrument--ch4 {
@@ -92,7 +102,10 @@
   border-radius: calc(var(--radius) - 0.05rem);
 }
 
-.psyche-arc-instrument--ch3 .psyche-arc-instrument__field,
+.psyche-arc-instrument--ch3 .psyche-arc-instrument__field {
+  min-height: clamp(7.15rem, 13vh, 8.55rem);
+}
+
 .psyche-arc-instrument--ch4 .psyche-arc-instrument__field {
   min-height: clamp(4.45rem, 7vh, 5.1rem);
 }

--- a/src/app/components/PsycheArcInstrument.tsx
+++ b/src/app/components/PsycheArcInstrument.tsx
@@ -156,17 +156,32 @@ function SyzygyRelationField({ activePanelId, label }: { activePanelId: string; 
       role="img"
       aria-label={label}
     >
+      <span className="syzygy-relation-instrument__veil syzygy-relation-instrument__veil--lunar" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__veil syzygy-relation-instrument__veil--solar" aria-hidden="true" />
       <span className="syzygy-relation-instrument__axis" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__axis-pulse" aria-hidden="true" />
       <span className="syzygy-relation-instrument__orbit syzygy-relation-instrument__orbit--outer" aria-hidden="true" />
       <span className="syzygy-relation-instrument__orbit syzygy-relation-instrument__orbit--inner" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__orbit syzygy-relation-instrument__orbit--thread" aria-hidden="true" />
       <span className="syzygy-relation-instrument__field syzygy-relation-instrument__field--upper" aria-hidden="true" />
       <span className="syzygy-relation-instrument__field syzygy-relation-instrument__field--lower" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__braid syzygy-relation-instrument__braid--upper" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__braid syzygy-relation-instrument__braid--lower" aria-hidden="true" />
       <span className="syzygy-relation-instrument__projection syzygy-relation-instrument__projection--outward" aria-hidden="true" />
       <span className="syzygy-relation-instrument__projection syzygy-relation-instrument__projection--return" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__target syzygy-relation-instrument__target--anima" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__target syzygy-relation-instrument__target--animus" aria-hidden="true" />
       <span className="syzygy-relation-instrument__mandorla" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__mandorla-ring syzygy-relation-instrument__mandorla-ring--left" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__mandorla-ring syzygy-relation-instrument__mandorla-ring--right" aria-hidden="true" />
       <span className="syzygy-relation-instrument__conjunction-core" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__return-seed" aria-hidden="true" />
       <span className="syzygy-relation-instrument__pole syzygy-relation-instrument__pole--anima" aria-hidden="true" />
       <span className="syzygy-relation-instrument__pole syzygy-relation-instrument__pole--animus" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__quaternio syzygy-relation-instrument__quaternio--north" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__quaternio syzygy-relation-instrument__quaternio--east" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__quaternio syzygy-relation-instrument__quaternio--south" aria-hidden="true" />
+      <span className="syzygy-relation-instrument__quaternio syzygy-relation-instrument__quaternio--west" aria-hidden="true" />
       <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--anima" aria-hidden="true">anima</span>
       <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--animus" aria-hidden="true">animus</span>
       <span className="syzygy-relation-instrument__label syzygy-relation-instrument__label--orbit" aria-hidden="true">orbit</span>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -2357,17 +2357,20 @@ h3 {
   width: min(34rem, calc(100% - 2rem));
   justify-content: flex-end;
   margin-left: clamp(1rem, 4.8vw, 4rem);
-  padding-bottom: clamp(2.8rem, 7vh, 5.25rem);
+  padding-bottom: clamp(1.45rem, 3.8vh, 2.9rem);
 }
 
 .chapter-experience[data-chapter-id="ch3"] .chapter-stage__intro h1 {
   max-width: 9.8ch;
-  font-size: clamp(3.25rem, 6.4vw, 5.85rem);
+  margin-bottom: 0.62rem;
+  font-size: clamp(3.05rem, 5.95vw, 5.45rem);
 }
 
 .chapter-experience[data-chapter-id="ch3"] .chapter-stage__intro p:not(.eyebrow) {
   max-width: 34ch;
+  margin-bottom: 0.78rem;
   font-size: clamp(1rem, 1.35vw, 1.08rem);
+  line-height: 1.55;
 }
 
 .chapter-experience[data-chapter-id="ch3"] .scene-host__controls {
@@ -2377,15 +2380,24 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch3"] .chapter-stage__thesis-map {
   max-width: 28rem;
-  margin-top: 1.25rem;
+  gap: 0.4rem;
+  margin-top: 0.82rem;
+}
+
+.chapter-experience[data-chapter-id="ch3"] .chapter-stage__thesis-node {
+  min-height: 2.18rem;
+  padding-block: 0.24rem;
 }
 
 .chapter-experience[data-chapter-id="ch3"] .chapter-stage__reference-map {
   width: min(24rem, 100%);
+  gap: 0.4rem;
+  margin-top: 0.44rem;
 }
 
 .chapter-experience[data-chapter-id="ch3"] .chapter-stage__reference-node {
-  min-height: 3.9rem;
+  min-height: 3.35rem;
+  padding: 0.36rem 0.44rem;
   background:
     radial-gradient(circle at 50% 30%, rgba(255, 224, 240, 0.08), transparent 2.1rem),
     linear-gradient(180deg, rgba(7, 7, 18, 0.48), rgba(7, 7, 18, 0.18));
@@ -2393,7 +2405,7 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch3"] .chapter-stage__reference-label {
-  margin-top: 2.15rem;
+  margin-top: 1.48rem;
 }
 
 .chapter-experience[data-chapter-id="ch5"] .chapter-stage__intro {
@@ -3394,19 +3406,20 @@ h3 {
 .syzygy-relation-instrument {
   position: relative;
   width: min(30rem, 100%);
-  min-height: clamp(5.8rem, 9vh, 6.1rem);
+  min-height: clamp(7.15rem, 13vh, 8.55rem);
   overflow: hidden;
   margin-top: 0.95rem;
   border: 1px solid rgba(244, 240, 232, 0.105);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 29% 47%, rgba(83, 216, 232, 0.16), transparent 5.8rem),
-    radial-gradient(circle at 72% 47%, rgba(212, 175, 55, 0.17), transparent 5.8rem),
-    radial-gradient(circle at 50% 50%, rgba(255, 224, 240, 0.1), transparent 4.8rem),
-    linear-gradient(90deg, rgba(4, 5, 12, 0.72), rgba(8, 8, 21, 0.46) 48%, rgba(18, 14, 8, 0.38));
+    radial-gradient(circle at 24% 50%, rgba(83, 216, 232, 0.18), transparent 6rem),
+    radial-gradient(circle at 76% 50%, rgba(212, 175, 55, 0.2), transparent 6.1rem),
+    radial-gradient(ellipse at 50% 50%, rgba(255, 224, 240, 0.15), transparent 5.4rem),
+    linear-gradient(90deg, rgba(4, 5, 12, 0.78), rgba(8, 8, 21, 0.48) 45%, rgba(28, 20, 10, 0.48) 55%, rgba(4, 5, 12, 0.58));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.22);
+    inset 0 0 0 1px rgba(255, 224, 240, 0.032),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.24);
 }
 
 .syzygy-relation-instrument::before,
@@ -3418,28 +3431,62 @@ h3 {
 
 .syzygy-relation-instrument::before {
   inset: 0.72rem;
-  border: 1px solid rgba(212, 175, 55, 0.075);
+  border: 1px solid rgba(244, 240, 232, 0.075);
   border-radius: calc(var(--radius) - 2px);
+  box-shadow:
+    inset 0 0 1.8rem rgba(255, 224, 240, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .syzygy-relation-instrument::after {
   inset: 0;
   background:
-    linear-gradient(90deg, transparent 0 18%, rgba(184, 200, 232, 0.06) 34%, rgba(255, 224, 240, 0.12) 50%, rgba(255, 208, 96, 0.06) 66%, transparent 82%),
+    linear-gradient(90deg, transparent 0 15%, rgba(184, 200, 232, 0.07) 34%, rgba(255, 224, 240, 0.16) 50%, rgba(255, 208, 96, 0.08) 66%, transparent 85%),
     repeating-linear-gradient(180deg, transparent 0 2.42rem, rgba(244, 240, 232, 0.042) 2.46rem, transparent 2.52rem);
   mask-image: linear-gradient(90deg, transparent, #000 14%, #000 86%, transparent);
 }
 
+.syzygy-relation-instrument__veil,
 .syzygy-relation-instrument__axis,
+.syzygy-relation-instrument__axis-pulse,
 .syzygy-relation-instrument__orbit,
 .syzygy-relation-instrument__field,
+.syzygy-relation-instrument__braid,
 .syzygy-relation-instrument__projection,
+.syzygy-relation-instrument__target,
 .syzygy-relation-instrument__mandorla,
+.syzygy-relation-instrument__mandorla-ring,
 .syzygy-relation-instrument__conjunction-core,
+.syzygy-relation-instrument__return-seed,
 .syzygy-relation-instrument__pole,
+.syzygy-relation-instrument__quaternio,
 .syzygy-relation-instrument__label {
   position: absolute;
   pointer-events: none;
+}
+
+.syzygy-relation-instrument__veil {
+  top: 13%;
+  bottom: 14%;
+  width: 34%;
+  border-radius: 50%;
+  opacity: 0.44;
+  filter: blur(0.12rem);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.syzygy-relation-instrument__veil--lunar {
+  left: 11%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.15), transparent 72%);
+  transform: rotate(-9deg);
+}
+
+.syzygy-relation-instrument__veil--solar {
+  right: 10%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(255, 208, 96, 0.15), transparent 72%);
+  transform: rotate(9deg);
 }
 
 .syzygy-relation-instrument__axis {
@@ -3450,6 +3497,20 @@ h3 {
   background: linear-gradient(90deg, transparent, rgba(184, 200, 232, 0.38), rgba(255, 224, 240, 0.5), rgba(255, 208, 96, 0.34), transparent);
   box-shadow: 0 0 1.7rem rgba(255, 224, 240, 0.12);
   transform: translateY(-50%);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.syzygy-relation-instrument__axis-pulse {
+  left: 23%;
+  right: 23%;
+  top: 50%;
+  height: 0.4rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, rgba(184, 200, 232, 0.14), rgba(255, 224, 240, 0.28), rgba(255, 208, 96, 0.14), transparent);
+  opacity: 0.34;
+  transform: translateY(-50%) scaleX(0.82);
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -3481,6 +3542,15 @@ h3 {
   transform: translate(-50%, -50%) rotate(12deg);
 }
 
+.syzygy-relation-instrument__orbit--thread {
+  width: 62%;
+  height: 21%;
+  border-color: rgba(255, 224, 240, 0.12);
+  border-style: dashed;
+  opacity: 0.42;
+  transform: translate(-50%, -50%) rotate(1deg);
+}
+
 .syzygy-relation-instrument__field {
   left: 29%;
   width: 42%;
@@ -3502,6 +3572,28 @@ h3 {
   bottom: 24%;
   border-bottom: 1px solid rgba(212, 175, 55, 0.24);
   transform: rotate(7deg);
+}
+
+.syzygy-relation-instrument__braid {
+  left: 22%;
+  right: 22%;
+  height: 1px;
+  opacity: 0.32;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.syzygy-relation-instrument__braid--upper {
+  top: 39%;
+  background: linear-gradient(90deg, transparent, rgba(83, 216, 232, 0.34), rgba(255, 224, 240, 0.18), rgba(212, 175, 55, 0.16), transparent);
+  transform: rotate(-8deg);
+}
+
+.syzygy-relation-instrument__braid--lower {
+  bottom: 38%;
+  background: linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.24), rgba(255, 224, 240, 0.2), rgba(83, 216, 232, 0.2), transparent);
+  transform: rotate(8deg);
 }
 
 .syzygy-relation-instrument__projection {
@@ -3531,11 +3623,37 @@ h3 {
   transform: rotate(-19deg);
 }
 
+.syzygy-relation-instrument__target {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  opacity: 0.34;
+  transform: translate(-50%, -50%) scale(0.8);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
+.syzygy-relation-instrument__target--anima {
+  left: 17%;
+  top: 25%;
+  background: rgba(184, 200, 232, 0.74);
+  box-shadow: 0 0 1.1rem rgba(83, 216, 232, 0.26);
+}
+
+.syzygy-relation-instrument__target--animus {
+  right: 16%;
+  bottom: 24%;
+  background: rgba(255, 208, 96, 0.76);
+  box-shadow: 0 0 1.1rem rgba(212, 175, 55, 0.26);
+}
+
 .syzygy-relation-instrument__mandorla {
   left: 50%;
   top: 50%;
-  width: 6.6rem;
-  height: 4.9rem;
+  width: 7.4rem;
+  height: 5.45rem;
   border-radius: 50%;
   background:
     radial-gradient(circle at 41% 50%, rgba(184, 200, 232, 0.23), transparent 1.9rem),
@@ -3549,6 +3667,28 @@ h3 {
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
     box-shadow 0.55s var(--motion-spring);
+}
+
+.syzygy-relation-instrument__mandorla-ring {
+  left: 50%;
+  top: 50%;
+  width: 3.9rem;
+  height: 5.1rem;
+  border: 1px solid rgba(255, 224, 240, 0.14);
+  border-radius: 50%;
+  opacity: 0.18;
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
+}
+
+.syzygy-relation-instrument__mandorla-ring--left {
+  transform: translate(-64%, -50%) rotate(-4deg) scale(0.82);
+}
+
+.syzygy-relation-instrument__mandorla-ring--right {
+  transform: translate(-36%, -50%) rotate(4deg) scale(0.82);
 }
 
 .syzygy-relation-instrument__conjunction-core {
@@ -3569,10 +3709,26 @@ h3 {
     box-shadow 0.55s var(--motion-spring);
 }
 
+.syzygy-relation-instrument__return-seed {
+  left: 50%;
+  top: 64%;
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 232, 241, 0.92), rgba(255, 208, 96, 0.36) 56%, transparent);
+  box-shadow: 0 0 1.35rem rgba(255, 224, 240, 0.22);
+  opacity: 0.22;
+  transform: translate(-50%, -50%) scale(0.68);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring);
+}
+
 .syzygy-relation-instrument__pole {
   top: 50%;
-  width: 1rem;
-  height: 1rem;
+  width: 1.18rem;
+  height: 1.18rem;
   border-radius: 50%;
   transform: translate(-50%, -50%);
   transition:
@@ -3597,12 +3753,47 @@ h3 {
     0 0 4rem rgba(212, 175, 55, 0.2);
 }
 
+.syzygy-relation-instrument__quaternio {
+  width: 0.32rem;
+  height: 0.32rem;
+  border: 1px solid rgba(229, 214, 255, 0.28);
+  border-radius: 50%;
+  background: rgba(229, 214, 255, 0.12);
+  opacity: 0.2;
+  transform: translate(-50%, -50%) scale(0.72);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring),
+    border-color 0.55s var(--motion-spring);
+}
+
+.syzygy-relation-instrument__quaternio--north {
+  left: 50%;
+  top: 19%;
+}
+
+.syzygy-relation-instrument__quaternio--east {
+  left: 78%;
+  top: 50%;
+}
+
+.syzygy-relation-instrument__quaternio--south {
+  left: 50%;
+  top: 81%;
+}
+
+.syzygy-relation-instrument__quaternio--west {
+  left: 22%;
+  top: 50%;
+}
+
 .syzygy-relation-instrument__label {
   color: rgba(244, 240, 232, 0.58);
   font-family: var(--font-ui);
-  font-size: 0.58rem;
+  font-size: 0.55rem;
   font-weight: 700;
   letter-spacing: 0;
+  text-shadow: 0 0 1rem rgba(3, 3, 7, 0.72);
 }
 
 .syzygy-relation-instrument__label--anima {
@@ -3634,8 +3825,30 @@ h3 {
   transform: translateY(-50%) scaleX(1.04);
 }
 
+.syzygy-relation-instrument[data-active-panel="pair"] .syzygy-relation-instrument__axis-pulse {
+  opacity: 0.74;
+  transform: translateY(-50%) scaleX(1.02);
+}
+
+.syzygy-relation-instrument[data-active-panel="pair"] .syzygy-relation-instrument__veil {
+  opacity: 0.72;
+}
+
+.syzygy-relation-instrument[data-active-panel="pair"] .syzygy-relation-instrument__veil--lunar {
+  transform: rotate(-12deg) translateX(-0.22rem);
+}
+
+.syzygy-relation-instrument[data-active-panel="pair"] .syzygy-relation-instrument__veil--solar {
+  transform: rotate(12deg) translateX(0.22rem);
+}
+
 .syzygy-relation-instrument[data-active-panel="pair"] .syzygy-relation-instrument__pole {
   transform: translate(-50%, -50%) scale(1.08);
+}
+
+.syzygy-relation-instrument[data-active-panel="pair"] .syzygy-relation-instrument__label--anima,
+.syzygy-relation-instrument[data-active-panel="pair"] .syzygy-relation-instrument__label--animus {
+  color: rgba(244, 240, 232, 0.86);
 }
 
 .syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__orbit--outer {
@@ -3650,8 +3863,26 @@ h3 {
   transform: translate(-50%, -50%) rotate(19deg) scale(1.04);
 }
 
+.syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__orbit--thread {
+  border-color: rgba(255, 224, 240, 0.3);
+  opacity: 0.86;
+  transform: translate(-50%, -50%) rotate(2deg) scaleX(1.08);
+}
+
 .syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__field {
   opacity: 0.86;
+}
+
+.syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__braid {
+  opacity: 0.74;
+}
+
+.syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__braid--upper {
+  transform: rotate(-10deg) translateY(-0.12rem);
+}
+
+.syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__braid--lower {
+  transform: rotate(10deg) translateY(0.12rem);
 }
 
 .syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__projection--outward {
@@ -3666,6 +3897,22 @@ h3 {
   border-left-color: rgba(212, 175, 55, 0.34);
   opacity: 0.88;
   transform: rotate(-19deg) translateX(-0.28rem);
+}
+
+.syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__target {
+  opacity: 0.82;
+  transform: translate(-50%, -50%) scale(1.2);
+  box-shadow: 0 0 1.7rem rgba(255, 224, 240, 0.28);
+}
+
+.syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__quaternio {
+  opacity: 0.5;
+  transform: translate(-50%, -50%) scale(1);
+  border-color: rgba(229, 214, 255, 0.45);
+}
+
+.syzygy-relation-instrument[data-active-panel="orbit"] .syzygy-relation-instrument__label--orbit {
+  color: rgba(229, 214, 255, 0.9);
 }
 
 .syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__pole--anima {
@@ -3684,12 +3931,43 @@ h3 {
     0 0 2.8rem rgba(255, 224, 240, 0.16);
 }
 
+.syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__mandorla-ring {
+  opacity: 0.82;
+  border-color: rgba(255, 224, 240, 0.36);
+}
+
+.syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__mandorla-ring--left {
+  transform: translate(-64%, -50%) rotate(-7deg) scale(1.06);
+}
+
+.syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__mandorla-ring--right {
+  transform: translate(-36%, -50%) rotate(7deg) scale(1.06);
+}
+
 .syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__conjunction-core {
   opacity: 1;
   transform: translate(-50%, -50%) scale(1.55);
   box-shadow:
     0 0 2.1rem rgba(255, 224, 240, 0.86),
     0 0 4rem rgba(212, 175, 55, 0.24);
+}
+
+.syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__return-seed {
+  opacity: 0.9;
+  transform: translate(-50%, -50%) scale(1.08);
+  box-shadow:
+    0 0 1.6rem rgba(255, 224, 240, 0.42),
+    0 0 3.2rem rgba(212, 175, 55, 0.18);
+}
+
+.syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__axis,
+.syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__axis-pulse {
+  opacity: 0.5;
+  transform: translateY(-50%) scaleX(0.55);
+}
+
+.syzygy-relation-instrument[data-active-panel="union"] .syzygy-relation-instrument__label--conjunction {
+  color: rgba(255, 224, 240, 0.95);
 }
 
 @keyframes syzygy-orbit-breathe {
@@ -10185,13 +10463,20 @@ h3 {
 	  .shadow-projection-instrument__ego,
 	  .shadow-projection-instrument__mirror,
 	  .shadow-projection-instrument__shadow,
+	  .syzygy-relation-instrument__veil,
 	  .syzygy-relation-instrument__axis,
+	  .syzygy-relation-instrument__axis-pulse,
 	  .syzygy-relation-instrument__orbit,
 	  .syzygy-relation-instrument__field,
+	  .syzygy-relation-instrument__braid,
 	  .syzygy-relation-instrument__projection,
+	  .syzygy-relation-instrument__target,
 	  .syzygy-relation-instrument__mandorla,
+	  .syzygy-relation-instrument__mandorla-ring,
 	  .syzygy-relation-instrument__conjunction-core,
+	  .syzygy-relation-instrument__return-seed,
 	  .syzygy-relation-instrument__pole,
+	  .syzygy-relation-instrument__quaternio,
 	  .self-mandala-instrument__ring,
 	  .self-mandala-instrument__axis,
 	  .self-mandala-instrument__point,
@@ -10306,6 +10591,7 @@ h3 {
   }
 
   .syzygy-relation-instrument__orbit--outer,
+  .syzygy-relation-instrument__axis-pulse,
   .self-mandala-instrument__ring--outer,
   .self-mandala-instrument__center,
   .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__ring--outer,

--- a/src/visualizations/chapters/ch3/ThreeSyzygyViz.js
+++ b/src/visualizations/chapters/ch3/ThreeSyzygyViz.js
@@ -141,15 +141,15 @@ export default class ThreeSyzygyViz extends BaseViz {
         this._buildAnnotations();
 
         /* ── Lighting ── */
-        S.add(new THREE.AmbientLight(0x080815, 0.15));
+        S.add(new THREE.AmbientLight(0x080815, 0.2));
 
-        this.animaLight = new THREE.PointLight(0x8090c0, 0.8, 18);
+        this.animaLight = new THREE.PointLight(0x8090c0, 0.92, 19);
         S.add(this.animaLight);
 
-        this.animusLight = new THREE.PointLight(0xd0a030, 1.0, 18);
+        this.animusLight = new THREE.PointLight(0xd0a030, 1.08, 19);
         S.add(this.animusLight);
 
-        this.conjLight = new THREE.PointLight(0xffe0f0, 0, 20);
+        this.conjLight = new THREE.PointLight(0xffe0f0, 0, 22);
         S.add(this.conjLight);
 
         // Subtle rim
@@ -161,7 +161,7 @@ export default class ThreeSyzygyViz extends BaseViz {
         this.composer = new EffectComposer(R);
         this.composer.addPass(new RenderPass(S, cam));
         this.bloom = new UnrealBloomPass(
-            new THREE.Vector2(this.width, this.height), 1.5, 0.4, 0.2
+            new THREE.Vector2(this.width, this.height), 1.42, 0.38, 0.22
         );
         this.composer.addPass(this.bloom);
 
@@ -311,7 +311,7 @@ export default class ThreeSyzygyViz extends BaseViz {
         }
         this.animaTrailGeo = new THREE.BufferGeometry().setFromPoints(this.animaTrailPts);
         this.animaTrail = new THREE.Line(this.animaTrailGeo, new THREE.LineBasicMaterial({
-            color: ANIMA_TRAIL, transparent: true, opacity: 0.18,
+            color: ANIMA_TRAIL, transparent: true, opacity: 0.22,
             blending: THREE.AdditiveBlending
         }));
         this.scene.add(this.animaTrail);
@@ -323,7 +323,7 @@ export default class ThreeSyzygyViz extends BaseViz {
         }
         this.animusTrailGeo = new THREE.BufferGeometry().setFromPoints(this.animusTrailPts);
         this.animusTrail = new THREE.Line(this.animusTrailGeo, new THREE.LineBasicMaterial({
-            color: ANIMUS_TRAIL, transparent: true, opacity: 0.18,
+            color: ANIMUS_TRAIL, transparent: true, opacity: 0.22,
             blending: THREE.AdditiveBlending
         }));
         this.scene.add(this.animusTrail);
@@ -341,7 +341,7 @@ export default class ThreeSyzygyViz extends BaseViz {
             for (let j = 0; j <= 50; j++) pts.push(new THREE.Vector3());
             const geo = new THREE.BufferGeometry().setFromPoints(pts);
             const line = new THREE.Line(geo, new THREE.LineBasicMaterial({
-                color: FIELD_CLR, transparent: true, opacity: 0.08,
+                color: FIELD_CLR, transparent: true, opacity: 0.1,
                 blending: THREE.AdditiveBlending
             }));
             this.scene.add(line);
@@ -401,7 +401,7 @@ export default class ThreeSyzygyViz extends BaseViz {
     _buildProjectionArcs() {
         this.projArcs = [];
         const arcMat = (clr) => new THREE.LineBasicMaterial({
-            color: clr, transparent: true, opacity: 0.06,
+            color: clr, transparent: true, opacity: 0.075,
             blending: THREE.AdditiveBlending
         });
 
@@ -428,7 +428,7 @@ export default class ThreeSyzygyViz extends BaseViz {
             const dot = new THREE.Mesh(
                 new THREE.SphereGeometry(0.06, 6, 6),
                 new THREE.MeshBasicMaterial({
-                    color: t.clr, transparent: true, opacity: 0.15,
+                    color: t.clr, transparent: true, opacity: 0.18,
                     blending: THREE.AdditiveBlending
                 })
             );
@@ -1217,12 +1217,12 @@ export default class ThreeSyzygyViz extends BaseViz {
                 pts[j * 3 + 2] = mz + Math.sin(fl.offset + t * 0.15) * bow;
             }
             fl.geo.attributes.position.needsUpdate = true;
-            fl.line.material.opacity = 0.08 + Math.sin(t * 0.3 + fl.offset) * 0.06 + this.orbitFocus * 0.12 + this.unionFocus * 0.08;
+            fl.line.material.opacity = 0.1 + Math.sin(t * 0.3 + fl.offset) * 0.055 + this.orbitFocus * 0.15 + this.unionFocus * 0.1;
         }
 
         /* ── Conjunction — when they're close ── */
         const dist = a.distanceTo(b);
-        const isConjunction = dist < 3 || this.unionFocus > 0.65;
+        const isConjunction = (panelId !== 'pair' && dist < 2.45) || this.unionFocus > 0.6;
 
         if (isConjunction && this.conjTimer <= 0) {
             this.conjTimer = 4;
@@ -1244,9 +1244,9 @@ export default class ThreeSyzygyViz extends BaseViz {
 
         if (this.conjTimer > 0) {
             this.conjTimer -= dt;
-            const fade = Math.max(0, this.conjTimer / 4, this.unionFocus * 0.85);
-            this.conjPts.material.opacity = fade * 0.6;
-            this.conjLight.intensity = fade * 3;
+            const fade = Math.max(0, this.conjTimer / 4, this.unionFocus * 0.9);
+            this.conjPts.material.opacity = fade * 0.55;
+            this.conjLight.intensity = fade * 3.2;
             const mid = new THREE.Vector3().lerpVectors(a, b, 0.5);
             this.conjLight.position.copy(mid);
 
@@ -1291,22 +1291,22 @@ export default class ThreeSyzygyViz extends BaseViz {
                     pts[j * 3 + 2] = inv * inv * src.z + 2 * inv * frac * cZ + frac * frac * arc.end.z;
                 }
                 arc.geo.attributes.position.needsUpdate = true;
-                arc.line.material.opacity = 0.04 + Math.sin(t * 0.2) * 0.03 + this.orbitFocus * 0.08;
-                arc.dot.material.opacity = 0.1 + Math.sin(t * 0.5) * 0.08 + this.orbitFocus * 0.18;
+                arc.line.material.opacity = 0.05 + Math.sin(t * 0.2) * 0.025 + this.orbitFocus * 0.12;
+                arc.dot.material.opacity = 0.12 + Math.sin(t * 0.5) * 0.07 + this.orbitFocus * 0.22;
             }
         }
 
         /* ── Mandorla — position rings at conjunction ── */
         if (this.mandorlaRing1) {
             const mid = new THREE.Vector3().lerpVectors(a, b, 0.5);
-            const conjFade = Math.max(this.conjTimer > 0 ? Math.min(this.conjTimer / 2, 1) * 0.25 : 0, this.unionFocus * 0.34);
+            const conjFade = Math.max(this.conjTimer > 0 ? Math.min(this.conjTimer / 2, 1) * 0.22 : 0, this.unionFocus * 0.44);
             // Position rings slightly offset to form vesica piscis
             this.mandorlaRing1.position.copy(mid).add(new THREE.Vector3(-0.5, 0, 0));
             this.mandorlaRing2.position.copy(mid).add(new THREE.Vector3(0.5, 0, 0));
             this.mandorlaRing1.material.opacity = conjFade;
             this.mandorlaRing2.material.opacity = conjFade;
             this.mandorlaGlow.position.copy(mid);
-            this.mandorlaGlow.material.opacity = conjFade * 0.5;
+            this.mandorlaGlow.material.opacity = conjFade * 0.56;
         }
 
         /* ── Atmosphere ── */
@@ -1327,8 +1327,8 @@ export default class ThreeSyzygyViz extends BaseViz {
 
         /* ── Bloom ── */
         if (this.bloom) {
-            const conjBoost = Math.max(this.conjTimer > 0 ? (this.conjTimer / 4) * 0.8 : 0, this.unionFocus * 0.85);
-            this.bloom.strength = 1.3 + Math.sin(t * 0.04) * 0.15 + conjBoost + this.orbitFocus * 0.18;
+            const conjBoost = Math.max(this.conjTimer > 0 ? (this.conjTimer / 4) * 0.72 : 0, this.unionFocus * 0.82);
+            this.bloom.strength = 1.2 + Math.sin(t * 0.04) * 0.12 + conjBoost + this.orbitFocus * 0.16;
         }
     }
 


### PR DESCRIPTION
## Summary
- enriches Chapter 3 as a visual relation-lab: living poles, orbit state, and brief mandorla/conjunction without changing scholarly copy
- adds stateful Ch3 symbolic glyphs to the shared psyche instrument while preserving the pair/orbit/union panel contract
- tunes the Three.js syzygy scene for clearer poles, projection arcs, and less premature conjunction emphasis
- compacts the first viewport so scene controls stay stable in the scene-control smoke path

## Verification
- git diff --check
- rg -n "^(<<<<<<<|=======|>>>>>>>)" .
- npm run test:app --silent
- npm run validate:consistency --silent
- npm run ci:chapter-shell --silent
- npx tsc --noEmit
- npm run test:e2e:app:scene-controls --silent
- npm run test:e2e:app:mobile --silent
- npm run lint --silent
- npm test --silent
- npm run test:a11y:app --silent
- npm run build --silent
- local Browser/Playwright screenshot QA for /journey/chapter/ch3 at 1440x1000, 390x844, and 320x568
- npm run build:pages --silent && npm run test:pages:artifact --silent

## Notes
- No source text/content claims changed.
- No new long-lived listeners or new particle systems; this is a constrained visual and layout pass.
- The earlier GitHub Actions failure I inspected was an old scene-controls failure for Chapter 11 lapis emphasis; latest main scene-controls is green, and this branch passes the same shard locally.