### PR TITLE
[codex] Refine Chapter 4 Self mandala

### DIFF
--- a/src/app/components/PsycheArcInstrument.css
+++ b/src/app/components/PsycheArcInstrument.css
@@ -50,6 +50,16 @@
 .psyche-arc-instrument--ch4 {
   --psyche-accent: #d4af37;
   --psyche-secondary: #53d8e8;
+  width: min(33.5rem, 100%);
+  background:
+    radial-gradient(circle at 18% 6%, rgba(83, 216, 232, 0.16), transparent 6.6rem),
+    radial-gradient(circle at 84% 12%, rgba(212, 175, 55, 0.19), transparent 6.8rem),
+    conic-gradient(from 45deg at 50% 50%, rgba(83, 216, 232, 0.08), rgba(212, 175, 55, 0.105), rgba(204, 109, 134, 0.075), rgba(132, 201, 155, 0.075), rgba(83, 216, 232, 0.08)),
+    linear-gradient(180deg, rgba(244, 240, 232, 0.058), rgba(244, 240, 232, 0.018));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.09),
+    inset 0 0 0 1px rgba(255, 227, 156, 0.035),
+    0 1.9rem 4.4rem rgba(0, 0, 0, 0.25);
 }
 
 .psyche-arc-instrument__header,
@@ -107,7 +117,7 @@
 }
 
 .psyche-arc-instrument--ch4 .psyche-arc-instrument__field {
-  min-height: clamp(4.45rem, 7vh, 5.1rem);
+  min-height: clamp(7.15rem, 13vh, 8.55rem);
 }
 
 .psyche-arc-instrument__rail {

--- a/src/app/components/PsycheArcInstrument.tsx
+++ b/src/app/components/PsycheArcInstrument.tsx
@@ -198,14 +198,24 @@ function SelfMandalaField({ activePanelId, label }: { activePanelId: string; lab
       role="img"
       aria-label={label}
     >
+      <span className="self-mandala-instrument__field-glow self-mandala-instrument__field-glow--gold" aria-hidden="true" />
+      <span className="self-mandala-instrument__field-glow self-mandala-instrument__field-glow--cyan" aria-hidden="true" />
       <span className="self-mandala-instrument__ring self-mandala-instrument__ring--outer" aria-hidden="true" />
       <span className="self-mandala-instrument__ring self-mandala-instrument__ring--middle" aria-hidden="true" />
       <span className="self-mandala-instrument__ring self-mandala-instrument__ring--inner" aria-hidden="true" />
+      <span className="self-mandala-instrument__quaternity-square" aria-hidden="true" />
+      <span className="self-mandala-instrument__inner-diamond" aria-hidden="true" />
       <span className="self-mandala-instrument__axis self-mandala-instrument__axis--vertical" aria-hidden="true" />
       <span className="self-mandala-instrument__axis self-mandala-instrument__axis--horizontal" aria-hidden="true" />
+      <span className="self-mandala-instrument__thread self-mandala-instrument__thread--ascending" aria-hidden="true" />
+      <span className="self-mandala-instrument__thread self-mandala-instrument__thread--descending" aria-hidden="true" />
+      {quaternityDirections.map((direction) => (
+        <span key={`petal-${direction}`} className={`self-mandala-instrument__petal self-mandala-instrument__petal--${direction}`} aria-hidden="true" />
+      ))}
       {quaternityDirections.map((direction) => (
         <span key={direction} className={`self-mandala-instrument__point self-mandala-instrument__point--${direction}`} aria-hidden="true" />
       ))}
+      <span className="self-mandala-instrument__seed-halo" aria-hidden="true" />
       <span className="self-mandala-instrument__center" aria-hidden="true" />
       <span className="self-mandala-instrument__label self-mandala-instrument__label--center" aria-hidden="true">center</span>
       <span className="self-mandala-instrument__label self-mandala-instrument__label--fourfold" aria-hidden="true">fourfold</span>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -3985,20 +3985,23 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument {
   position: relative;
-  width: min(29rem, 100%);
-  min-height: clamp(5.8rem, 9vh, 6.15rem);
+  width: min(33.5rem, 100%);
+  min-height: clamp(7.15rem, 13vh, 8.55rem);
   overflow: hidden;
   margin-top: 0.95rem;
   border: 1px solid rgba(244, 240, 232, 0.11);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 50% 50%, rgba(244, 240, 232, 0.13), transparent 1.25rem),
-    radial-gradient(circle at 50% 50%, rgba(212, 175, 55, 0.12), transparent 4.8rem),
-    conic-gradient(from 45deg, rgba(83, 216, 232, 0.12), rgba(212, 175, 55, 0.13), rgba(204, 109, 134, 0.12), rgba(132, 201, 155, 0.12), rgba(83, 216, 232, 0.12)),
-    linear-gradient(180deg, rgba(4, 5, 10, 0.74), rgba(8, 8, 16, 0.46));
+    radial-gradient(circle at 50% 50%, rgba(244, 240, 232, 0.18), transparent 1.55rem),
+    radial-gradient(circle at 50% 50%, rgba(212, 175, 55, 0.16), transparent 5.7rem),
+    radial-gradient(circle at 27% 50%, rgba(83, 216, 232, 0.13), transparent 5.8rem),
+    radial-gradient(circle at 73% 50%, rgba(255, 227, 156, 0.13), transparent 6rem),
+    conic-gradient(from 45deg, rgba(83, 216, 232, 0.12), rgba(212, 175, 55, 0.15), rgba(204, 109, 134, 0.115), rgba(132, 201, 155, 0.105), rgba(83, 216, 232, 0.12)),
+    linear-gradient(180deg, rgba(4, 5, 10, 0.78), rgba(8, 8, 16, 0.5));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.2);
+    inset 0 0 0 1px rgba(255, 227, 156, 0.028),
+    0 1.4rem 4rem rgba(0, 0, 0, 0.24);
 }
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument::before,
@@ -4010,27 +4013,55 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument::before {
   inset: 0.66rem;
-  border: 1px solid rgba(212, 175, 55, 0.08);
+  border: 1px solid rgba(244, 240, 232, 0.082);
   border-radius: calc(var(--radius) - 2px);
+  box-shadow:
+    inset 0 0 2.2rem rgba(255, 227, 156, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.035);
 }
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument::after {
   inset: 0;
   background:
-    linear-gradient(90deg, transparent 0 23%, rgba(244, 240, 232, 0.08) 49%, transparent 77%),
-    linear-gradient(0deg, transparent 0 24%, rgba(244, 240, 232, 0.07) 50%, transparent 76%),
-    repeating-radial-gradient(circle at 50% 50%, transparent 0 1.15rem, rgba(244, 240, 232, 0.03) 1.18rem 1.2rem, transparent 1.24rem 2.18rem);
-  opacity: 0.86;
-  mask-image: radial-gradient(circle at 50% 50%, #000 0 58%, transparent 80%);
+    linear-gradient(90deg, transparent 0 20%, rgba(244, 240, 232, 0.09) 49%, transparent 80%),
+    linear-gradient(0deg, transparent 0 22%, rgba(244, 240, 232, 0.085) 50%, transparent 78%),
+    repeating-radial-gradient(circle at 50% 50%, transparent 0 1.15rem, rgba(244, 240, 232, 0.035) 1.18rem 1.2rem, transparent 1.24rem 2.18rem);
+  opacity: 0.9;
+  mask-image: radial-gradient(circle at 50% 50%, #000 0 64%, transparent 84%);
 }
 
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__field-glow,
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__ring,
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__axis,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__thread,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__quaternity-square,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__inner-diamond,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__petal,
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__point,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__seed-halo,
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__center,
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__label {
   position: absolute;
   pointer-events: none;
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__field-glow {
+  inset: 13% 18%;
+  border-radius: 50%;
+  opacity: 0.42;
+  filter: blur(0.1rem);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__field-glow--gold {
+  background: radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.15), transparent 70%);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__field-glow--cyan {
+  background: radial-gradient(ellipse at 46% 50%, rgba(83, 216, 232, 0.11), transparent 68%);
+  transform: rotate(90deg);
 }
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__ring {
@@ -4043,6 +4074,36 @@ h3 {
   transition:
     border-color 0.55s var(--motion-spring),
     box-shadow 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__quaternity-square {
+  left: 50%;
+  top: 50%;
+  width: 42%;
+  height: 54%;
+  border: 1px solid rgba(255, 227, 156, 0.16);
+  border-radius: 0.44rem;
+  opacity: 0.36;
+  transform: translate(-50%, -50%) rotate(45deg);
+  transition:
+    border-color 0.55s var(--motion-spring),
+    box-shadow 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__inner-diamond {
+  left: 50%;
+  top: 50%;
+  width: 20%;
+  height: 26%;
+  border: 1px solid rgba(244, 240, 232, 0.16);
+  border-radius: 0.36rem;
+  opacity: 0.42;
+  transform: translate(-50%, -50%) rotate(45deg);
+  transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
 }
@@ -4090,6 +4151,58 @@ h3 {
   height: 1px;
 }
 
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__thread {
+  left: 50%;
+  top: 50%;
+  width: 62%;
+  height: 1px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.12), rgba(255, 227, 156, 0.22), rgba(244, 240, 232, 0.12), transparent);
+  opacity: 0.34;
+  transform: translate(-50%, -50%) rotate(22deg);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__thread--descending {
+  transform: translate(-50%, -50%) rotate(-22deg);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__petal {
+  left: 50%;
+  top: 50%;
+  width: 18%;
+  height: 35%;
+  border-radius: 50%;
+  opacity: 0.24;
+  transform: translate(-50%, -50%);
+  filter: blur(0.02rem);
+  transition:
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__petal--north {
+  background: radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.18), transparent 72%);
+  transform: translate(-50%, -78%);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__petal--east {
+  background: radial-gradient(ellipse at 50% 50%, rgba(255, 227, 156, 0.18), transparent 72%);
+  transform: translate(-8%, -50%) rotate(90deg);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__petal--south {
+  background: radial-gradient(ellipse at 50% 50%, rgba(204, 109, 134, 0.14), transparent 72%);
+  transform: translate(-50%, -22%);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__petal--west {
+  background: radial-gradient(ellipse at 50% 50%, rgba(132, 201, 155, 0.14), transparent 72%);
+  transform: translate(-92%, -50%) rotate(90deg);
+}
+
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__point {
   width: 0.62rem;
   height: 0.62rem;
@@ -4128,6 +4241,21 @@ h3 {
   top: 50%;
   background: var(--green);
   box-shadow: 0 0 1.45rem rgba(132, 201, 155, 0.28);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__seed-halo {
+  left: 50%;
+  top: 50%;
+  width: 2.6rem;
+  height: 2.6rem;
+  border: 1px solid rgba(255, 227, 156, 0.16);
+  border-radius: 50%;
+  opacity: 0.44;
+  transform: translate(-50%, -50%) scale(0.78);
+  transition:
+    border-color 0.55s var(--motion-spring),
+    opacity 0.55s var(--motion-spring),
+    transform 0.55s var(--motion-spring);
 }
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__center {
@@ -4182,19 +4310,54 @@ h3 {
   transform: translate(-50%, -50%) scale(1.34);
 }
 
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="seed"] .self-mandala-instrument__seed-halo {
+  border-color: rgba(255, 227, 156, 0.32);
+  opacity: 0.72;
+  transform: translate(-50%, -50%) scale(1.16);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="seed"] .self-mandala-instrument__inner-diamond {
+  opacity: 0.62;
+  transform: translate(-50%, -50%) rotate(45deg) scale(0.82);
+}
+
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="seed"] .self-mandala-instrument__ring,
-.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="seed"] .self-mandala-instrument__point {
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="seed"] .self-mandala-instrument__point,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="seed"] .self-mandala-instrument__petal,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="seed"] .self-mandala-instrument__quaternity-square {
   opacity: 0.4;
 }
 
-.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__axis {
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__axis,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__thread {
   opacity: 0.9;
   transform: translate(-50%, -50%) scale(1.06);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__thread--ascending {
+  transform: translate(-50%, -50%) rotate(22deg) scaleX(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__thread--descending {
+  transform: translate(-50%, -50%) rotate(-22deg) scaleX(1.08);
 }
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__point {
   opacity: 1;
   transform: translate(-50%, -50%) scale(1.24);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__petal {
+  opacity: 0.62;
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__quaternity-square {
+  border-color: rgba(255, 227, 156, 0.34);
+  box-shadow:
+    0 0 2rem rgba(212, 175, 55, 0.12),
+    inset 0 0 1.8rem rgba(83, 216, 232, 0.055);
+  opacity: 0.88;
+  transform: translate(-50%, -50%) rotate(45deg) scale(1.04);
 }
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="quaternity"] .self-mandala-instrument__ring--middle {
@@ -4217,6 +4380,27 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="mandala"] .self-mandala-instrument__ring--middle {
   transform: translate(-50%, -50%) rotate(45deg) scale(1.08);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="mandala"] .self-mandala-instrument__field-glow,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="mandala"] .self-mandala-instrument__petal {
+  opacity: 0.72;
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="mandala"] .self-mandala-instrument__quaternity-square,
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="mandala"] .self-mandala-instrument__inner-diamond {
+  opacity: 0.72;
+  transform: translate(-50%, -50%) rotate(45deg) scale(1.1);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="mandala"] .self-mandala-instrument__thread--ascending {
+  opacity: 0.68;
+  transform: translate(-50%, -50%) rotate(22deg) scaleX(1.16);
+}
+
+.chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="mandala"] .self-mandala-instrument__thread--descending {
+  opacity: 0.68;
+  transform: translate(-50%, -50%) rotate(-22deg) scaleX(1.16);
 }
 
 .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument[data-active-panel="mandala"] .self-mandala-instrument__center,
@@ -10477,9 +10661,15 @@ h3 {
 	  .syzygy-relation-instrument__return-seed,
 	  .syzygy-relation-instrument__pole,
 	  .syzygy-relation-instrument__quaternio,
+	  .self-mandala-instrument__field-glow,
 	  .self-mandala-instrument__ring,
 	  .self-mandala-instrument__axis,
+	  .self-mandala-instrument__thread,
+	  .self-mandala-instrument__quaternity-square,
+	  .self-mandala-instrument__inner-diamond,
+	  .self-mandala-instrument__petal,
 	  .self-mandala-instrument__point,
+	  .self-mandala-instrument__seed-halo,
 	  .self-mandala-instrument__center,
 	  .christ-symbol-instrument__field,
 	  .christ-symbol-instrument__ring,
@@ -10599,9 +10789,15 @@ h3 {
     animation: none;
   }
 
+  .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__field-glow,
   .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__ring,
   .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__axis,
+  .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__thread,
+  .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__quaternity-square,
+  .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__inner-diamond,
+  .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__petal,
   .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__point,
+  .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__seed-halo,
   .chapter-experience[data-chapter-id="ch4"] .self-mandala-instrument__center {
     transition: none;
   }

--- a/src/visualizations/chapters/ch4/ThreeSelfViz.js
+++ b/src/visualizations/chapters/ch4/ThreeSelfViz.js
@@ -29,21 +29,21 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
 
 /* ── Palette ── */
-const GOLD = new THREE.Color('#ffd700');
-const GOLD_DIM = new THREE.Color('#a08520');
+const GOLD = new THREE.Color('#ffe39c');
+const GOLD_DIM = new THREE.Color('#d4af37');
 const QUAD_COLORS = [
-    new THREE.Color('#e63946'),  // Q0: Feeling  (red/warm)  — left
-    new THREE.Color('#457b9d'),  // Q1: Thinking  (blue/cool) — top
-    new THREE.Color('#2a9d8f'),  // Q2: Sensation (teal/earth) — bottom
-    new THREE.Color('#e9c46a'),  // Q3: Intuition (gold/light) — right
+    new THREE.Color('#cc6d86'),  // Q0: Feeling  (rose/warm)  — left
+    new THREE.Color('#53d8e8'),  // Q1: Thinking  (cyan/cool) — top
+    new THREE.Color('#84c99b'),  // Q2: Sensation (green/earth) — bottom
+    new THREE.Color('#d4af37'),  // Q3: Intuition (gold/light) — right
 ];
 const ZONE_COLORS = [
-    new THREE.Color('#ffd700'),  // innermost: ego — gold
-    new THREE.Color('#665544'),  // shadow — muted earth
-    new THREE.Color('#884466'),  // anima — deep rose
-    new THREE.Color('#2244aa'),  // Self — deep blue (outermost)
+    new THREE.Color('#ffe39c'),  // innermost: ego — gold
+    new THREE.Color('#6f6253'),  // shadow — muted earth
+    new THREE.Color('#9e5c78'),  // anima — deep rose
+    new THREE.Color('#274a89'),  // Self — deep blue (outermost)
 ];
-const STAR_CLR = 0x1a1a40;
+const STAR_CLR = 0x25304f;
 
 export default class ThreeSelfViz extends BaseViz {
     constructor(c, o = {}) {
@@ -72,7 +72,7 @@ export default class ThreeSelfViz extends BaseViz {
         });
         R.setPixelRatio(Math.min(devicePixelRatio, 2));
         R.setSize(this.width, this.height);
-        R.setClearColor(0x030308);
+        R.setClearColor(0x020207);
 
         this.scene = new THREE.Scene();
         this.camera = new THREE.PerspectiveCamera(50, this.width / this.height, 0.1, 200);
@@ -82,14 +82,19 @@ export default class ThreeSelfViz extends BaseViz {
         this.mouse = new THREE.Vector2();
         this.mouseSmooth = new THREE.Vector2();
         this._onMM = e => {
-            this.mouse.x = (e.clientX / innerWidth) * 2 - 1;
-            this.mouse.y = -(e.clientY / innerHeight) * 2 + 1;
+            const bounds = this.canvas.getBoundingClientRect();
+            const width = Math.max(bounds.width, 1);
+            const height = Math.max(bounds.height, 1);
+            this.mouse.x = ((e.clientX - bounds.left) / width) * 2 - 1;
+            this.mouse.y = -(((e.clientY - bounds.top) / height) * 2 - 1);
         };
-        addEventListener('mousemove', this._onMM);
+        this._inputTarget = this.container || this.canvas.parentElement || this.canvas;
+        this._inputTarget.addEventListener('mousemove', this._onMM);
         this._onWheel = e => {
+            if (this._inputTarget && !this._inputTarget.contains(e.target)) return;
             this.zoomTarget = Math.max(5, Math.min(30, this.zoomTarget + e.deltaY * 0.01));
         };
-        addEventListener('wheel', this._onWheel, { passive: true });
+        this._inputTarget.addEventListener('wheel', this._onWheel, { passive: true });
         this.zoomTarget = 20;
         this.introT = 0;
 
@@ -103,13 +108,13 @@ export default class ThreeSelfViz extends BaseViz {
         this._buildStarfield();
         this._buildAnnotations();
 
-        this.scene.add(new THREE.AmbientLight(0x0a0a10, 0.2));
+        this.scene.add(new THREE.AmbientLight(0x0a0a10, 0.24));
 
         /* ── Post-processing ── */
         this.composer = new EffectComposer(R);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloom = new UnrealBloomPass(
-            new THREE.Vector2(this.width, this.height), 1.4, 0.5, 0.35
+            new THREE.Vector2(this.width, this.height), 1.32, 0.42, 0.26
         );
         this.composer.addPass(this.bloom);
     }
@@ -194,7 +199,7 @@ export default class ThreeSelfViz extends BaseViz {
         this.scene.add(this.centerHalo);
 
         /* Center point light */
-        this.centerLight = new THREE.PointLight(GOLD, 1.5, 15);
+        this.centerLight = new THREE.PointLight(GOLD, 1.42, 17);
         this.scene.add(this.centerLight);
     }
 
@@ -345,7 +350,7 @@ export default class ThreeSelfViz extends BaseViz {
         const geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
         this.stars = new THREE.Points(geo, new THREE.PointsMaterial({
-            color: STAR_CLR, size: 0.04, transparent: true, opacity: 0.3,
+            color: STAR_CLR, size: 0.04, transparent: true, opacity: 0.34,
             depthWrite: false
         }));
         this.scene.add(this.stars);
@@ -924,8 +929,8 @@ export default class ThreeSelfViz extends BaseViz {
     }
 
     dispose() {
-        removeEventListener('mousemove', this._onMM);
-        removeEventListener('wheel', this._onWheel);
+        this._inputTarget?.removeEventListener('mousemove', this._onMM);
+        this._inputTarget?.removeEventListener('wheel', this._onWheel);
         if (this._annTimers) this._annTimers.forEach(t => clearTimeout(t));
         this._annotationOverlay?.remove();
         this.renderer?.dispose();


### PR DESCRIPTION
## Summary

- Refines Chapter 4 (`/journey/chapter/ch4`) as the Self / ordering-center pass for the Chapter 2-4 psyche arc.
- Expands the React fallback/teaching instrument with layered mandala glows, quaternity square/diamond geometry, diagonal threads, petals, and richer active-panel states while preserving the `seed`, `quaternity`, `mandala` panel contract.
- Tunes the Three.js Self scene palette toward the shared gold/cyan/rose/green visual system, warms bloom/light response, scopes pointer and wheel input to the scene host, and keeps cleanup explicit.

## Visual Thesis

Chapter 4 should feel like an ordering center: a small seed that quietly organizes the field into a fourfold mandala. The page remains sparse in prose and lets the canvas plus compact symbolic instrument do the teaching.

## Verification

- `npm run lint --silent`
- `npx tsc --noEmit`
- `npm run validate:consistency --silent`
- `npm run ci:chapter-shell --silent`
- `npm run test:app --silent`
- `npm test -- --runInBand`
- `npm run build --silent`
- `npm run test:e2e:app:foundation --silent`
- `npm run test:e2e:app:scene-controls --silent`
- `npm run test:e2e:app:mobile --silent`
- `npm run test:e2e:app --silent`
- `npm run test:a11y:app --silent`
- `npm run build:pages --silent && npm run test:pages:artifact --silent`
- `npm run test:visual:control-tower --silent`

## Browser QA

Local screenshots captured for `/journey/chapter/ch4` at 1440x1000, 390x844, and 320x568. The route loaded with no console errors, no request failures, no horizontal overflow, no nav/heading overlap, and expected Chapter 4 panel ordering.

Control tower report: 20 routes inspected across desktop/mobile/narrow with 0 technical blockers; Chapter 4 scored 100% in the report-only rubric.