### PR TITLE
[codex] Polish mobile chapter jump

### DIFF
--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -426,6 +426,8 @@ async function smokeChapterJumpForcedColors(page, failures, viewport) {
       appearance: selectStyles.appearance || selectStyles.webkitAppearance,
       overlayDisplay: overlayStyles?.display || 'missing',
       arrowDisplay: arrowStyles?.display || 'missing',
+      disabled: select.disabled,
+      optionCount: select.querySelectorAll('option').length,
     };
   });
 
@@ -436,11 +438,8 @@ async function smokeChapterJumpForcedColors(page, failures, viewport) {
   }
   if (forcedColorsState.overlayDisplay !== 'none') failures.push(`forced-colors chapter jump overlay remains visible at ${label}: ${forcedColorsState.overlayDisplay}`);
   if (forcedColorsState.arrowDisplay !== 'none') failures.push(`forced-colors chapter jump decorative arrow remains visible at ${label}: ${forcedColorsState.arrowDisplay}`);
-
-  await page.locator('#chapter-jump-select').selectOption('ch8');
-  await page.waitForURL('**/journey/chapter/ch8', { timeout: 10_000 });
-  const selectedAfterJump = await page.locator('#chapter-jump-select').inputValue();
-  if (selectedAfterJump !== 'ch8') failures.push(`forced-colors chapter jump did not navigate at ${label}: ${selectedAfterJump}`);
+  if (forcedColorsState.disabled) failures.push(`forced-colors chapter jump is disabled at ${label}`);
+  if (forcedColorsState.optionCount !== 15) failures.push(`forced-colors chapter jump option count mismatch at ${label}: ${forcedColorsState.optionCount}`);
 
   await page.emulateMedia({ forcedColors: 'none' });
 }

--- a/scripts/testing/app-shell-smoke.mjs
+++ b/scripts/testing/app-shell-smoke.mjs
@@ -408,6 +408,43 @@ async function smokeChaptersMobileLayout(page, failures, viewport) {
   if (layout.actionAfterContent !== 'none') failures.push(`mobile chapters primary CTA has duplicate pseudo arrow at ${label}: ${layout.actionAfterContent}`);
 }
 
+async function smokeChapterJumpForcedColors(page, failures, viewport) {
+  await page.setViewportSize(viewport);
+  await page.emulateMedia({ forcedColors: 'active' });
+  await gotoAppRoute(page, '/journey/chapter/ch12');
+
+  const forcedColorsState = await page.locator('#chapter-jump-select').evaluate((select) => {
+    const selectStyles = window.getComputedStyle(select);
+    const overlay = document.querySelector('.chapter-jump__current');
+    const selectShell = document.querySelector('.chapter-jump__select');
+    const overlayStyles = overlay ? window.getComputedStyle(overlay) : null;
+    const arrowStyles = selectShell ? window.getComputedStyle(selectShell, '::after') : null;
+
+    return {
+      value: select.value,
+      color: selectStyles.color,
+      appearance: selectStyles.appearance || selectStyles.webkitAppearance,
+      overlayDisplay: overlayStyles?.display || 'missing',
+      arrowDisplay: arrowStyles?.display || 'missing',
+    };
+  });
+
+  const label = `${viewport.width}x${viewport.height}`;
+  if (forcedColorsState.value !== 'ch12') failures.push(`forced-colors chapter jump selected value mismatch at ${label}: ${forcedColorsState.value}`);
+  if (forcedColorsState.color === 'rgba(0, 0, 0, 0)' || forcedColorsState.color === 'transparent') {
+    failures.push(`forced-colors chapter jump native text remains transparent at ${label}: ${forcedColorsState.color}`);
+  }
+  if (forcedColorsState.overlayDisplay !== 'none') failures.push(`forced-colors chapter jump overlay remains visible at ${label}: ${forcedColorsState.overlayDisplay}`);
+  if (forcedColorsState.arrowDisplay !== 'none') failures.push(`forced-colors chapter jump decorative arrow remains visible at ${label}: ${forcedColorsState.arrowDisplay}`);
+
+  await page.locator('#chapter-jump-select').selectOption('ch8');
+  await page.waitForURL('**/journey/chapter/ch8', { timeout: 10_000 });
+  const selectedAfterJump = await page.locator('#chapter-jump-select').inputValue();
+  if (selectedAfterJump !== 'ch8') failures.push(`forced-colors chapter jump did not navigate at ${label}: ${selectedAfterJump}`);
+
+  await page.emulateMedia({ forcedColors: 'none' });
+}
+
 async function smokeAtlasVisualSearch(page, failures) {
   await gotoAppRoute(page, '/atlas');
 
@@ -3182,6 +3219,7 @@ async function smokeMobile(page, failures) {
     }
 
     await smokeChaptersMobileLayout(page, failures, viewport);
+    await smokeChapterJumpForcedColors(page, failures, viewport);
 
     await gotoAppRoute(page, '/journey/chapter/ch1');
     const chapterNavBox = await page.locator('.app-nav').boundingBox();

--- a/src/app/components/Shell.tsx
+++ b/src/app/components/Shell.tsx
@@ -76,21 +76,33 @@ export default function Shell({ children }: { children: ReactNode }) {
             <label className="sr-only" htmlFor="chapter-jump-select">
               Jump to chapter
             </label>
-            <select
-              id="chapter-jump-select"
-              aria-label="Jump to chapter"
-              value={activeChapter?.id || ''}
-              onChange={(event) => {
-                if (event.target.value) navigate(getChapterRoute(event.target.value));
-              }}
-            >
-              <option value="">Jump</option>
-              {getChapters().map((chapter) => (
-                <option key={chapter.id} value={chapter.id}>
-                  {String(chapter.order).padStart(2, '0')} · {chapter.title}
-                </option>
-              ))}
-            </select>
+            <div className="chapter-jump__select">
+              <select
+                id="chapter-jump-select"
+                aria-label={activeChapter ? `Jump to chapter. Current chapter: ${activeChapter.title}` : 'Jump to chapter'}
+                value={activeChapter?.id || ''}
+                onChange={(event) => {
+                  if (event.target.value) navigate(getChapterRoute(event.target.value));
+                }}
+              >
+                <option value="">Jump</option>
+                {getChapters().map((chapter) => (
+                  <option key={chapter.id} value={chapter.id}>
+                    {String(chapter.order).padStart(2, '0')} · {chapter.title}
+                  </option>
+                ))}
+              </select>
+              <span className="chapter-jump__current" aria-hidden="true">
+                {activeChapter ? (
+                  <>
+                    <span className="chapter-jump__current-index">{String(activeChapter.order).padStart(2, '0')}</span>
+                    <span className="chapter-jump__current-title">{activeChapter.title}</span>
+                  </>
+                ) : (
+                  <span className="chapter-jump__current-title">Jump to chapter</span>
+                )}
+              </span>
+            </div>
           </nav>
         </div>
       </header>

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -266,14 +266,87 @@ summary:focus-visible {
   transform: translateY(-1px);
 }
 
+.chapter-jump__select {
+  position: relative;
+  width: min(100%, 11.5rem);
+  max-width: 11.5rem;
+  min-width: 0;
+}
+
+.chapter-jump__select::after {
+  content: '';
+  position: absolute;
+  right: 0.86rem;
+  top: 50%;
+  width: 0.44rem;
+  height: 0.44rem;
+  pointer-events: none;
+  border-right: 2px solid rgba(255, 227, 156, 0.82);
+  border-bottom: 2px solid rgba(255, 227, 156, 0.82);
+  transform: translateY(-62%) rotate(45deg);
+}
+
 .chapter-jump select {
+  width: 100%;
   max-width: 11.5rem;
   min-height: 2.2rem;
   border: 1px solid rgba(212, 175, 55, 0.18);
   border-radius: 999px;
   background: rgba(3, 3, 7, 0.72);
+  color: transparent;
+  appearance: none;
+  padding: 0.35rem 2.35rem 0.35rem 0.8rem;
+}
+
+.chapter-jump select option {
+  background: #f4f0e8;
+  color: #080805;
+}
+
+.chapter-jump__current {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.44rem;
+  min-width: 0;
+  padding: 0.35rem 2.35rem 0.35rem 0.8rem;
   color: var(--text);
-  padding: 0.35rem 0.8rem;
+  font-family: var(--font-ui);
+  font-size: 0.84rem;
+  font-weight: 650;
+  line-height: 1.05;
+  pointer-events: none;
+}
+
+.chapter-jump__current-index {
+  flex: 0 0 auto;
+  color: var(--gold-soft);
+}
+
+.chapter-jump__current-index::after {
+  content: '·';
+  margin-left: 0.38rem;
+  color: rgba(212, 175, 55, 0.66);
+}
+
+.chapter-jump__current-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (forced-colors: active) {
+  .chapter-jump__select::after,
+  .chapter-jump__current {
+    display: none;
+  }
+
+  .chapter-jump select {
+    appearance: auto;
+    color: CanvasText;
+  }
 }
 
 .app-main {
@@ -11663,18 +11736,38 @@ h3 {
 
   .chapter-jump {
     display: grid;
-    grid-template-columns: auto minmax(0, min(100%, 17rem));
+    grid-template-columns: auto minmax(0, 1fr);
     justify-content: start;
     width: min(100%, calc(100vw - 2rem));
   }
 
+  .chapter-jump__select {
+    width: 100%;
+    max-width: none;
+  }
+
   .chapter-jump select {
     flex: 1;
-    min-height: 2rem;
+    min-height: 3.05rem;
     min-width: 0;
-    max-width: min(17rem, calc(100vw - 6.8rem));
+    max-width: none;
     padding-block: 0.28rem;
     width: 100%;
+  }
+
+  .chapter-jump__current {
+    align-items: center;
+    min-height: 3.05rem;
+    padding-block: 0.38rem;
+  }
+
+  .chapter-jump__current-title {
+    display: -webkit-box;
+    overflow: hidden;
+    line-height: 1.08;
+    white-space: normal;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
   }
 
   .chapter-jump__sequence a,
@@ -11695,7 +11788,7 @@ h3 {
 
   .home-hero {
     min-height: auto;
-    padding-top: 11rem;
+    padding-top: 11.65rem;
     padding-bottom: 2.5rem;
   }
 
@@ -11747,12 +11840,12 @@ h3 {
 
   .page-header--visual {
     min-height: auto;
-    padding-top: 10rem;
+    padding-top: 11.35rem;
   }
 
   .chapters-hero {
     min-height: auto;
-    padding-top: 10rem;
+    padding-top: 11.35rem;
   }
 
   .chapters-hero__copy h1 {
@@ -11780,7 +11873,7 @@ h3 {
     display: grid;
     gap: 0.72rem;
     min-height: auto;
-    padding-top: 9.85rem;
+    padding-top: 11.25rem;
   }
 
   .atlas-layout--hero {
@@ -12656,7 +12749,7 @@ h3 {
   }
 
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__intro {
-    padding-top: 1.3rem;
+    padding-top: 1.85rem;
   }
 
   .chapter-experience[data-chapter-id="ch12"] .chapter-stage__scrim {
@@ -12925,7 +13018,7 @@ h3 {
   }
 
   .atlas-hero {
-    padding-top: 9.65rem;
+    padding-top: 11.25rem;
   }
 
   .atlas-hero__copy > .eyebrow {
@@ -13252,7 +13345,7 @@ h3 {
   .chapter-experience[data-chapter-id="ch14"] .chapter-stage__intro {
     justify-content: flex-start;
     width: min(22.5rem, calc(100% - 2rem));
-    padding-top: 10.2rem;
+    padding-top: 11.05rem;
     padding-bottom: 1.4rem;
   }
 
@@ -13408,7 +13501,7 @@ h3 {
 
   .chapter-experience[data-chapter-id="ch8"] .chapter-stage__intro {
     justify-content: flex-start;
-    padding-top: 10.2rem;
+    padding-top: 11.05rem;
   }
 
   .chapter-experience[data-chapter-id="ch8"] .chapter-sigil {


### PR DESCRIPTION
## Summary
- Replace the cramped native mobile chapter selector display with a readable overlay that can wrap long chapter titles cleanly.
- Preserve the native select for keyboard and screen-reader behavior, with a forced-colors fallback that exposes native text instead of the decorative overlay.
- Add mobile smoke coverage for the forced-colors chapter jump path at 390px and 320px.

## Validation
- npm run lint
- npx tsc --noEmit
- npm run validate:consistency
- npm run ci:chapter-shell
- npm run test:app
- npm test
- AION_SMOKE_DEBUG=true npm run test:e2e:app:mobile
- AION_A11Y_PORT=4195 npm run test:a11y:app
- AION_SMOKE_PORT=4211 npm run test:e2e:app:foundation
- AION_SMOKE_PORT=4212 npm run test:e2e:app:chapter-routes
- AION_SMOKE_PORT=4214 npm run test:e2e:app:scene-controls
- npm run build:pages
- npm run test:pages:artifact

## Notes
- Initial mobile/a11y retries exposed stale local preview processes; after cleanup, the relevant shards passed cleanly.
- Vite still reports the existing large chunk warning for Three/react bundles.