### PR TITLE
feat: refine chapter eight historical fish atlas

### DIFF
--- a/src/app/components/ChapterEightHistoricalField.css
+++ b/src/app/components/ChapterEightHistoricalField.css
@@ -1,21 +1,22 @@
 .chapter-experience[data-chapter-id="ch8"] .chapter-eight-history .historical-strata-instrument {
   position: relative;
   width: 100%;
-  min-height: clamp(8.05rem, 13.6vh, 9.45rem);
+  min-height: clamp(8.7rem, 15.2vh, 10.45rem);
   overflow: hidden;
   margin: 0;
-  border: 1px solid rgba(255, 227, 156, 0.13);
+  border: 1px solid rgba(255, 227, 156, 0.17);
   border-radius: calc(var(--radius) - 0.12rem);
   background:
-    radial-gradient(circle at 18% 45%, rgba(225, 182, 79, 0.32), transparent 5.4rem),
-    radial-gradient(circle at 50% 43%, rgba(130, 226, 165, 0.22), transparent 6rem),
-    radial-gradient(circle at 83% 56%, rgba(83, 216, 232, 0.22), transparent 6rem),
-    repeating-linear-gradient(0deg, rgba(255, 227, 156, 0.07) 0 1px, transparent 1px 0.62rem),
-    linear-gradient(90deg, rgba(9, 7, 7, 0.9), rgba(5, 14, 14, 0.72) 53%, rgba(2, 14, 20, 0.62));
+    radial-gradient(circle at 17% 46%, rgba(237, 189, 104, 0.42), transparent 5.9rem),
+    radial-gradient(circle at 50% 43%, rgba(143, 233, 178, 0.27), transparent 6.2rem),
+    radial-gradient(circle at 84% 57%, rgba(110, 231, 242, 0.28), transparent 6.5rem),
+    repeating-linear-gradient(0deg, rgba(255, 232, 177, 0.085) 0 1px, transparent 1px 0.56rem),
+    repeating-linear-gradient(90deg, rgba(244, 240, 232, 0.032) 0 1px, transparent 1px 2.2rem),
+    linear-gradient(90deg, rgba(10, 7, 6, 0.94), rgba(5, 16, 14, 0.78) 52%, rgba(2, 15, 22, 0.66));
   box-shadow:
     var(--shadow-inset),
-    0 1.4rem 4rem rgba(0, 0, 0, 0.24),
-    0 0 2.8rem rgba(83, 216, 232, 0.08);
+    0 1.55rem 4.4rem rgba(0, 0, 0, 0.3),
+    0 0 3.2rem rgba(110, 231, 242, 0.11);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-eight-history .historical-strata-instrument::before,
@@ -27,23 +28,23 @@
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-eight-history .historical-strata-instrument::before {
   inset: 0.6rem;
-  border: 1px solid rgba(255, 227, 156, 0.1);
+  border: 1px solid rgba(255, 227, 156, 0.13);
   border-radius: calc(var(--radius) - 0.35rem);
   background:
-    linear-gradient(90deg, rgba(255, 227, 156, 0.035), transparent 45%, rgba(83, 216, 232, 0.04)),
-    repeating-linear-gradient(0deg, transparent 0 0.82rem, rgba(244, 240, 232, 0.024) 0.86rem 0.88rem);
+    linear-gradient(90deg, rgba(255, 232, 177, 0.052), transparent 45%, rgba(110, 231, 242, 0.055)),
+    repeating-linear-gradient(0deg, transparent 0 0.76rem, rgba(244, 240, 232, 0.032) 0.8rem 0.82rem);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .chapter-eight-history .historical-strata-instrument::after {
   left: 56%;
   top: 51%;
-  width: 10.8rem;
-  height: 5.65rem;
-  border: 1px solid rgba(143, 231, 237, 0.26);
+  width: 11.65rem;
+  height: 6.05rem;
+  border: 1px solid rgba(143, 231, 237, 0.34);
   border-radius: 50%;
   box-shadow:
-    inset 0 0 1.55rem rgba(83, 216, 232, 0.16),
-    0 0 2.15rem rgba(225, 182, 79, 0.12);
+    inset 0 0 1.8rem rgba(110, 231, 242, 0.2),
+    0 0 2.4rem rgba(237, 189, 104, 0.16);
   transform: translate(-50%, -50%) rotate(-9deg);
 }
 
@@ -64,7 +65,7 @@
 .chapter-eight-history__grain {
   inset: 0;
   z-index: 1;
-  opacity: 0.42;
+  opacity: 0.5;
   background:
     radial-gradient(circle at 18% 32%, rgba(255, 255, 255, 0.12) 0 1px, transparent 1.5px),
     radial-gradient(circle at 62% 62%, rgba(255, 255, 255, 0.1) 0 1px, transparent 1.5px),
@@ -78,8 +79,8 @@
   right: 12%;
   z-index: 1;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.22), rgba(83, 216, 232, 0.18), transparent);
-  opacity: 0.74;
+  background: linear-gradient(90deg, transparent, rgba(255, 232, 177, 0.28), rgba(110, 231, 242, 0.23), transparent);
+  opacity: 0.8;
 }
 
 .chapter-eight-history__archive-line--one {
@@ -95,13 +96,15 @@
 }
 
 .chapter-eight-history__source-orb {
-  top: 19%;
+  top: 19.5%;
   z-index: 1;
-  width: 0.42rem;
+  width: 0.48rem;
   aspect-ratio: 1;
   border-radius: 50%;
-  opacity: 0.78;
-  box-shadow: 0 0 1.1rem currentColor;
+  opacity: 0.9;
+  box-shadow:
+    0 0 0 0.35rem color-mix(in srgb, currentColor 12%, transparent),
+    0 0 1.3rem currentColor;
 }
 
 .chapter-eight-history__source-orb--gold {
@@ -128,10 +131,10 @@
   z-index: 1;
   width: 66%;
   height: 3.8rem;
-  border-bottom: 1px solid rgba(83, 216, 232, 0.18);
-  border-left: 1px solid rgba(225, 182, 79, 0.18);
+  border-bottom: 1px solid rgba(110, 231, 242, 0.26);
+  border-left: 1px solid rgba(237, 189, 104, 0.24);
   border-radius: 0 0 50% 50%;
-  opacity: 0.7;
+  opacity: 0.8;
   transform: rotate(7deg);
 }
 
@@ -139,7 +142,7 @@
   top: 0;
   bottom: 0;
   width: 50%;
-  opacity: 0.6;
+  opacity: 0.66;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -148,15 +151,15 @@
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__field--archive {
   left: 0;
   background:
-    radial-gradient(circle at 42% 44%, rgba(225, 182, 79, 0.18), transparent 4.5rem),
-    linear-gradient(90deg, rgba(225, 182, 79, 0.09), transparent);
+    radial-gradient(circle at 42% 44%, rgba(237, 189, 104, 0.23), transparent 4.8rem),
+    linear-gradient(90deg, rgba(237, 189, 104, 0.12), transparent);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__field--afterlife {
   right: 0;
   background:
-    radial-gradient(circle at 63% 51%, rgba(83, 216, 232, 0.17), transparent 4.8rem),
-    linear-gradient(270deg, rgba(83, 216, 232, 0.09), transparent);
+    radial-gradient(circle at 63% 51%, rgba(110, 231, 242, 0.22), transparent 5.1rem),
+    linear-gradient(270deg, rgba(110, 231, 242, 0.12), transparent);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__axis {
@@ -164,8 +167,8 @@
   right: 8%;
   top: 56%;
   height: 1px;
-  background: linear-gradient(90deg, rgba(225, 182, 79, 0.18), rgba(244, 240, 232, 0.58), rgba(83, 216, 232, 0.22));
-  opacity: 0.78;
+  background: linear-gradient(90deg, rgba(237, 189, 104, 0.24), rgba(244, 240, 232, 0.68), rgba(110, 231, 242, 0.3));
+  opacity: 0.86;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring);
@@ -177,10 +180,10 @@
   height: 0.52rem;
   border-radius: 999px;
   background:
-    linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.34), rgba(130, 226, 165, 0.29), rgba(83, 216, 232, 0.3), transparent);
-  border-top: 1px solid rgba(244, 240, 232, 0.14);
-  box-shadow: 0 0 1.25rem rgba(83, 216, 232, 0.1);
-  opacity: 0.72;
+    linear-gradient(90deg, transparent, rgba(255, 232, 177, 0.46), rgba(143, 233, 178, 0.34), rgba(110, 231, 242, 0.38), transparent);
+  border-top: 1px solid rgba(244, 240, 232, 0.18);
+  box-shadow: 0 0 1.45rem rgba(110, 231, 242, 0.13);
+  opacity: 0.8;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
@@ -208,12 +211,12 @@
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment {
-  width: 0.6rem;
+  width: 0.68rem;
   aspect-ratio: 1;
   border-radius: 50%;
-  background: rgba(255, 227, 156, 0.74);
-  box-shadow: 0 0 0.95rem rgba(225, 182, 79, 0.26);
-  opacity: 0.88;
+  background: rgba(255, 232, 177, 0.84);
+  box-shadow: 0 0 1.15rem rgba(237, 189, 104, 0.34);
+  opacity: 0.94;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
@@ -228,30 +231,30 @@
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment--two {
   left: 35%;
   top: 52%;
-  background: rgba(130, 226, 165, 0.68);
+  background: rgba(143, 233, 178, 0.78);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__sediment--three {
   left: 70%;
   top: 43%;
-  background: rgba(143, 231, 237, 0.68);
+  background: rgba(143, 231, 237, 0.78);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__fish {
   left: 49%;
   top: 48%;
-  width: 5rem;
-  height: 1.52rem;
-  border-top: 1px solid rgba(255, 227, 156, 0.74);
-  border-bottom: 1px solid rgba(143, 231, 237, 0.58);
+  width: 5.35rem;
+  height: 1.62rem;
+  border-top: 1px solid rgba(255, 232, 177, 0.86);
+  border-bottom: 1px solid rgba(143, 231, 237, 0.72);
   border-radius: 50%;
   background:
-    radial-gradient(circle at 31% 50%, rgba(255, 227, 156, 0.7) 0 0.17rem, transparent 0.19rem),
-    radial-gradient(ellipse at 50% 50%, rgba(83, 216, 232, 0.16), transparent 66%);
+    radial-gradient(circle at 31% 50%, rgba(255, 232, 177, 0.86) 0 0.18rem, transparent 0.2rem),
+    radial-gradient(ellipse at 50% 50%, rgba(110, 231, 242, 0.22), transparent 66%);
   box-shadow:
-    0 0 1.55rem rgba(83, 216, 232, 0.2),
-    0 0 1.3rem rgba(225, 182, 79, 0.13);
-  opacity: 0.94;
+    0 0 1.85rem rgba(110, 231, 242, 0.26),
+    0 0 1.55rem rgba(237, 189, 104, 0.17);
+  opacity: 1;
   transform: translate(-50%, -50%) rotate(-8deg);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -276,9 +279,9 @@
   top: 49%;
   width: 1px;
   height: 5rem;
-  background: linear-gradient(180deg, transparent, rgba(255, 227, 156, 0.74), rgba(130, 226, 165, 0.3), transparent);
-  box-shadow: 0 0 1.35rem rgba(225, 182, 79, 0.28);
-  opacity: 0.64;
+  background: linear-gradient(180deg, transparent, rgba(255, 232, 177, 0.84), rgba(143, 233, 178, 0.36), transparent);
+  box-shadow: 0 0 1.55rem rgba(237, 189, 104, 0.34);
+  opacity: 0.72;
   transform: translate(-50%, -50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -293,7 +296,7 @@
   top: 35%;
   width: 2.55rem;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(255, 227, 156, 0.6), transparent);
+  background: linear-gradient(90deg, transparent, rgba(255, 232, 177, 0.72), transparent);
   transform: translateX(-50%);
 }
 
@@ -303,7 +306,7 @@
   width: 8.5rem;
   height: 4.05rem;
   border-radius: 50%;
-  opacity: 0.48;
+  opacity: 0.58;
   transition:
     border-color 0.55s var(--motion-spring),
     opacity 0.55s var(--motion-spring),
@@ -311,29 +314,31 @@
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread--descent {
-  border-top: 1px solid rgba(255, 227, 156, 0.32);
-  border-left: 1px solid rgba(255, 227, 156, 0.2);
+  border-top: 1px solid rgba(255, 232, 177, 0.42);
+  border-left: 1px solid rgba(255, 232, 177, 0.24);
   transform: translate(-50%, -50%) rotate(-11deg);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__thread--return {
-  border-bottom: 1px solid rgba(143, 231, 237, 0.35);
-  border-right: 1px solid rgba(130, 226, 165, 0.24);
+  border-bottom: 1px solid rgba(143, 231, 237, 0.44);
+  border-right: 1px solid rgba(143, 233, 178, 0.28);
   transform: translate(-50%, -50%) rotate(15deg);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__depth {
   right: 8%;
   top: 50%;
-  width: 4rem;
-  height: 2.55rem;
-  border: 1px solid rgba(143, 231, 237, 0.28);
+  width: 4.25rem;
+  height: 2.7rem;
+  border: 1px solid rgba(143, 231, 237, 0.36);
   border-radius: 50%;
   background:
-    radial-gradient(circle at 44% 50%, rgba(83, 216, 232, 0.22), transparent 66%),
-    linear-gradient(130deg, transparent 48%, rgba(83, 216, 232, 0.3) 49%, transparent 51%);
-  box-shadow: inset 0 0 1.35rem rgba(83, 216, 232, 0.13);
-  opacity: 0.7;
+    radial-gradient(circle at 44% 50%, rgba(110, 231, 242, 0.28), transparent 66%),
+    linear-gradient(130deg, transparent 48%, rgba(110, 231, 242, 0.36) 49%, transparent 51%);
+  box-shadow:
+    inset 0 0 1.55rem rgba(110, 231, 242, 0.16),
+    0 0 1.45rem rgba(110, 231, 242, 0.12);
+  opacity: 0.78;
   transform: translateY(-50%) rotate(-9deg);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -343,7 +348,7 @@
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label {
   z-index: 3;
-  color: rgba(244, 240, 232, 0.82);
+  color: rgba(244, 240, 232, 0.86);
   font-family: var(--font-ui);
   font-size: 0.58rem;
   font-weight: 800;
@@ -353,31 +358,36 @@
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--strata {
   left: 7%;
   top: 13%;
-  color: rgba(255, 227, 156, 0.95);
+  color: rgba(255, 232, 177, 0.96);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--carrier {
   left: 47%;
   top: 13%;
-  color: rgba(159, 238, 186, 0.95);
+  color: rgba(169, 248, 198, 0.96);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument__label--afterlife {
   right: 5%;
   top: 13%;
-  color: rgba(143, 231, 237, 0.96);
+  color: rgba(156, 239, 247, 0.97);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="strata"] .historical-strata-instrument__layer,
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="strata"] .historical-strata-instrument__sediment {
   opacity: 1;
   transform: translateY(-0.1rem);
-  box-shadow: 0 0 1.45rem rgba(225, 182, 79, 0.22);
+  box-shadow:
+    0 0 1.55rem rgba(237, 189, 104, 0.28),
+    0 0 0.6rem rgba(255, 232, 177, 0.12);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="strata"] .historical-strata-instrument__fish {
   opacity: 1;
-  transform: translate(-50%, -50%) rotate(-8deg) scale(1.08);
+  transform: translate(-50%, -50%) rotate(-8deg) scale(1.12);
+  box-shadow:
+    0 0 2.05rem rgba(110, 231, 242, 0.28),
+    0 0 1.8rem rgba(237, 189, 104, 0.22);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="christian"] .historical-strata-instrument__carrier,
@@ -393,7 +403,7 @@
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="christian"] .historical-strata-instrument__fish {
   border-top-color: rgba(255, 227, 156, 0.86);
   border-bottom-color: rgba(130, 226, 165, 0.7);
-  box-shadow: 0 0 1.85rem rgba(130, 226, 165, 0.25), 0 0 1.25rem rgba(225, 182, 79, 0.12);
+  box-shadow: 0 0 2.05rem rgba(143, 233, 178, 0.3), 0 0 1.42rem rgba(237, 189, 104, 0.16);
   opacity: 1;
 }
 
@@ -404,14 +414,14 @@
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__field--afterlife {
-  opacity: 0.95;
+  opacity: 1;
   transform: scaleX(1.06);
 }
 
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__depth,
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__thread--return {
   opacity: 1;
-  box-shadow: 0 0 1.72rem rgba(83, 216, 232, 0.22);
+  box-shadow: 0 0 1.95rem rgba(110, 231, 242, 0.28);
   transform: translateY(-50%) rotate(-9deg) scale(1.12);
 }
 
@@ -423,12 +433,12 @@
 .chapter-experience[data-chapter-id="ch8"] .historical-strata-instrument[data-active-panel="modern"] .historical-strata-instrument__layer--5 {
   opacity: 1;
   transform: translateY(0.06rem) scaleX(1.05);
-  box-shadow: 0 0 1.35rem rgba(83, 216, 232, 0.18);
+  box-shadow: 0 0 1.55rem rgba(110, 231, 242, 0.22);
 }
 
 @media (max-width: 720px) {
   .chapter-experience[data-chapter-id="ch8"] .chapter-eight-history .historical-strata-instrument {
-    min-height: 6.9rem;
+    min-height: 7.45rem;
     margin: 0;
   }
 

--- a/src/app/components/ChapterEightHistoricalInstrument.css
+++ b/src/app/components/ChapterEightHistoricalInstrument.css
@@ -1,20 +1,24 @@
 .chapter-eight-history {
-  --ch8-strata: #e1b64f;
-  --ch8-carrier: #82e2a5;
-  --ch8-afterlife: #53d8e8;
+  --ch8-strata: #edbd68;
+  --ch8-carrier: #8fe9b2;
+  --ch8-afterlife: #6ee7f2;
   position: relative;
-  width: min(31.5rem, 100%);
+  width: min(34rem, 100%);
   margin-top: 0.92rem;
-  padding: 0.36rem;
+  padding: 0.42rem;
   overflow: hidden;
-  border: 1px solid rgba(244, 240, 232, 0.14);
+  border: 1px solid rgba(244, 240, 232, 0.17);
   border-radius: calc(var(--radius) + 0.22rem);
   background:
-    radial-gradient(circle at 18% 0%, rgba(225, 182, 79, 0.15), transparent 7.4rem),
-    radial-gradient(circle at 57% 7%, rgba(130, 226, 165, 0.12), transparent 8rem),
-    radial-gradient(circle at 94% 13%, rgba(83, 216, 232, 0.13), transparent 7rem),
-    linear-gradient(180deg, rgba(244, 240, 232, 0.056), rgba(244, 240, 232, 0.014));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.075), 0 1.6rem 4.8rem rgba(0, 0, 0, 0.25);
+    radial-gradient(circle at 18% 2%, rgba(237, 189, 104, 0.2), transparent 7.8rem),
+    radial-gradient(circle at 55% 4%, rgba(143, 233, 178, 0.15), transparent 8.2rem),
+    radial-gradient(circle at 96% 14%, rgba(110, 231, 242, 0.16), transparent 7.4rem),
+    linear-gradient(180deg, rgba(244, 240, 232, 0.07), rgba(244, 240, 232, 0.016));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.09),
+    inset 0 -1px 0 rgba(244, 240, 232, 0.035),
+    0 1.8rem 5.4rem rgba(0, 0, 0, 0.3),
+    0 0 4.2rem rgba(110, 231, 242, 0.08);
 }
 
 .chapter-eight-history::before {
@@ -24,8 +28,8 @@
   pointer-events: none;
   opacity: 0.52;
   background:
-    linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.065), transparent),
-    repeating-linear-gradient(90deg, transparent 0 2.45rem, rgba(244, 240, 232, 0.035) 2.49rem 2.53rem);
+    linear-gradient(90deg, transparent, rgba(244, 240, 232, 0.075), transparent),
+    repeating-linear-gradient(90deg, transparent 0 2.3rem, rgba(244, 240, 232, 0.04) 2.34rem 2.39rem);
   mask-image: linear-gradient(180deg, #000, transparent 76%);
 }
 
@@ -39,9 +43,9 @@
 
 .chapter-eight-history__header {
   position: absolute;
-  top: 0.62rem;
-  left: 0.72rem;
-  right: 0.72rem;
+  top: 0.68rem;
+  left: 0.8rem;
+  right: 0.8rem;
   z-index: 4;
   display: grid;
   grid-template-columns: 1fr auto;
@@ -68,7 +72,7 @@
 .chapter-eight-history__header strong {
   color: rgba(244, 240, 232, 0.94);
   font-family: var(--font-display);
-  font-size: 1rem;
+  font-size: 1.08rem;
   font-weight: 650;
   line-height: 0.95;
 }
@@ -87,15 +91,18 @@
 }
 
 .chapter-eight-history__plate {
-  padding: 0.3rem;
+  padding: 0.34rem;
   overflow: hidden;
-  border: 1px solid rgba(244, 240, 232, 0.08);
+  border: 1px solid rgba(244, 240, 232, 0.11);
   border-radius: calc(var(--radius) - 0.02rem);
   background:
-    radial-gradient(circle at 24% 36%, rgba(225, 182, 79, 0.12), transparent 6.4rem),
-    radial-gradient(circle at 70% 50%, rgba(83, 216, 232, 0.12), transparent 7rem),
-    linear-gradient(180deg, rgba(4, 8, 10, 0.74), rgba(3, 4, 7, 0.5));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), inset 0 -1px 0 rgba(244, 240, 232, 0.035);
+    radial-gradient(circle at 21% 39%, rgba(237, 189, 104, 0.16), transparent 6.8rem),
+    radial-gradient(circle at 53% 50%, rgba(143, 233, 178, 0.08), transparent 6rem),
+    radial-gradient(circle at 76% 51%, rgba(110, 231, 242, 0.15), transparent 7.4rem),
+    linear-gradient(180deg, rgba(4, 8, 10, 0.84), rgba(3, 4, 7, 0.55));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    inset 0 -1px 0 rgba(244, 240, 232, 0.045);
 }
 
 .chapter-eight-history__legend {
@@ -118,12 +125,12 @@
   gap: 0.1rem;
   min-height: 2.36rem;
   padding: 0.38rem 0.46rem;
-  border: 1px solid rgba(244, 240, 232, 0.08);
+  border: 1px solid rgba(244, 240, 232, 0.095);
   border-radius: calc(var(--radius) - 0.28rem);
   background:
     radial-gradient(circle at 22% 18%, rgba(225, 182, 79, 0.11), transparent 2.4rem),
     linear-gradient(180deg, rgba(244, 240, 232, 0.045), rgba(244, 240, 232, 0.015));
-  opacity: 0.64;
+  opacity: 0.68;
   transition:
     opacity 0.48s var(--motion-spring),
     border-color 0.48s var(--motion-spring),
@@ -147,12 +154,12 @@
 }
 
 .chapter-eight-history__step--active {
-  border-color: color-mix(in srgb, var(--ch8-strata) 48%, rgba(244, 240, 232, 0.12));
+  border-color: color-mix(in srgb, var(--ch8-strata) 58%, rgba(244, 240, 232, 0.14));
   background:
     radial-gradient(circle at 28% 16%, rgba(225, 182, 79, 0.18), transparent 2.8rem),
     linear-gradient(180deg, rgba(255, 227, 156, 0.08), rgba(244, 240, 232, 0.02));
   opacity: 1;
-  transform: translateY(-0.04rem);
+  transform: translateY(-0.06rem);
 }
 
 .chapter-eight-history[data-active-panel="christian"] .chapter-eight-history__step--active {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -10461,6 +10461,217 @@ h3 {
   height: 0.78rem;
 }
 
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__symbol {
+  border-color: rgba(237, 189, 104, 0.15);
+  background:
+    radial-gradient(circle at 30% 56%, rgba(237, 189, 104, 0.16), transparent 5.5rem),
+    radial-gradient(circle at 53% 50%, rgba(143, 233, 178, 0.1), transparent 5.8rem),
+    radial-gradient(circle at 76% 55%, rgba(110, 231, 242, 0.13), transparent 6rem),
+    repeating-linear-gradient(0deg, rgba(244, 240, 232, 0.026) 0 1px, transparent 1px 1.55rem),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.048), rgba(255, 255, 255, 0.013));
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__symbol::before {
+  inset: 18% 11%;
+  border-color: rgba(244, 240, 232, 0.1);
+  border-radius: 48%;
+  box-shadow:
+    inset 0 0 4.8rem rgba(110, 231, 242, 0.07),
+    inset 0 0 3rem rgba(237, 189, 104, 0.04);
+  transform: rotate(-8deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__symbol::after {
+  left: 36%;
+  top: 58%;
+  width: 0.78rem;
+  height: 0.78rem;
+  background: rgba(255, 232, 177, 0.96);
+  box-shadow:
+    0 0 0 0.48rem rgba(237, 189, 104, 0.1),
+    0 0 1.85rem rgba(237, 189, 104, 0.62),
+    6.2rem -0.65rem 2rem rgba(143, 233, 178, 0.3),
+    10.1rem -0.05rem 2.2rem rgba(110, 231, 242, 0.24);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__ring,
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__axis,
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__spark,
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__depth,
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__quaternity-point,
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__mandala-band {
+  display: block;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__ring--outer {
+  width: 78%;
+  aspect-ratio: 1.9 / 1;
+  border-color: rgba(237, 189, 104, 0.18);
+  transform: translate(-50%, -50%) rotate(-7deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__ring--inner {
+  width: 48%;
+  aspect-ratio: 1.9 / 1;
+  border-color: rgba(110, 231, 242, 0.16);
+  transform: translate(-50%, -50%) rotate(-7deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__axis--horizontal {
+  top: 58%;
+  width: 74%;
+  background: linear-gradient(90deg, rgba(237, 189, 104, 0.16), rgba(244, 240, 232, 0.48), rgba(110, 231, 242, 0.22));
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__axis--vertical {
+  left: 56%;
+  height: 62%;
+  background: linear-gradient(180deg, transparent, rgba(255, 232, 177, 0.42), rgba(143, 233, 178, 0.2), transparent);
+  box-shadow: 0 0 1.2rem rgba(237, 189, 104, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__spark--one {
+  left: 33%;
+  top: 58%;
+  background: rgba(255, 232, 177, 0.96);
+  box-shadow: 0 0 1.45rem rgba(237, 189, 104, 0.68);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__spark--two {
+  right: 26%;
+  top: 52%;
+  background: rgba(110, 231, 242, 0.94);
+  box-shadow: 0 0 1.45rem rgba(110, 231, 242, 0.66);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__depth--one {
+  left: 57%;
+  top: 50%;
+  width: 42%;
+  height: 28%;
+  border: 1px solid rgba(143, 233, 178, 0.22);
+  border-top-color: rgba(237, 189, 104, 0.26);
+  border-bottom-color: rgba(110, 231, 242, 0.26);
+  border-radius: 50%;
+  background: transparent;
+  transform: translateX(-50%) rotate(-11deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__depth--two {
+  left: 71%;
+  top: 51%;
+  width: 28%;
+  height: 26%;
+  border-color: rgba(110, 231, 242, 0.2);
+  transform: translateX(-50%) rotate(-7deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__quaternity-point {
+  width: 0.5rem;
+  height: 0.5rem;
+  background: rgba(169, 248, 198, 0.92);
+  box-shadow: 0 0 1.2rem rgba(143, 233, 178, 0.58);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__quaternity-point--north {
+  left: 42%;
+  top: 38%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__quaternity-point--east {
+  left: 55%;
+  top: 47%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__quaternity-point--south {
+  left: 67%;
+  top: 59%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel__quaternity-point--west {
+  left: 30%;
+  top: 61%;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="strata"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 30% 58%, rgba(237, 189, 104, 0.2), transparent 5.4rem),
+    radial-gradient(circle at 57% 52%, rgba(143, 233, 178, 0.11), transparent 5rem),
+    radial-gradient(circle at 80% 56%, rgba(110, 231, 242, 0.1), transparent 5.2rem),
+    repeating-linear-gradient(0deg, rgba(255, 232, 177, 0.04) 0 1px, transparent 1px 1.2rem),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.052), rgba(255, 255, 255, 0.014));
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="strata"] .chapter-panel__ring {
+  aspect-ratio: 2.4 / 1;
+  transform: translate(-50%, -50%) rotate(-4deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="strata"] .chapter-panel__quaternity-point {
+  opacity: 0.9;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="christian"] .chapter-panel__axis--vertical {
+  left: 52%;
+  height: 76%;
+  background: linear-gradient(180deg, transparent, rgba(255, 232, 177, 0.56), rgba(143, 233, 178, 0.28), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="christian"] .chapter-panel__axis--horizontal {
+  top: 48%;
+  width: 42%;
+  background: linear-gradient(90deg, transparent, rgba(255, 232, 177, 0.5), transparent);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="christian"] .chapter-panel__depth--one {
+  width: 36%;
+  height: 22%;
+  border-color: rgba(255, 232, 177, 0.3);
+  border-bottom-color: rgba(143, 233, 178, 0.3);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="modern"] .chapter-panel__symbol {
+  background:
+    radial-gradient(circle at 76% 54%, rgba(110, 231, 242, 0.2), transparent 5.8rem),
+    radial-gradient(circle at 35% 56%, rgba(237, 189, 104, 0.1), transparent 5.2rem),
+    radial-gradient(circle at 56% 46%, rgba(143, 233, 178, 0.09), transparent 5.6rem),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.052), rgba(255, 255, 255, 0.014));
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="modern"] .chapter-panel__ring--outer,
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="modern"] .chapter-panel__ring--inner {
+  left: 70%;
+  border-color: rgba(110, 231, 242, 0.22);
+  transform: translate(-50%, -50%) rotate(-12deg);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="modern"] .chapter-panel__ring--outer {
+  width: 42%;
+  aspect-ratio: 0.9 / 1;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="modern"] .chapter-panel__ring--inner {
+  width: 26%;
+  aspect-ratio: 0.9 / 1;
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="modern"] .chapter-panel__axis--vertical {
+  left: 70%;
+  height: 78%;
+  background: linear-gradient(180deg, transparent, rgba(110, 231, 242, 0.52), rgba(237, 189, 104, 0.16), transparent);
+  box-shadow: 0 0 1.35rem rgba(110, 231, 242, 0.18);
+}
+
+.chapter-experience[data-chapter-id="ch8"] .chapter-panel[data-panel-id="modern"] .chapter-panel__spark--two {
+  right: 29%;
+  top: 52%;
+  width: 0.78rem;
+  height: 0.78rem;
+  box-shadow:
+    0 0 0 0.4rem rgba(110, 231, 242, 0.08),
+    0 0 1.8rem rgba(110, 231, 242, 0.72);
+}
+
 .chapter-experience[data-chapter-id="ch1"] .chapter-panels {
   width: min(1260px, calc(100% - 2rem));
   gap: 10vh;

--- a/src/visualizations/chapters/ch8/ThreeHistoricalViz.js
+++ b/src/visualizations/chapters/ch8/ThreeHistoricalViz.js
@@ -22,19 +22,18 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
 
 /* ── Palette (true black base) ── */
-const STAR_GOLD = new THREE.Color('#ffd700');
-const WOMAN_WHITE = new THREE.Color('#f0f0ff');
-const DRAGON_RED = new THREE.Color('#8b0000');
+const STAR_GOLD = new THREE.Color('#edbd68');
+const WOMAN_WHITE = new THREE.Color('#f4f0e8');
+const DRAGON_RED = new THREE.Color('#7b2438');
 const HOOK_SILVER = new THREE.Color('#c0c0c8');
-const FISH_CYAN = new THREE.Color('#22d3ee');
-const HEAL_GREEN = new THREE.Color('#32cd32');
-const ARIES_RED = new THREE.Color('#ff4444');
-const PISCES_BLUE = new THREE.Color('#4a90d9');
-const WATER_DARK = new THREE.Color('#050505');
-const VOID = 0x000000;
-const STRATA_GOLD = new THREE.Color('#d4af37');
-const STRATA_GREEN = new THREE.Color('#5bd68f');
-const STRATA_CYAN = new THREE.Color('#53d8e8');
+const FISH_CYAN = new THREE.Color('#6ee7f2');
+const HEAL_GREEN = new THREE.Color('#8fe9b2');
+const ARIES_RED = new THREE.Color('#d46254');
+const PISCES_BLUE = new THREE.Color('#6ee7f2');
+const VOID = 0x03040a;
+const STRATA_GOLD = new THREE.Color('#edbd68');
+const STRATA_GREEN = new THREE.Color('#8fe9b2');
+const STRATA_CYAN = new THREE.Color('#6ee7f2');
 
 /* ── Scene boundaries ── */
 const S1_END = 0.20;
@@ -80,25 +79,31 @@ export default class ThreeHistoricalViz extends BaseViz {
             canvas: this.canvas, antialias: true, alpha: false,
             powerPreference: 'high-performance',
         });
-        R.setPixelRatio(Math.min(devicePixelRatio, 2));
+        R.setPixelRatio(Math.min(globalThis.devicePixelRatio || 1, 2));
         R.setSize(this.width, this.height);
         R.setClearColor(VOID);
         R.toneMapping = THREE.ACESFilmicToneMapping;
-        R.toneMappingExposure = 1.1;
+        R.toneMappingExposure = 1.18;
 
         this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.FogExp2(VOID, 0.008);
-        this.camera = new THREE.PerspectiveCamera(55, this.width / this.height, 0.1, 200);
-        this.camera.position.set(0, 4, 16);
+        this.scene.fog = new THREE.FogExp2(VOID, 0.0058);
+        this.camera = new THREE.PerspectiveCamera(50, this.width / this.height, 0.1, 200);
+        this.camera.position.set(0, 3.8, 15.5);
 
         /* ── Mouse tracking ── */
         this.mouse = new THREE.Vector2();
         this.mouseSmooth = new THREE.Vector2();
+        this._inputTarget = this.canvas?.parentElement || this.container || this.canvas || globalThis;
         this._onMM = e => {
-            this.mouse.x = (e.clientX / innerWidth) * 2 - 1;
-            this.mouse.y = -(e.clientY / innerHeight) * 2 + 1;
+            const bounds = this._inputTarget === globalThis ? null : this._inputTarget?.getBoundingClientRect?.();
+            const width = bounds?.width || globalThis.innerWidth || 1;
+            const height = bounds?.height || globalThis.innerHeight || 1;
+            const left = bounds?.left || 0;
+            const top = bounds?.top || 0;
+            this.mouse.x = ((e.clientX - left) / width) * 2 - 1;
+            this.mouse.y = -((e.clientY - top) / height) * 2 + 1;
         };
-        addEventListener('mousemove', this._onMM);
+        this._inputTarget?.addEventListener?.('mousemove', this._onMM, { passive: true });
 
         /* The React chapter shell owns scroll. This scene receives panel state
            and maps it to the historical-symbol descent internally. */
@@ -117,7 +122,7 @@ export default class ThreeHistoricalViz extends BaseViz {
         this.composer = new EffectComposer(R);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloom = new UnrealBloomPass(
-            new THREE.Vector2(this.width, this.height), 1.2, 0.5, 0.35
+            new THREE.Vector2(this.width, this.height), 1.34, 0.58, 0.26
         );
         this.composer.addPass(this.bloom);
     }
@@ -557,7 +562,7 @@ export default class ThreeHistoricalViz extends BaseViz {
        ═══════════════════════════════════════════════════════════════ */
     _buildHistoricalAtlas() {
         this._atlas = new THREE.Group();
-        this._atlas.position.set(0.6, 0.4, -4.8);
+        this._atlas.position.set(0.75, 0.44, -4.55);
         this._atlas.renderOrder = -1;
         this._atlasBands = [];
         this._atlasNodes = [];
@@ -567,7 +572,7 @@ export default class ThreeHistoricalViz extends BaseViz {
         bandY.forEach((y, index) => {
             const width = 12.6 - index * 0.42;
             const color = index < 3 ? STRATA_GOLD : index < 6 ? STRATA_GREEN : STRATA_CYAN;
-            const opacity = index < 3 ? 0.12 : index < 6 ? 0.1 : 0.09;
+            const opacity = index < 3 ? 0.18 : index < 6 ? 0.15 : 0.14;
 
             const line = new THREE.Line(
                 new THREE.BufferGeometry().setFromPoints([
@@ -590,7 +595,7 @@ export default class ThreeHistoricalViz extends BaseViz {
                 new THREE.MeshBasicMaterial({
                     color,
                     transparent: true,
-                    opacity: opacity * 0.15,
+                    opacity: opacity * 0.22,
                     blending: THREE.AdditiveBlending,
                     depthWrite: false,
                     side: THREE.DoubleSide,
@@ -616,7 +621,7 @@ export default class ThreeHistoricalViz extends BaseViz {
                 new THREE.MeshBasicMaterial({
                     color: node.color,
                     transparent: true,
-                    opacity: 0.7,
+                    opacity: 0.86,
                     blending: THREE.AdditiveBlending,
                     depthWrite: false,
                 })
@@ -640,7 +645,7 @@ export default class ThreeHistoricalViz extends BaseViz {
             new THREE.LineBasicMaterial({
                 color: STRATA_CYAN,
                 transparent: true,
-                opacity: 0.2,
+                opacity: 0.32,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
             })
@@ -659,7 +664,7 @@ export default class ThreeHistoricalViz extends BaseViz {
             new THREE.LineBasicMaterial({
                 color: STRATA_GOLD,
                 transparent: true,
-                opacity: 0.14,
+                opacity: 0.22,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
             })
@@ -673,7 +678,7 @@ export default class ThreeHistoricalViz extends BaseViz {
             new THREE.MeshBasicMaterial({
                 color: STRATA_CYAN,
                 transparent: true,
-                opacity: 0.16,
+                opacity: 0.24,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
             })
@@ -692,7 +697,7 @@ export default class ThreeHistoricalViz extends BaseViz {
             new THREE.MeshBasicMaterial({
                 color: STRATA_GOLD,
                 transparent: true,
-                opacity: 0.18,
+                opacity: 0.24,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
                 side: THREE.DoubleSide,
@@ -704,11 +709,11 @@ export default class ThreeHistoricalViz extends BaseViz {
         this._atlas.add(this._atlasFish);
 
         this._afterlifeEcho = new THREE.Mesh(
-            new THREE.TorusGeometry(2.35, 0.018, 8, 96),
+            new THREE.TorusGeometry(2.35, 0.024, 8, 96),
             new THREE.MeshBasicMaterial({
                 color: STRATA_CYAN,
                 transparent: true,
-                opacity: 0.08,
+                opacity: 0.12,
                 blending: THREE.AdditiveBlending,
                 depthWrite: false,
             })
@@ -725,17 +730,17 @@ export default class ThreeHistoricalViz extends BaseViz {
     _buildLights() {
         this.scene.add(new THREE.AmbientLight(0x080808, 0.3));
         // Golden light from above (woman)
-        const sunLight = new THREE.PointLight(0xffd700, 0.9, 20);
+        const sunLight = new THREE.PointLight(0xedbd68, 0.9, 20);
         sunLight.position.set(0, 8, 5);
         this.scene.add(sunLight);
         this._sunLight = sunLight;
         // Red light from below (dragon)
-        const dragonLight = new THREE.PointLight(0x8b0000, 0.5, 15);
+        const dragonLight = new THREE.PointLight(0x7b2438, 0.5, 15);
         dragonLight.position.set(0, -4, 3);
         this.scene.add(dragonLight);
         this._dragonLight = dragonLight;
         // Green heal light
-        const healLight = new THREE.PointLight(0x32cd32, 0.4, 12);
+        const healLight = new THREE.PointLight(0x8fe9b2, 0.4, 12);
         healLight.position.set(-4, -1, 4);
         this.scene.add(healLight);
         this._healLight = healLight;
@@ -823,7 +828,7 @@ export default class ThreeHistoricalViz extends BaseViz {
                 margin-bottom: 14px;
             }
             .ch8-quote.ch8-entering .ch8-quote-main {
-                animation: ch8Glow 3s ease-in-out 1.4s infinite;
+                animation: ch8Glow 3.2s cubic-bezier(0.45, 0, 0.2, 1) 1.4s infinite;
             }
             .ch8-quote-sub {
                 font-family: 'Instrument Serif', serif;
@@ -886,13 +891,17 @@ export default class ThreeHistoricalViz extends BaseViz {
             .ch8-dot {
                 width: 4px; height: 4px; border-radius: 50%;
                 background: rgba(255,255,255,0.12);
-                transition: all 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+                transition:
+                    background 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                    box-shadow 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                    width 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                    height 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
             }
             .ch8-dot-label {
                 font-family: 'Instrument Serif', serif;
                 font-style: italic; font-size: 0.4rem;
                 color: rgba(255,255,255,0); letter-spacing: 0.08em;
-                transition: color 0.6s ease; white-space: nowrap;
+                transition: color 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94); white-space: nowrap;
             }
             .ch8-annotations [data-ch8-copy="quiet"] {
                 display: none !important;
@@ -1190,19 +1199,19 @@ export default class ThreeHistoricalViz extends BaseViz {
             const pulse = this.reducedMotion ? 0 : (Math.sin(t * 0.55) + 1) * 0.5;
             const compactStage = this.width < 560;
             const tabletStage = this.width >= 560 && this.width < 900;
-            const atlasBoost = compactStage ? 1.32 : tabletStage ? 1.16 : 1;
-            const atlasScale = compactStage ? 0.74 : tabletStage ? 0.86 : 1;
+            const atlasBoost = compactStage ? 1.34 : tabletStage ? 1.22 : 1.22;
+            const atlasScale = compactStage ? 0.74 : tabletStage ? 0.9 : 1.08;
 
             this._atlas.rotation.y = this.mouseSmooth.x * 0.08 + Math.sin(t * 0.04 * motionScale) * 0.025;
             this._atlas.rotation.x = -0.08 + this.mouseSmooth.y * 0.035;
             this._atlas.scale.setScalar(atlasScale);
-            this._atlas.position.x = compactStage ? 0.08 : tabletStage ? 0.24 : 0.6;
-            this._atlas.position.y = (compactStage ? 1.08 : tabletStage ? 0.72 : 0.25) - p * (compactStage ? 1.08 : 1.45);
-            this._atlas.position.z = (compactStage ? -4.45 : -5.2) + p * 1.4;
+            this._atlas.position.x = compactStage ? 0.08 : tabletStage ? 0.28 : 0.72;
+            this._atlas.position.y = (compactStage ? 1.12 : tabletStage ? 0.78 : 0.42) - p * (compactStage ? 1.02 : 1.25);
+            this._atlas.position.z = (compactStage ? -4.38 : tabletStage ? -4.62 : -4.85) + p * 1.15;
 
             this._atlasBands.forEach((band, index) => {
                 const layerIndex = Math.floor(index / 2);
-                const base = index % 2 === 0 ? 0.11 : 0.018;
+                const base = index % 2 === 0 ? 0.16 : 0.028;
                 const historicalBias = layerIndex < 3 ? strataWeight : layerIndex < 6 ? carrierWeight : depthWeight;
                 band.material.opacity = clamp01(base * historicalBias * atlasBoost * (0.86 + pulse * 0.18));
             });
@@ -1211,25 +1220,25 @@ export default class ThreeHistoricalViz extends BaseViz {
                 const isEarly = index < 3;
                 const isLate = index > 3;
                 const weight = isEarly ? strataWeight : isLate ? depthWeight : carrierWeight;
-                node.material.opacity = clamp01((0.38 + weight * 0.38) * atlasBoost * (0.88 + pulse * 0.22));
+                node.material.opacity = clamp01((0.46 + weight * 0.42) * atlasBoost * (0.88 + pulse * 0.22));
                 node.scale.setScalar(1 + weight * 0.28 + pulse * 0.08);
             });
 
             if (this._atlasThreads[0]) {
-                this._atlasThreads[0].material.opacity = clamp01((0.16 + carrierWeight * 0.18) * atlasBoost * (0.9 + pulse * 0.18));
+                this._atlasThreads[0].material.opacity = clamp01((0.22 + carrierWeight * 0.22) * atlasBoost * (0.9 + pulse * 0.18));
             }
             if (this._atlasThreads[1]) {
-                this._atlasThreads[1].material.opacity = clamp01((0.08 + depthWeight * 0.12) * atlasBoost * (0.9 + pulse * 0.16));
+                this._atlasThreads[1].material.opacity = clamp01((0.13 + depthWeight * 0.16) * atlasBoost * (0.9 + pulse * 0.16));
             }
             if (this._atlasFish) {
                 this._atlasFish.position.x = 0.2 + Math.sin(t * 0.1 * motionScale) * 0.2;
                 this._atlasFish.rotation.z = -0.16 + Math.sin(t * 0.13 * motionScale) * 0.05;
                 this._atlasFish.children.forEach((part) => {
-                    if (part.material) part.material.opacity = clamp01(((part === this._atlasFishTail ? 0.14 : 0.18) + carrierWeight * 0.12) * atlasBoost);
+                    if (part.material) part.material.opacity = clamp01(((part === this._atlasFishTail ? 0.2 : 0.22) + carrierWeight * 0.15) * atlasBoost);
                 });
             }
             if (this._afterlifeEcho) {
-                this._afterlifeEcho.material.opacity = clamp01((0.05 + depthWeight * 0.11) * atlasBoost * (0.92 + pulse * 0.18));
+                this._afterlifeEcho.material.opacity = clamp01((0.08 + depthWeight * 0.15) * atlasBoost * (0.92 + pulse * 0.18));
                 this._afterlifeEcho.rotation.z = -0.18 + Math.sin(t * 0.05 * motionScale) * 0.06;
                 this._afterlifeEcho.scale.set(1.68 + depthWeight * 0.12, 0.55 + depthWeight * 0.1, 1);
             }
@@ -1299,7 +1308,7 @@ export default class ThreeHistoricalViz extends BaseViz {
 
         /* ── Bloom modulation ── */
         if (this.bloom) {
-            this.bloom.strength = lerp(1.4, 0.8, clamp01(p));
+            this.bloom.strength = lerp(1.32, 0.92, clamp01(p));
         }
 
         /* ── Light intensity modulation ── */
@@ -1342,12 +1351,13 @@ export default class ThreeHistoricalViz extends BaseViz {
     }
 
     dispose() {
-        removeEventListener('mousemove', this._onMM);
+        this._inputTarget?.removeEventListener?.('mousemove', this._onMM);
         if (this._onScroll) removeEventListener('scroll', this._onScroll);
         if (this._onWheel) removeEventListener('wheel', this._onWheel);
         if (this._overlay) this._overlay.remove();
         if (this._progressContainer) this._progressContainer.remove();
         if (this._ch8Style) this._ch8Style.remove();
+        this.composer?.dispose?.();
         if (this.renderer) { this.renderer.dispose(); this.renderer.forceContextLoss(); }
         this.scene?.traverse(o => {
             o.geometry?.dispose();


### PR DESCRIPTION
## Summary
- Refines Chapter 8 into a clearer historical-fish atlas with brighter strata, carrier-path, and afterlife states.
- Strengthens the compact historical instrument and lower panel symbols without changing chapter data contracts.
- Tunes the Three.js scene palette, fog, bloom, input scoping, and disposal cleanup for safer route cycling.

## Visual QA
- Captured Chapter 8 desktop, mobile, and narrow screenshots.
- Interacted through History, Early Image, and Afterlife panel states.
- Confirmed no console errors, no failed network responses, and no horizontal overflow during local Browser/Playwright QA.

## Verification
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- npm run build
- AION_SMOKE_PORT=4184 npm run test:e2e:app:scene-controls
- AION_SMOKE_PORT=4185 npm run test:e2e:app:chapter-routes
- npm run test:e2e:app:mobile
- npm run test:a11y:app
- AION_SMOKE_PORT=4186 npm run test:e2e:app
- npm run build:pages
- npm run test:pages:artifact
