### PR TITLE
[codex] refine chapter six fish aeon

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -4780,20 +4780,22 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument {
   position: relative;
-  width: min(29.5rem, 100%);
-  min-height: clamp(6.25rem, 9.6vh, 7.2rem);
+  width: min(34rem, 100%);
+  min-height: clamp(7.7rem, 12.2vh, 9.15rem);
   overflow: hidden;
-  margin-top: 0.85rem;
-  border: 1px solid rgba(244, 240, 232, 0.105);
+  isolation: isolate;
+  margin-top: 0.95rem;
+  border: 1px solid rgba(244, 240, 232, 0.14);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 47% 50%, rgba(83, 216, 232, 0.13), transparent 4.6rem),
-    radial-gradient(circle at 28% 48%, rgba(212, 175, 55, 0.16), transparent 4.1rem),
-    radial-gradient(circle at 80% 45%, rgba(103, 186, 214, 0.12), transparent 4.6rem),
-    linear-gradient(90deg, rgba(8, 7, 14, 0.82), rgba(5, 8, 15, 0.52) 50%, rgba(5, 16, 22, 0.48));
+    radial-gradient(circle at 47% 49%, rgba(83, 216, 232, 0.18), transparent 5.4rem),
+    radial-gradient(circle at 27% 42%, rgba(255, 227, 156, 0.2), transparent 5.8rem),
+    radial-gradient(circle at 78% 52%, rgba(83, 216, 232, 0.19), transparent 5.8rem),
+    linear-gradient(90deg, rgba(7, 6, 13, 0.9), rgba(4, 9, 17, 0.62) 49%, rgba(3, 22, 31, 0.56));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.2);
+    0 1.5rem 4.4rem rgba(0, 0, 0, 0.26),
+    0 0 5rem rgba(83, 216, 232, 0.04);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument::before,
@@ -4804,21 +4806,31 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument::before {
-  inset: 0.64rem;
-  border: 1px solid rgba(83, 216, 232, 0.09);
+  inset: 0.72rem;
+  z-index: 0;
+  border: 1px solid rgba(83, 216, 232, 0.12);
   border-radius: calc(var(--radius) - 2px);
+  background:
+    linear-gradient(90deg, transparent 0 49.82%, rgba(244, 240, 232, 0.08) 49.94% 50.06%, transparent 50.18%),
+    linear-gradient(0deg, transparent 0 49.85%, rgba(83, 216, 232, 0.06) 49.96% 50.04%, transparent 50.15%),
+    radial-gradient(circle at 50% 50%, transparent 0 34%, rgba(83, 216, 232, 0.08) 34.6% 35.2%, transparent 36%),
+    radial-gradient(circle at 50% 50%, transparent 0 51%, rgba(255, 227, 156, 0.06) 51.6% 52.2%, transparent 53%);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument::after {
   left: 50%;
   top: 50%;
-  width: 7.6rem;
+  z-index: 1;
+  width: min(16.8rem, 56%);
   aspect-ratio: 1;
-  border: 1px solid rgba(255, 227, 156, 0.09);
+  border: 1px solid rgba(255, 227, 156, 0.12);
   border-radius: 50%;
+  background:
+    conic-gradient(from 236deg, rgba(255, 227, 156, 0.16) 0 54deg, transparent 54deg 205deg, rgba(83, 216, 232, 0.14) 205deg 256deg, transparent 256deg 360deg);
+  mask-image: radial-gradient(circle at 50% 50%, transparent 0 55%, #000 56% 58%, transparent 60%);
   box-shadow:
     inset 0 0 1.4rem rgba(83, 216, 232, 0.08),
-    0 0 1.9rem rgba(212, 175, 55, 0.08);
+    0 0 2.5rem rgba(212, 175, 55, 0.08);
   transform: translate(-50%, -50%);
 }
 
@@ -4831,6 +4843,7 @@ h3 {
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__threshold,
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label {
   position: absolute;
+  z-index: 2;
   pointer-events: none;
 }
 
@@ -4838,8 +4851,10 @@ h3 {
   top: 0;
   bottom: 0;
   width: 50%;
-  opacity: 0.58;
+  z-index: 1;
+  opacity: 0.6;
   transition:
+    filter 0.55s var(--motion-spring),
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
 }
@@ -4847,20 +4862,21 @@ h3 {
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__field--pisces {
   left: 0;
   background:
-    radial-gradient(circle at 38% 50%, rgba(255, 227, 156, 0.15), transparent 4.2rem),
-    linear-gradient(90deg, rgba(212, 175, 55, 0.09), transparent);
+    radial-gradient(circle at 36% 50%, rgba(255, 227, 156, 0.2), transparent 5.2rem),
+    linear-gradient(90deg, rgba(212, 175, 55, 0.13), transparent);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__field--aquarius {
   right: 0;
   background:
-    radial-gradient(circle at 65% 48%, rgba(83, 216, 232, 0.17), transparent 4.5rem),
-    linear-gradient(270deg, rgba(83, 216, 232, 0.09), transparent);
+    radial-gradient(circle at 68% 50%, rgba(83, 216, 232, 0.23), transparent 5.2rem),
+    linear-gradient(270deg, rgba(83, 216, 232, 0.13), transparent);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring {
   left: 50%;
   top: 50%;
+  z-index: 2;
   border-radius: 50%;
   transform: translate(-50%, -50%);
   transition:
@@ -4871,17 +4887,17 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring--outer {
-  width: 7.1rem;
+  width: 8.5rem;
   aspect-ratio: 1;
-  border: 1px solid rgba(244, 240, 232, 0.32);
+  border: 1px solid rgba(244, 240, 232, 0.36);
   background:
-    conic-gradient(from -28deg, rgba(212, 175, 55, 0.36), rgba(83, 216, 232, 0.24), rgba(244, 240, 232, 0.16), rgba(212, 175, 55, 0.36));
+    conic-gradient(from -28deg, rgba(255, 227, 156, 0.42), rgba(83, 216, 232, 0.32), rgba(244, 240, 232, 0.16), rgba(255, 227, 156, 0.42));
   mask-image: radial-gradient(circle at 50% 50%, transparent 0 61%, #000 63% 66%, transparent 68%);
   opacity: 0.9;
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring--inner {
-  width: 4.35rem;
+  width: 5.25rem;
   aspect-ratio: 1;
   border: 1px solid rgba(83, 216, 232, 0.28);
   opacity: 0.68;
@@ -4892,20 +4908,22 @@ h3 {
   --sign-counter: 0deg;
   left: 50%;
   top: 50%;
-  width: 1.05rem;
-  height: 1.05rem;
+  z-index: 3;
+  width: 1.12rem;
+  height: 1.12rem;
   display: grid;
   place-items: center;
   border: 1px solid rgba(244, 240, 232, 0.1);
   border-radius: 50%;
-  background: rgba(4, 5, 10, 0.72);
+  background: rgba(4, 5, 10, 0.78);
   color: rgba(244, 240, 232, 0.78);
   font-family: var(--font-ui);
   font-size: 0.48rem;
   font-weight: 800;
   letter-spacing: 0;
-  opacity: 0.72;
-  transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.65rem) rotate(var(--sign-counter));
+  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.16);
+  opacity: 0.74;
+  transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-4.22rem) rotate(var(--sign-counter));
   transition:
     background 0.55s var(--motion-spring),
     border-color 0.55s var(--motion-spring),
@@ -4977,10 +4995,12 @@ h3 {
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__thread {
   left: 50%;
   top: 50%;
-  width: 43%;
+  z-index: 4;
+  width: 48%;
   height: 1px;
-  background: linear-gradient(90deg, rgba(255, 227, 156, 0.08), rgba(244, 240, 232, 0.54), rgba(83, 216, 232, 0.08));
-  opacity: 0.68;
+  background: linear-gradient(90deg, rgba(255, 227, 156, 0.12), rgba(244, 240, 232, 0.66), rgba(83, 216, 232, 0.14));
+  box-shadow: 0 0 1rem rgba(255, 227, 156, 0.12);
+  opacity: 0.72;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -4989,8 +5009,9 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish {
   top: 50%;
-  width: 2.75rem;
-  height: 0.76rem;
+  z-index: 5;
+  width: 3.15rem;
+  height: 0.86rem;
   border-radius: 999px 60% 60% 999px;
   transition:
     box-shadow 0.55s var(--motion-spring),
@@ -5011,29 +5032,35 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish--light {
-  left: 35%;
+  left: 34%;
   color: rgba(255, 227, 156, 0.9);
-  background: linear-gradient(90deg, rgba(255, 227, 156, 0.18), rgba(255, 227, 156, 0.82));
-  box-shadow: 0 0 1.5rem rgba(212, 175, 55, 0.28);
+  background: linear-gradient(90deg, rgba(255, 227, 156, 0.2), rgba(255, 227, 156, 0.88));
+  box-shadow:
+    0 0 1.5rem rgba(212, 175, 55, 0.32),
+    0 0 2.6rem rgba(212, 175, 55, 0.08);
   transform: translate(-50%, -50%);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish--shadow {
-  left: 65%;
+  left: 66%;
   color: rgba(143, 231, 237, 0.88);
-  background: linear-gradient(90deg, rgba(83, 216, 232, 0.78), rgba(83, 216, 232, 0.16));
-  box-shadow: 0 0 1.5rem rgba(83, 216, 232, 0.24);
+  background: linear-gradient(90deg, rgba(83, 216, 232, 0.86), rgba(83, 216, 232, 0.16));
+  box-shadow:
+    0 0 1.5rem rgba(83, 216, 232, 0.28),
+    0 0 2.6rem rgba(83, 216, 232, 0.08);
   transform: translate(-50%, -50%) rotate(180deg);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__hand {
   left: 50%;
   top: 50%;
-  width: 21%;
+  z-index: 4;
+  width: 24%;
   height: 2px;
-  background: linear-gradient(90deg, rgba(244, 240, 232, 0.86), rgba(83, 216, 232, 0.44), transparent);
+  background: linear-gradient(90deg, rgba(244, 240, 232, 0.88), rgba(83, 216, 232, 0.5), transparent);
   border-radius: 999px;
-  opacity: 0.76;
+  box-shadow: 0 0 1.2rem rgba(83, 216, 232, 0.12);
+  opacity: 0.8;
   transform: rotate(28deg);
   transform-origin: left center;
   transition:
@@ -5043,13 +5070,16 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__threshold {
-  right: 22%;
-  top: 17%;
-  bottom: 17%;
+  right: 20%;
+  top: 11%;
+  bottom: 10%;
+  z-index: 4;
   width: 1px;
-  background: linear-gradient(180deg, transparent, rgba(83, 216, 232, 0.66), rgba(255, 227, 156, 0.24), transparent);
-  box-shadow: 0 0 1.5rem rgba(83, 216, 232, 0.24);
-  opacity: 0.56;
+  background: linear-gradient(180deg, transparent, rgba(143, 231, 237, 0.74), rgba(255, 227, 156, 0.26), transparent);
+  box-shadow:
+    0 0 1.5rem rgba(83, 216, 232, 0.28),
+    0 0 3rem rgba(83, 216, 232, 0.08);
+  opacity: 0.62;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -5060,7 +5090,9 @@ h3 {
   font-family: var(--font-ui);
   font-size: 0.58rem;
   font-weight: 700;
+  text-transform: uppercase;
   letter-spacing: 0;
+  text-shadow: 0 0 1rem rgba(0, 0, 0, 0.34);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__label--fish {
@@ -5083,17 +5115,17 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__fish--light {
   opacity: 1;
-  transform: translate(-50%, -50%) translateX(-0.3rem) scale(1.12);
+  transform: translate(-50%, -50%) translateX(-0.5rem) scale(1.16);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__fish--shadow {
   opacity: 1;
-  transform: translate(-50%, -50%) translateX(0.3rem) rotate(180deg) scale(1.12);
+  transform: translate(-50%, -50%) translateX(0.5rem) rotate(180deg) scale(1.16);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__thread {
-  opacity: 0.92;
-  transform: translate(-50%, -50%) scaleX(1.08);
+  opacity: 1;
+  transform: translate(-50%, -50%) scaleX(1.14);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__sign {
@@ -5102,13 +5134,17 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="fish"] .aeon-fish-instrument__sign--12 {
   border-color: rgba(255, 227, 156, 0.58);
+  background: rgba(38, 28, 8, 0.88);
   color: var(--gold-soft);
   opacity: 1;
+  box-shadow: 0 0 1.3rem rgba(255, 227, 156, 0.22);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="zodiac"] .aeon-fish-instrument__ring {
   border-color: rgba(244, 240, 232, 0.46);
-  filter: drop-shadow(0 0 0.7rem rgba(83, 216, 232, 0.12));
+  filter:
+    drop-shadow(0 0 0.8rem rgba(83, 216, 232, 0.14))
+    drop-shadow(0 0 1.2rem rgba(212, 175, 55, 0.08));
   opacity: 1;
   transform: translate(-50%, -50%) scale(1.05);
 }
@@ -5116,12 +5152,12 @@ h3 {
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="zodiac"] .aeon-fish-instrument__sign {
   border-color: rgba(83, 216, 232, 0.24);
   color: rgba(244, 240, 232, 0.92);
-  opacity: 0.95;
+  opacity: 0.98;
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="zodiac"] .aeon-fish-instrument__hand {
   opacity: 1;
-  transform: rotate(44deg) scaleX(1.12);
+  transform: rotate(44deg) scaleX(1.2);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="zodiac"] .aeon-fish-instrument__fish {
@@ -5129,19 +5165,20 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__field--aquarius {
-  opacity: 0.9;
+  filter: saturate(1.18);
+  opacity: 0.94;
   transform: scaleX(1.06);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__threshold {
   opacity: 1;
-  transform: scaleY(1.08);
+  transform: scaleY(1.12);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__hand {
   background: linear-gradient(90deg, rgba(244, 240, 232, 0.74), rgba(143, 231, 237, 0.92), transparent);
   opacity: 1;
-  transform: rotate(62deg) scaleX(1.16);
+  transform: rotate(62deg) scaleX(1.24);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__sign--11 {
@@ -5149,7 +5186,8 @@ h3 {
   background: rgba(7, 37, 48, 0.76);
   color: var(--ink-cyan);
   opacity: 1;
-  transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.65rem) rotate(var(--sign-counter)) scale(1.2);
+  box-shadow: 0 0 1.35rem rgba(83, 216, 232, 0.28);
+  transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-4.22rem) rotate(var(--sign-counter)) scale(1.22);
 }
 
 .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__fish {
@@ -10063,6 +10101,140 @@ h3 {
   box-shadow: 0 0 1.25rem rgba(83, 216, 232, 0.62);
 }
 
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 50% 50%, rgba(83, 216, 232, 0.12), transparent 4.8rem),
+    radial-gradient(circle at 34% 56%, rgba(255, 227, 156, 0.15), transparent 4.9rem),
+    radial-gradient(circle at 68% 56%, rgba(83, 216, 232, 0.13), transparent 5.1rem),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.048), rgba(255, 255, 255, 0.014));
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel__symbol::before {
+  inset: 11% 17%;
+  border-color: rgba(255, 227, 156, 0.16);
+  box-shadow:
+    inset 0 0 4rem rgba(83, 216, 232, 0.06),
+    0 0 3.8rem rgba(212, 175, 55, 0.04);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel__symbol::after {
+  top: 28%;
+  background: #f7f1df;
+  box-shadow:
+    0 0 1.7rem rgba(244, 240, 232, 0.72),
+    0 8rem 2.6rem rgba(212, 175, 55, 0.46);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel__ring--outer {
+  width: 72%;
+  border-color: rgba(255, 227, 156, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel__ring--inner {
+  width: 45%;
+  border-color: rgba(83, 216, 232, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel__axis--vertical {
+  background: linear-gradient(180deg, rgba(244, 240, 232, 0.28), rgba(255, 227, 156, 0.24), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel__axis--horizontal {
+  top: 55%;
+  width: 68%;
+  background: linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.34), rgba(83, 216, 232, 0.32), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="fish"] .chapter-panel__axis--horizontal {
+  top: 52%;
+  width: 72%;
+  background:
+    linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.48), rgba(244, 240, 232, 0.34), rgba(83, 216, 232, 0.42), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="fish"] .chapter-panel__depth--one,
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="fish"] .chapter-panel__depth--two {
+  top: 50%;
+  height: 21%;
+  border-radius: 50%;
+  border-top: 1px solid currentColor;
+  border-bottom: 1px solid currentColor;
+  opacity: 0.72;
+  transform: translate(-50%, -50%) rotate(-14deg);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="fish"] .chapter-panel__depth--one {
+  left: 37%;
+  color: rgba(255, 227, 156, 0.44);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="fish"] .chapter-panel__depth--two {
+  left: 63%;
+  color: rgba(83, 216, 232, 0.42);
+  transform: translate(-50%, -50%) rotate(166deg);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="fish"] .chapter-panel__spark--one {
+  left: 36%;
+  top: 52%;
+  background: var(--gold-soft);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="fish"] .chapter-panel__spark--two {
+  right: 36%;
+  top: 52%;
+  background: var(--cyan);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="zodiac"] .chapter-panel__ring--outer {
+  width: 82%;
+  border-color: rgba(255, 227, 156, 0.28);
+  box-shadow: 0 0 2rem rgba(83, 216, 232, 0.06);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="zodiac"] .chapter-panel__ring--inner {
+  width: 52%;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="zodiac"] .chapter-panel__mandala-band {
+  opacity: 0.42;
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="zodiac"] .chapter-panel__mandala-band--outer {
+  width: 78%;
+  border-color: rgba(255, 227, 156, 0.12);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="zodiac"] .chapter-panel__mandala-band--middle {
+  width: 63%;
+  border-color: rgba(83, 216, 232, 0.12);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="transition"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 72% 50%, rgba(83, 216, 232, 0.2), transparent 5.4rem),
+    radial-gradient(circle at 34% 58%, rgba(255, 227, 156, 0.11), transparent 5rem),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.046), rgba(255, 255, 255, 0.012));
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="transition"] .chapter-panel__axis--vertical {
+  left: 72%;
+  height: 76%;
+  background: linear-gradient(180deg, transparent, rgba(83, 216, 232, 0.58), rgba(255, 227, 156, 0.22), transparent);
+  box-shadow: 0 0 1.4rem rgba(83, 216, 232, 0.2);
+}
+
+.chapter-experience[data-chapter-id="ch6"] .chapter-panel[data-panel-id="transition"] .chapter-panel__spark--two {
+  right: 27%;
+  top: 50%;
+  width: 0.7rem;
+  height: 0.7rem;
+  background: var(--cyan);
+  box-shadow:
+    0 0 0 0.45rem rgba(83, 216, 232, 0.08),
+    0 0 1.8rem rgba(83, 216, 232, 0.72);
+}
+
 .chapter-experience[data-chapter-id="ch1"] .chapter-panels {
   width: min(1260px, calc(100% - 2rem));
   gap: 10vh;
@@ -12561,24 +12733,24 @@ h3 {
   }
 
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument {
-    min-height: 6.75rem;
+    min-height: 7.05rem;
     margin-top: 0.7rem;
   }
 
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring--outer {
-    width: 6.15rem;
+    width: 6.35rem;
   }
 
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__ring--inner {
-    width: 3.75rem;
+    width: 3.92rem;
   }
 
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__sign {
-    transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.12rem) rotate(var(--sign-counter));
+    transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.2rem) rotate(var(--sign-counter));
   }
 
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument[data-active-panel="transition"] .aeon-fish-instrument__sign--11 {
-    transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.12rem) rotate(var(--sign-counter)) scale(1.16);
+    transform: translate(-50%, -50%) rotate(var(--sign-angle)) translateY(-3.2rem) rotate(var(--sign-counter)) scale(1.16);
   }
 
   .chapter-experience[data-chapter-id="ch6"] .aeon-fish-instrument__fish {
@@ -12608,23 +12780,36 @@ h3 {
     right: 1rem;
     top: 20.8rem;
     width: auto;
-    padding: 0.56rem 0.7rem;
+    padding: 0.72rem 0.84rem;
+    border-color: rgba(83, 216, 232, 0.2);
+    background:
+      radial-gradient(circle at 74% 64%, rgba(83, 216, 232, 0.22), transparent 4.8rem),
+      radial-gradient(circle at 35% 34%, rgba(255, 227, 156, 0.17), transparent 4.2rem),
+      linear-gradient(90deg, rgba(5, 6, 12, 0.92), rgba(4, 19, 27, 0.74));
     text-align: left;
     transform: none;
   }
 
   .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback .eyebrow {
-    margin: 0;
+    margin: 0 0 0.2rem;
   }
 
-  .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback h2,
+  .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback h2 {
+    margin: 0;
+    max-width: 17ch;
+    font-size: clamp(1.05rem, 5.2vw, 1.28rem);
+    line-height: 1;
+  }
+
   .chapter-experience[data-chapter-id="ch6"][data-reduced-motion="true"] .scene-host__fallback p:not(.eyebrow) {
-    position: absolute;
-    width: 1px;
-    height: 1px;
+    display: -webkit-box;
+    margin: 0.35rem 0 0;
+    max-width: 40ch;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+    font-size: 0.78rem;
+    line-height: 1.42;
   }
 
   .chapter-experience[data-chapter-id="ch14"] .chapter-stage__intro {

--- a/src/visualizations/chapters/ch6/ThreeFishViz.js
+++ b/src/visualizations/chapters/ch6/ThreeFishViz.js
@@ -23,18 +23,18 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
 
 /* ─── Palette ─── */
-const ZODIAC_GOLD = new THREE.Color('#c8a820');
-const FISH_SILVER = new THREE.Color('#b0c4de');
-const FISH_DARK = new THREE.Color('#2a3a5a');
-const COMMISSURE = new THREE.Color('#ffd700');
-const SATURN_BLACK = new THREE.Color('#1a1a28');
-const SATURN_RING_C = new THREE.Color('#4a4a5a');
-const JUPITER_AMBER = new THREE.Color('#d4a030');
-const CONJUNCTION_C = new THREE.Color('#ffffff');
-const SPRING_PT = new THREE.Color('#ff6600');
+const ZODIAC_GOLD = new THREE.Color('#d4af37');
+const FISH_SILVER = new THREE.Color('#f7f1df');
+const FISH_DARK = new THREE.Color('#25304f');
+const COMMISSURE = new THREE.Color('#ffe39c');
+const SATURN_BLACK = new THREE.Color('#070814');
+const SATURN_RING_C = new THREE.Color('#64708f');
+const JUPITER_AMBER = new THREE.Color('#d4af37');
+const CONJUNCTION_C = new THREE.Color('#f7f1df');
+const SPRING_PT = new THREE.Color('#cc6d86');
 const LION_RED = new THREE.Color('#c0392b');
 const SERPENT_GREEN = new THREE.Color('#2ecc71');
-const VOID = 0x030310;
+const VOID = 0x02030a;
 
 const ZODIAC_R = 5;
 
@@ -67,13 +67,13 @@ export default class ThreeFishViz extends BaseViz {
             canvas: this.canvas, antialias: true, alpha: false,
             powerPreference: 'high-performance',
         });
-        R.setPixelRatio(Math.min(devicePixelRatio, 2));
+        R.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 2));
         R.setSize(this.width, this.height);
         R.setClearColor(VOID);
         R.toneMapping = THREE.ACESFilmicToneMapping;
 
         this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.FogExp2(VOID, 0.008);
+        this.scene.fog = new THREE.FogExp2(VOID, 0.006);
 
         this.camera = new THREE.PerspectiveCamera(55, this.width / this.height, 0.1, 200);
         this.camera.position.set(0, 5, 14);
@@ -81,10 +81,16 @@ export default class ThreeFishViz extends BaseViz {
         this.mouse = new THREE.Vector2();
         this.mouseSmooth = new THREE.Vector2();
         this._onMM = e => {
-            this.mouse.x = (e.clientX / innerWidth) * 2 - 1;
-            this.mouse.y = -(e.clientY / innerHeight) * 2 + 1;
+            const bounds = this._inputTarget?.getBoundingClientRect?.();
+            const width = bounds?.width || globalThis.innerWidth || 1;
+            const height = bounds?.height || globalThis.innerHeight || 1;
+            const left = bounds?.left || 0;
+            const top = bounds?.top || 0;
+            this.mouse.x = ((e.clientX - left) / width) * 2 - 1;
+            this.mouse.y = -(((e.clientY - top) / height) * 2 - 1);
         };
-        addEventListener('mousemove', this._onMM);
+        this._inputTarget = this.container || this.canvas || globalThis;
+        this._inputTarget.addEventListener('mousemove', this._onMM, { passive: true });
 
         /* Scratch vectors for projection (reuse to avoid GC) */
         this._projVec = new THREE.Vector3();
@@ -167,7 +173,7 @@ export default class ThreeFishViz extends BaseViz {
         const geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
         this.starfield = new THREE.Points(geo, new THREE.PointsMaterial({
-            color: 0x8585c8, size: 0.05, transparent: true, opacity: 0.38,
+            color: 0x9aa7d8, size: 0.055, transparent: true, opacity: 0.44,
             blending: THREE.AdditiveBlending, depthWrite: false,
         }));
         this.scene.add(this.starfield);
@@ -182,9 +188,9 @@ export default class ThreeFishViz extends BaseViz {
         this.spokes = [];
 
         /* Main ring */
-        const ringGeo = new THREE.TorusGeometry(ZODIAC_R, 0.03, 8, 128);
+        const ringGeo = new THREE.TorusGeometry(ZODIAC_R, 0.035, 8, 128);
         const mainRingMat = new THREE.MeshBasicMaterial({
-            color: ZODIAC_GOLD, transparent: true, opacity: 0.25,
+            color: ZODIAC_GOLD, transparent: true, opacity: 0.32,
             blending: THREE.AdditiveBlending,
         });
         this.wheelGroup.add(new THREE.Mesh(ringGeo, mainRingMat));
@@ -193,7 +199,7 @@ export default class ThreeFishViz extends BaseViz {
         /* Inner ring — fainter, smaller */
         const innerGeo = new THREE.TorusGeometry(ZODIAC_R * 0.85, 0.015, 8, 128);
         const innerRingMat = new THREE.MeshBasicMaterial({
-            color: ZODIAC_GOLD, transparent: true, opacity: 0.08,
+            color: ZODIAC_GOLD, transparent: true, opacity: 0.12,
             blending: THREE.AdditiveBlending,
         });
         this.wheelGroup.add(new THREE.Mesh(innerGeo, innerRingMat));
@@ -208,11 +214,11 @@ export default class ThreeFishViz extends BaseViz {
             const isAquarius = i === 10;
 
             /* Marker dot */
-            const dotGeo = new THREE.SphereGeometry(isPisces ? 0.09 : 0.05, 8, 8);
+            const dotGeo = new THREE.SphereGeometry(isPisces ? 0.11 : (isAquarius ? 0.085 : 0.052), 8, 8);
             const dot = new THREE.Mesh(dotGeo, new THREE.MeshBasicMaterial({
                 color: isPisces ? COMMISSURE : (isAquarius ? 0x22d3ee : ZODIAC_GOLD),
                 transparent: true,
-                opacity: isPisces ? 0.7 : (isAquarius ? 0.5 : 0.3),
+                opacity: isPisces ? 0.82 : (isAquarius ? 0.62 : 0.34),
             }));
             dot.position.set(Math.cos(angle) * ZODIAC_R, 0, Math.sin(angle) * ZODIAC_R);
             this.wheelGroup.add(dot);
@@ -255,7 +261,7 @@ export default class ThreeFishViz extends BaseViz {
                 }
                 const arcGeo = new THREE.BufferGeometry().setFromPoints(arcPts);
                 this._piscesArc = new THREE.Line(arcGeo, new THREE.LineBasicMaterial({
-                    color: COMMISSURE, transparent: true, opacity: 0.35,
+                    color: COMMISSURE, transparent: true, opacity: 0.42,
                     blending: THREE.AdditiveBlending,
                 }));
                 this.wheelGroup.add(this._piscesArc);
@@ -273,7 +279,7 @@ export default class ThreeFishViz extends BaseViz {
                 }
                 const arcGeo = new THREE.BufferGeometry().setFromPoints(arcPts);
                 this._aquariusArc = new THREE.Line(arcGeo, new THREE.LineBasicMaterial({
-                    color: 0x22d3ee, transparent: true, opacity: 0.15,
+                    color: 0x53d8e8, transparent: true, opacity: 0.22,
                     blending: THREE.AdditiveBlending,
                 }));
                 this.wheelGroup.add(this._aquariusArc);
@@ -284,7 +290,7 @@ export default class ThreeFishViz extends BaseViz {
         this.springPoint = new THREE.Mesh(
             new THREE.OctahedronGeometry(0.15, 0),
             new THREE.MeshStandardMaterial({
-                color: SPRING_PT, emissive: SPRING_PT, emissiveIntensity: 0.6,
+                color: SPRING_PT, emissive: SPRING_PT, emissiveIntensity: 0.82,
             })
         );
         this.wheelGroup.add(this.springPoint);
@@ -305,19 +311,19 @@ export default class ThreeFishViz extends BaseViz {
             const color = isLight ? FISH_SILVER : FISH_DARK;
 
             /* Body — elongated sphere */
-            const bodyGeo = new THREE.SphereGeometry(0.22, 12, 10);
-            bodyGeo.scale(2.2, 0.6, 0.45);
+            const bodyGeo = new THREE.SphereGeometry(0.24, 16, 12);
+            bodyGeo.scale(2.45, 0.72, 0.5);
             const bodyMat = new THREE.MeshStandardMaterial({
                 color, emissive: color,
-                emissiveIntensity: isLight ? 0.5 : 0.2,
-                transparent: true, opacity: isLight ? 0.75 : 0.5,
-                metalness: 0.4, roughness: 0.3,
+                emissiveIntensity: isLight ? 0.72 : 0.34,
+                transparent: true, opacity: isLight ? 0.84 : 0.58,
+                metalness: 0.45, roughness: 0.24,
             });
             const body = new THREE.Mesh(bodyGeo, bodyMat);
             group.add(body);
 
             /* Tail fin */
-            const tailGeo = new THREE.ConeGeometry(0.12, 0.3, 4);
+            const tailGeo = new THREE.ConeGeometry(0.14, 0.34, 4);
             const tailMat = bodyMat.clone();
             tailMat.opacity = isLight ? 0.55 : 0.35;
             const tail = new THREE.Mesh(tailGeo, tailMat);
@@ -355,8 +361,8 @@ export default class ThreeFishViz extends BaseViz {
             /* Glow sphere — used for visual emphasis during label reveal */
             const glowGeo = new THREE.SphereGeometry(isLight ? 0.9 : 0.7, 12, 12);
             const glowMat = new THREE.MeshBasicMaterial({
-                color: isLight ? 0x4488bb : 0x1a2244,
-                transparent: true, opacity: isLight ? 0.06 : 0.03,
+                color: isLight ? 0xd4af37 : 0x53d8e8,
+                transparent: true, opacity: isLight ? 0.08 : 0.045,
                 blending: THREE.AdditiveBlending,
             });
             const glow = new THREE.Mesh(glowGeo, glowMat);
@@ -380,7 +386,7 @@ export default class ThreeFishViz extends BaseViz {
         }
         const geo = new THREE.BufferGeometry().setFromPoints(pts);
         this.commissure = new THREE.Line(geo, new THREE.LineBasicMaterial({
-            color: COMMISSURE, transparent: true, opacity: 0.35,
+            color: COMMISSURE, transparent: true, opacity: 0.42,
             blending: THREE.AdditiveBlending,
         }));
         this.scene.add(this.commissure);
@@ -392,7 +398,7 @@ export default class ThreeFishViz extends BaseViz {
         const glowGeo = new THREE.BufferGeometry();
         glowGeo.setAttribute('position', new THREE.BufferAttribute(glowPos, 3));
         this.commissureGlow = new THREE.Points(glowGeo, new THREE.PointsMaterial({
-            color: COMMISSURE, size: 0.07, transparent: true, opacity: 0.4,
+            color: COMMISSURE, size: 0.085, transparent: true, opacity: 0.48,
             blending: THREE.AdditiveBlending, depthWrite: false,
         }));
         this.scene.add(this.commissureGlow);
@@ -416,7 +422,7 @@ export default class ThreeFishViz extends BaseViz {
         /* Saturn ring */
         const sRingGeo = new THREE.TorusGeometry(0.9, 0.04, 4, 64);
         const sRing = new THREE.Mesh(sRingGeo, new THREE.MeshBasicMaterial({
-            color: SATURN_RING_C, transparent: true, opacity: 0.3,
+            color: SATURN_RING_C, transparent: true, opacity: 0.38,
         }));
         sRing.rotation.x = Math.PI / 3;
         this.saturnGroup.add(sRing);
@@ -516,11 +522,11 @@ export default class ThreeFishViz extends BaseViz {
 
     /* ═══ Lights ═══ */
     _createLights() {
-        this.scene.add(new THREE.AmbientLight(0x0a0a15, 0.3));
-        const p1 = new THREE.PointLight(0xc8a820, 0.5, 20);
+        this.scene.add(new THREE.AmbientLight(0x0a0a18, 0.38));
+        const p1 = new THREE.PointLight(0xd4af37, 0.72, 22);
         p1.position.set(0, 3, 5);
         this.scene.add(p1);
-        const p2 = new THREE.PointLight(0x4a4a7a, 0.3, 25);
+        const p2 = new THREE.PointLight(0x53d8e8, 0.44, 26);
         p2.position.set(-4, 4, -4);
         this.scene.add(p2);
     }
@@ -543,8 +549,8 @@ export default class ThreeFishViz extends BaseViz {
             /* ─── Phase system ─── */
             .ch6-overlay [data-phase] {
                 opacity: 0;
-                transition: opacity 2.5s cubic-bezier(0.25, 0.46, 0.45, 0.94),
-                            transform 2.5s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+                transition: opacity 1.8s cubic-bezier(0.32, 0.72, 0, 1),
+                            transform 1.8s cubic-bezier(0.32, 0.72, 0, 1);
                 transform: translateY(8px);
             }
             .ch6-overlay [data-phase].vis {
@@ -565,7 +571,9 @@ export default class ThreeFishViz extends BaseViz {
             /* ─── Tracked labels (positioned by JS) ─── */
             .ch6-tracked {
                 position: absolute;
-                transition: left 0.18s ease-out, top 0.18s ease-out;
+                transition:
+                    left 0.18s cubic-bezier(0.32, 0.72, 0, 1),
+                    top 0.18s cubic-bezier(0.32, 0.72, 0, 1);
                 will-change: left, top;
             }
 
@@ -624,11 +632,11 @@ export default class ThreeFishViz extends BaseViz {
                 white-space: nowrap;
             }
             .ch6-fish--light {
-                color: rgba(176, 196, 222, 0.65);
+                color: rgba(247, 241, 223, 0.7);
                 text-align: right;
             }
             .ch6-fish--dark {
-                color: rgba(60, 80, 120, 0.7);
+                color: rgba(83, 216, 232, 0.62);
             }
             .ch6-fish-explain {
                 display: block;
@@ -643,10 +651,10 @@ export default class ThreeFishViz extends BaseViz {
                 white-space: normal;
             }
             .ch6-fish--light .ch6-fish-explain {
-                color: rgba(176, 196, 222, 0.38);
+                color: rgba(247, 241, 223, 0.42);
             }
             .ch6-fish--dark .ch6-fish-explain {
-                color: rgba(80, 100, 140, 0.45);
+                color: rgba(83, 216, 232, 0.42);
             }
 
             /* Commissure label (tracked to thread midpoint) */
@@ -655,10 +663,10 @@ export default class ThreeFishViz extends BaseViz {
                 font-style: italic;
                 font-size: 10px;
                 letter-spacing: 1px;
-                color: rgba(255, 215, 0, 0.4);
+                color: rgba(255, 227, 156, 0.46);
                 text-align: center;
                 white-space: nowrap;
-                text-shadow: 0 0 12px rgba(255, 215, 0, 0.15);
+                text-shadow: 0 0 12px rgba(255, 227, 156, 0.18);
             }
 
             /* ═══ PHASE 4 — Zodiac context ═══ */
@@ -686,12 +694,12 @@ export default class ThreeFishViz extends BaseViz {
                 pointer-events: none;
             }
             .ch6-sign-name.ch6-sign--pisces {
-                color: rgba(255, 215, 0, 0.45);
+                color: rgba(255, 227, 156, 0.52);
                 font-size: 8px;
                 letter-spacing: 3px;
             }
             .ch6-sign-name.ch6-sign--aquarius {
-                color: rgba(34, 211, 238, 0.35);
+                color: rgba(83, 216, 232, 0.44);
                 font-size: 8px;
                 letter-spacing: 3px;
             }
@@ -704,7 +712,7 @@ export default class ThreeFishViz extends BaseViz {
                 font-family: 'Cormorant Garamond', serif;
                 font-size: 9px;
                 letter-spacing: 2px;
-                color: rgba(255, 102, 0, 0.5);
+                color: rgba(204, 109, 134, 0.62);
                 text-align: center;
                 white-space: nowrap;
             }
@@ -714,7 +722,7 @@ export default class ThreeFishViz extends BaseViz {
                 font-size: 9.5px;
                 letter-spacing: 0;
                 margin-top: 3px;
-                color: rgba(255, 102, 0, 0.28);
+                color: rgba(204, 109, 134, 0.36);
                 max-width: 160px;
                 white-space: normal;
             }
@@ -841,12 +849,12 @@ export default class ThreeFishViz extends BaseViz {
             this._leaderSvg.appendChild(line);
             this._leaders[id] = line;
         };
-        makeLeader('fish-light', 'rgba(176,196,222,0.25)', 0.3);
-        makeLeader('fish-dark', 'rgba(60,80,120,0.25)', 0.3);
+        makeLeader('fish-light', 'rgba(247,241,223,0.28)', 0.34);
+        makeLeader('fish-dark', 'rgba(83,216,232,0.24)', 0.32);
         makeLeader('saturn', 'rgba(100,100,130,0.2)', 0.25);
         makeLeader('jupiter', 'rgba(212,160,48,0.2)', 0.25);
-        makeLeader('spring', 'rgba(255,102,0,0.2)', 0.25);
-        makeLeader('commissure', 'rgba(255,215,0,0.15)', 0.2);
+        makeLeader('spring', 'rgba(204,109,134,0.24)', 0.28);
+        makeLeader('commissure', 'rgba(255,227,156,0.18)', 0.22);
 
         /* ─── HTML elements ─── */
         ov.insertAdjacentHTML('beforeend', `
@@ -855,48 +863,45 @@ export default class ThreeFishViz extends BaseViz {
 
             <!-- Phase 2: Framing sentence -->
             <div class="ch6-framing" data-phase="2">
-                The birth of Christ coincided with the dawn
-                of the <em>Age of Pisces</em> — two fish,
-                swimming in opposite directions,
+                Aion reads the <em>Age of Pisces</em> as a symbolic weather system:
+                two fish, swimming in opposite directions,
                 bound by a single golden thread.<br><br>
-                <em>One fish is light. The other is shadow.</em><br>
-                Jung saw in this the eternal tension
-                between Christ and Antichrist — the
-                hostile brothers of the psyche.
+                <em>One current carries the received image. The other carries the counter-current.</em><br>
+                The chapter asks how an age can hold opposition without splitting its meaning.
             </div>
 
             <!-- Phase 3: Fish labels (tracked by JS) + commissure -->
             <div class="ch6-tracked ch6-fish-label ch6-fish--light" data-phase="3" data-track="fish-light">
-                Christ-Fish
-                <span class="ch6-fish-explain">the luminous half — what the age chose to worship</span>
+                Bright Fish
+                <span class="ch6-fish-explain">the received current of the Piscean image</span>
             </div>
             <div class="ch6-tracked ch6-fish-label ch6-fish--dark" data-phase="3" data-track="fish-dark">
-                Shadow-Fish
-                <span class="ch6-fish-explain">the dark twin — the Antichrist, denied but never absent</span>
+                Counter-Fish
+                <span class="ch6-fish-explain">the contrary current that keeps the symbol tense</span>
             </div>
             <div class="ch6-tracked ch6-commissure-label" data-phase="3" data-track="commissure">
-                the commissure — what binds the opposites
+                the commissure: what binds the opposites
             </div>
 
             <!-- Phase 4: Zodiac context -->
             <div class="ch6-zodiac-label" data-phase="4">the great year</div>
             <div class="ch6-tracked ch6-spring-label" data-phase="4" data-track="spring">
                 ◆ Spring Point
-                <span class="ch6-spring-explain">slowly precessing from Pisces toward Aquarius — marking the turn of the aeon</span>
+                <span class="ch6-spring-explain">slowly precessing from Pisces toward Aquarius: the symbolic threshold of the aeon</span>
             </div>
 
             <!-- Phase 5: Saturn + Jupiter (tracked) + lion/serpent -->
             <div class="ch6-tracked ch6-saturn-label" data-phase="5" data-track="saturn">
                 Saturn
-                <span class="ch6-saturn-explain">the "black star" — malefic father of time, orbited by lion and serpent</span>
+                <span class="ch6-saturn-explain">the dark time-marker in the chapter's astrological image field</span>
             </div>
             <div class="ch6-tracked ch6-jupiter-label" data-phase="5" data-track="jupiter">
                 Jupiter
-                <span class="ch6-jupiter-explain">life and justice — the benefic counterpart</span>
+                <span class="ch6-jupiter-explain">a bright counterpart that charges the historical sign</span>
             </div>
             <div class="ch6-tracked ch6-conjunction-label" data-phase="5" data-track="conjunction">
                 Great Conjunction
-                <span class="ch6-conjunction-explain">Saturn meets Jupiter in Pisces, ~7 BC — the Star of Bethlehem</span>
+                <span class="ch6-conjunction-explain">a charged meeting inside Pisces: history seen through symbol</span>
             </div>
             <div class="ch6-tracked ch6-orbiter-label ch6-orbiter--lion" data-phase="5" data-track="lion">
                 lion
@@ -1304,8 +1309,10 @@ export default class ThreeFishViz extends BaseViz {
 
     /* ═══ Dispose ═══ */
     dispose() {
-        removeEventListener('mousemove', this._onMM);
+        this._inputTarget?.removeEventListener?.('mousemove', this._onMM);
         if (this._overlay) this._overlay.remove();
+        this.bloom?.dispose?.();
+        this.composer?.dispose?.();
         if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
         this.scene?.traverse(o => {
             o.geometry?.dispose();


### PR DESCRIPTION
## Summary
- Refines Chapter 6 into a stronger fish/aeon astrolabe surface with a larger first-viewport instrument.
- Strengthens Pisces/Aquarius contrast, fish opposition, zodiac wheel emphasis, threshold state, and down-page panel visuals.
- Tunes the Three.js scene palette and mouse tracking/disposal while preserving the existing Ch6 route, panel, and accessibility contracts.

Skill stack:
- frontend-design, high-end-visual-design, storytelling-web, accessibility-review, webapp-testing, Aion skill-routing playbook, subagent explorer/planner/verifier lanes

Routes changed:
- `/journey/chapter/ch6`

Visual thesis:
- Piscean aeon astrolabe: two opposing fish held by one thread inside zodiacal time, with Aquarius as a slow symbolic threshold.

Browser evidence:
- Local desktop/mobile/narrow smoke at `/journey/chapter/ch6` passed with no console errors, request failures, 404s, overflow, or nav overlap.
- Screenshots captured under `/tmp/aion-ch6-polish-final/`.
- Control Tower scored `/journey/chapter/ch6` at 100% with no technical blockers and 0px mobile overflow.

Checks:
- `node --check src/visualizations/chapters/ch6/ThreeFishViz.js`
- `git diff --check`
- `npm run lint --silent`
- `npx tsc --noEmit`
- `npm run test:app --silent`
- `npm test -- --runInBand`
- `npm run validate:consistency --silent`
- `npm run ci:chapter-shell --silent`
- `npm run build --silent`
- `AION_SMOKE_PORT=4195 node scripts/testing/app-shell-smoke.mjs --shard=scene-controls`
- `AION_SMOKE_PORT=4196 node scripts/testing/app-shell-smoke.mjs --shard=mobile`
- `AION_SMOKE_PORT=4197 node scripts/testing/app-shell-smoke.mjs --shard=foundation`
- `npm run test:e2e:app --silent`
- `npm run test:a11y:app --silent`
- `npm run build:pages --silent && npm run test:pages:artifact --silent`
- `npm run test:visual:control-tower --silent`

Residual debt:
- The known large Three.js chunk warning remains unchanged.
- Push surfaced existing default-branch Dependabot vulnerability alerts; this PR does not alter dependencies.
