### PR TITLE
[codex] Refine chapter nine ambivalence field

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -5705,22 +5705,24 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument {
   position: relative;
+  isolation: isolate;
   width: min(33.5rem, 100%);
   min-height: clamp(8.35rem, 13vh, 10.1rem);
   overflow: hidden;
   margin-top: 0.92rem;
-  border: 1px solid rgba(244, 240, 232, 0.2);
+  border: 1px solid rgba(244, 240, 232, 0.24);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 27% 48%, rgba(255, 227, 156, 0.34), transparent 4.95rem),
-    radial-gradient(circle at 72% 52%, rgba(83, 216, 232, 0.28), transparent 5.25rem),
-    radial-gradient(ellipse at 50% 50%, rgba(244, 240, 232, 0.15), transparent 48%),
-    linear-gradient(90deg, rgba(28, 18, 7, 0.92), rgba(8, 8, 12, 0.78) 47%, rgba(3, 18, 23, 0.84));
+    radial-gradient(circle at 24% 48%, rgba(255, 227, 156, 0.44), transparent 5.25rem),
+    radial-gradient(circle at 74% 52%, rgba(83, 216, 232, 0.32), transparent 5.45rem),
+    radial-gradient(ellipse at 50% 50%, rgba(244, 240, 232, 0.18), transparent 46%),
+    linear-gradient(90deg, rgba(37, 23, 7, 0.94), rgba(9, 8, 11, 0.8) 47%, rgba(3, 22, 28, 0.86)),
+    repeating-linear-gradient(135deg, rgba(244, 240, 232, 0.035) 0 1px, transparent 1px 0.72rem);
   box-shadow:
     var(--shadow-inset),
     0 1.7rem 4.8rem rgba(0, 0, 0, 0.34),
     0 0 2.8rem rgba(83, 216, 232, 0.12),
-    0 0 1.9rem rgba(212, 175, 55, 0.08);
+    0 0 1.9rem rgba(212, 175, 55, 0.1);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::before,
@@ -5732,17 +5734,19 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::before {
   inset: 0.62rem;
-  border: 1px solid rgba(255, 227, 156, 0.15);
+  z-index: 1;
+  border: 1px solid rgba(255, 227, 156, 0.18);
   border-radius: calc(var(--radius) - 2px);
   background:
     radial-gradient(ellipse at 50% 50%, transparent 47%, rgba(244, 240, 232, 0.06) 47.4% 47.8%, transparent 49%),
-    linear-gradient(90deg, rgba(255, 227, 156, 0.07), transparent 34%, transparent 66%, rgba(83, 216, 232, 0.07)),
-    repeating-linear-gradient(90deg, transparent 0 16%, rgba(244, 240, 232, 0.04) 16.2% 16.45%, transparent 16.8% 32%);
+    linear-gradient(90deg, rgba(255, 227, 156, 0.09), transparent 34%, transparent 66%, rgba(83, 216, 232, 0.09)),
+    repeating-linear-gradient(90deg, transparent 0 15.7%, rgba(244, 240, 232, 0.06) 15.95% 16.2%, transparent 16.55% 32%);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::after {
   left: 50%;
   top: 50%;
+  z-index: 2;
   width: 0.16rem;
   height: 6.9rem;
   background: linear-gradient(180deg, transparent, rgba(244, 240, 232, 0.5), transparent);
@@ -5764,6 +5768,7 @@ h3 {
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__charge,
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label {
   position: absolute;
+  z-index: 3;
   pointer-events: none;
 }
 
@@ -5802,8 +5807,8 @@ h3 {
   right: 0;
   background:
     radial-gradient(circle at 58% 52%, rgba(83, 216, 232, 0.34), transparent 4.55rem),
-    radial-gradient(ellipse at 34% 50%, rgba(181, 130, 255, 0.17), transparent 3.4rem),
-    linear-gradient(270deg, rgba(83, 216, 232, 0.12), rgba(181, 130, 255, 0.06), transparent);
+    radial-gradient(ellipse at 34% 50%, rgba(47, 100, 120, 0.2), transparent 3.4rem),
+    linear-gradient(270deg, rgba(83, 216, 232, 0.13), rgba(47, 100, 120, 0.08), transparent);
 }
 
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__field--shadow::before {
@@ -5949,13 +5954,13 @@ h3 {
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--shadow {
   right: 23%;
   border-top: 1px solid rgba(83, 216, 232, 0.72);
-  border-bottom: 1px solid rgba(181, 130, 255, 0.5);
+  border-bottom: 1px solid rgba(123, 205, 218, 0.46);
   background:
     radial-gradient(circle at 68% 50%, rgba(143, 231, 237, 0.84) 0 0.16rem, transparent 0.18rem),
-    radial-gradient(ellipse at 48% 50%, rgba(83, 216, 232, 0.3), rgba(181, 130, 255, 0.14) 58%, transparent 70%);
+    radial-gradient(ellipse at 48% 50%, rgba(83, 216, 232, 0.3), rgba(47, 100, 120, 0.18) 58%, transparent 70%);
   box-shadow:
     0 0 1.65rem rgba(83, 216, 232, 0.34),
-    0 0 2.45rem rgba(181, 130, 255, 0.14);
+    0 0 2.45rem rgba(47, 100, 120, 0.16);
   filter: saturate(1.05);
   transform: translate(50%, -50%) rotate(172deg);
 }
@@ -5963,7 +5968,7 @@ h3 {
 .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish--shadow::after {
   left: -0.38rem;
   border-left: 1px solid rgba(83, 216, 232, 0.34);
-  border-bottom: 1px solid rgba(181, 130, 255, 0.28);
+  border-bottom: 1px solid rgba(123, 205, 218, 0.28);
   transform: translateY(-50%) rotate(45deg);
 }
 
@@ -5993,14 +5998,15 @@ h3 {
   top: 50%;
   width: 4.25rem;
   height: 2.72rem;
-  border: 1px solid rgba(181, 130, 255, 0.4);
+  border: 1px solid rgba(83, 216, 232, 0.36);
   border-radius: 50%;
   background:
-    radial-gradient(circle at 50% 50%, rgba(181, 130, 255, 0.24), transparent 68%),
+    radial-gradient(circle at 50% 50%, rgba(83, 216, 232, 0.2), transparent 68%),
+    radial-gradient(ellipse at 58% 50%, rgba(9, 13, 18, 0.72), transparent 72%),
     linear-gradient(130deg, transparent 47%, rgba(83, 216, 232, 0.28) 49%, transparent 52%);
   box-shadow:
     inset 0 0 1.1rem rgba(83, 216, 232, 0.12),
-    0 0 1.6rem rgba(181, 130, 255, 0.1);
+    0 0 1.6rem rgba(83, 216, 232, 0.12);
   opacity: 0.7;
   transform: translateY(-50%) rotate(-12deg);
   transition:
@@ -6015,8 +6021,13 @@ h3 {
   font-family: var(--font-ui);
   font-size: 0.6rem;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  padding: 0.14rem 0.32rem;
+  border: 1px solid rgba(244, 240, 232, 0.12);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.36);
+  box-shadow: inset 0 0 0.7rem rgba(244, 240, 232, 0.04);
   transition:
     color 0.55s var(--motion-spring),
     opacity 0.55s var(--motion-spring),
@@ -6037,6 +6048,9 @@ h3 {
   font-size: 0.62rem;
   font-weight: 700;
   letter-spacing: 0;
+  padding: 0.1rem 0.26rem;
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.32);
   text-shadow: 0 0 0.8rem rgba(0, 0, 0, 0.72);
 }
 
@@ -9597,6 +9611,31 @@ h3 {
 .scene-host__status span {
   display: block;
   color: var(--gold);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .scene-host__status {
+  left: clamp(1rem, 3vw, 2rem);
+  top: auto;
+  bottom: clamp(1rem, 3vh, 2rem);
+  width: min(18rem, calc(100% - 2rem));
+  transform: none;
+  padding: 0.72rem 0.82rem;
+  border-color: rgba(255, 227, 156, 0.22);
+  background:
+    linear-gradient(135deg, rgba(8, 7, 10, 0.76), rgba(3, 20, 25, 0.62)),
+    radial-gradient(circle at 18% 30%, rgba(255, 227, 156, 0.13), transparent 3rem);
+  text-align: left;
+  box-shadow:
+    var(--shadow-inset),
+    0 1.2rem 3rem rgba(0, 0, 0, 0.28);
+}
+
+.chapter-experience[data-chapter-id="ch9"] .scene-host__status span {
+  color: rgba(255, 227, 156, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .scene-host__controls {
@@ -13563,24 +13602,32 @@ h3 {
 
 	  .chapter-experience[data-chapter-id="ch9"] .chapter-stage__intro {
 	    justify-content: flex-start;
-	    padding-top: 10.25rem;
+	    width: min(22.2rem, calc(100% - 1.5rem));
+	    padding-top: clamp(10.65rem, 26vh, 12.1rem);
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .chapter-sigil {
-	    display: none;
+	    display: block;
+	    width: 3.65rem;
+	    height: 3.65rem;
+	    margin: 0 auto 0.42rem;
+	    opacity: 0.9;
+	    filter:
+	      drop-shadow(0 0 0.7rem rgba(212, 175, 55, 0.22))
+	      drop-shadow(0 0 1rem rgba(83, 216, 232, 0.12));
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .chapter-stage__intro h1 {
-	    max-width: 9.2ch;
-	    font-size: clamp(2.05rem, 10.7vw, 2.82rem);
+	    max-width: 8.95ch;
+	    font-size: clamp(1.92rem, 10.05vw, 2.66rem);
 	    line-height: 0.92;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .chapter-stage__intro p:not(.eyebrow) {
-	    margin-top: 0.7rem;
-	    max-width: 28.5ch;
-	    font-size: 0.9rem;
-	    line-height: 1.47;
+	    margin-top: 0.62rem;
+	    max-width: 27ch;
+	    font-size: 0.84rem;
+	    line-height: 1.44;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .scene-host__pause {
@@ -13600,8 +13647,10 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument {
-	    min-height: 7.15rem;
-	    margin-top: 0.68rem;
+	    width: min(21.5rem, 100%);
+	    min-height: clamp(7.85rem, 24vw, 8.9rem);
+	    margin-top: 0.76rem;
+	    border-color: rgba(244, 240, 232, 0.28);
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::before {
@@ -13609,7 +13658,7 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument::after {
-	    height: 4.95rem;
+	    height: 5.25rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__mirror {
@@ -13618,18 +13667,18 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring--outer {
-	    width: 7.65rem;
-	    height: 4.18rem;
+	    width: 8.15rem;
+	    height: 4.28rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__ring--inner {
-	    width: 5.36rem;
-	    height: 2.86rem;
+	    width: 5.75rem;
+	    height: 2.95rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__thread {
-	    width: 6.58rem;
-	    height: 3.16rem;
+	    width: 7rem;
+	    height: 3.25rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__fish {
@@ -13652,12 +13701,17 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__charge {
-	    bottom: 12%;
-	    font-size: 0.55rem;
+	    bottom: 10%;
+	    max-width: 6.9rem;
+	    font-size: 0.5rem;
+	    letter-spacing: 0.04em;
+	    white-space: nowrap;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label {
-	    font-size: 0.51rem;
+	    font-size: 0.48rem;
+	    padding-inline: 0.2rem;
+	    white-space: nowrap;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--paradox {
@@ -13666,12 +13720,32 @@ h3 {
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--return {
-	    left: 44%;
+	    left: 43%;
 	    top: 12%;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"] .ambivalent-fish-instrument__label--shadow {
 	    right: 4%;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .scene-host__status {
+	    left: 0.78rem;
+	    bottom: 0.78rem;
+	    width: min(12.5rem, calc(100% - 1.56rem));
+	    padding: 0.54rem 0.62rem;
+	    opacity: 0.88;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .scene-host__status strong {
+	    display: block;
+	    overflow: hidden;
+	    max-width: 100%;
+	    text-overflow: ellipsis;
+	    white-space: nowrap;
+	  }
+
+	  .chapter-experience[data-chapter-id="ch9"] .scene-host__status span {
+	    font-size: 0.58rem;
 	  }
 
 	  .chapter-experience[data-chapter-id="ch9"][data-reduced-motion="true"] .scene-host__fallback {

--- a/src/visualizations/chapters/ch9/ThreeOuroborosViz.js
+++ b/src/visualizations/chapters/ch9/ThreeOuroborosViz.js
@@ -13,7 +13,7 @@ const SERPENT_CLR = new THREE.Color('#53d8e8');
 const SERPENT_DARK = new THREE.Color('#123f38');
 const GOLD = new THREE.Color('#f2c95d');
 const SILVER = new THREE.Color('#f4f0e8');
-const SHADOW = new THREE.Color('#6d5a9c');
+const SHADOW = new THREE.Color('#2f6674');
 const MIRROR = new THREE.Color('#d9fff8');
 
 export default class ThreeOuroborosViz extends BaseViz {
@@ -36,7 +36,7 @@ export default class ThreeOuroborosViz extends BaseViz {
 
     async init() {
         const R = this.renderer = new THREE.WebGLRenderer({ canvas: this.canvas, antialias: true, alpha: false });
-        R.setPixelRatio(Math.min(devicePixelRatio, 2)); R.setSize(this.width, this.height); R.setClearColor(0x04050d);
+        R.setPixelRatio(Math.min(window.devicePixelRatio || 1, this.width < 700 ? 1.5 : 2)); R.setSize(this.width, this.height); R.setClearColor(0x04050d);
         this.scene = new THREE.Scene();
         this.scene.fog = new THREE.FogExp2(0x04050d, 0.007);
         this.camera = new THREE.PerspectiveCamera(50, this.width / this.height, 0.1, 100);
@@ -44,8 +44,17 @@ export default class ThreeOuroborosViz extends BaseViz {
         this.focusTarget = new THREE.Vector3(0.25, 0, 0);
 
         this.mouse = new THREE.Vector2(); this.mouseSmooth = new THREE.Vector2();
-        this._onMM = e => { this.mouse.x = (e.clientX / innerWidth) * 2 - 1; this.mouse.y = -(e.clientY / innerHeight) * 2 + 1; };
-        addEventListener('mousemove', this._onMM);
+        this._onMM = e => {
+            const rect = this.container?.getBoundingClientRect();
+            const width = rect?.width || window.innerWidth || 1;
+            const height = rect?.height || window.innerHeight || 1;
+            const left = rect?.left || 0;
+            const top = rect?.top || 0;
+            this.mouse.x = THREE.MathUtils.clamp(((e.clientX - left) / width) * 2 - 1, -1, 1);
+            this.mouse.y = THREE.MathUtils.clamp(-(((e.clientY - top) / height) * 2 - 1), -1, 1);
+        };
+        this.pointerTarget = this.container || window;
+        this.pointerTarget.addEventListener('mousemove', this._onMM);
 
         this._createTeachingField();
 
@@ -99,7 +108,7 @@ export default class ThreeOuroborosViz extends BaseViz {
         this.scene.add(this.junction);
 
         // Cyclic particle flow along the serpent body
-        const flowN = 300;
+        const flowN = this.width < 700 ? 180 : 300;
         const flowPos = new Float32Array(flowN * 3);
         this.flowPhases = new Float32Array(flowN);
         for (let i = 0; i < flowN; i++) {
@@ -211,13 +220,13 @@ export default class ThreeOuroborosViz extends BaseViz {
         const goldLight = new THREE.PointLight(0xf2c95d, 0.46, 12);
         goldLight.position.set(3.3, 2.2, 4);
         this.scene.add(goldLight);
-        const shadowLight = new THREE.PointLight(0x7b6aa8, 0.42, 14);
+        const shadowLight = new THREE.PointLight(0x2f6674, 0.42, 14);
         shadowLight.position.set(5, -1, 3);
         this.scene.add(shadowLight);
 
         this.composer = new EffectComposer(R);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
-        this.bloom = new UnrealBloomPass(new THREE.Vector2(this.width, this.height), 1.2, 0.5, 0.35);
+        this.bloom = new UnrealBloomPass(new THREE.Vector2(this.width, this.height), this.width < 700 ? 0.95 : 1.2, 0.5, 0.35);
         this.composer.addPass(this.bloom);
     }
 
@@ -414,10 +423,14 @@ export default class ThreeOuroborosViz extends BaseViz {
     onResize(w, h) {
         if (!this.renderer) return;
         this.camera.aspect = w / h; this.camera.updateProjectionMatrix();
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, w < 700 ? 1.5 : 2));
         this.renderer.setSize(w, h); this.composer?.setSize(w, h); this.bloom?.setSize(w, h);
     }
     dispose() {
-        removeEventListener('mousemove', this._onMM);
+        this.pointerTarget?.removeEventListener('mousemove', this._onMM);
+        this.pointerTarget = null;
+        this.bloom?.dispose?.();
+        this.composer?.dispose?.();
         this.renderer?.dispose(); this.renderer?.forceContextLoss();
         this.scene?.traverse(o => {
             o.geometry?.dispose();
@@ -428,6 +441,6 @@ export default class ThreeOuroborosViz extends BaseViz {
                 });
             }
         });
-        this.composer = null; this.scene = null; this.renderer = null; super.dispose();
+        this.bloom = null; this.composer = null; this.scene = null; this.renderer = null; super.dispose();
     }
 }


### PR DESCRIPTION
## Summary
- Refine Chapter 9's ambivalent fish instrument into a richer gold/cyan atlas plate with clearer paradox, return, and shadow emphasis.
- Restore mobile chapter identity with a compact sigil, improved first-viewport spacing, and a non-colliding Chapter 9 loading status chip.
- Tune the Chapter 9 Ouroboros scene for cooler shadow coloration, container-scoped pointer tracking, mobile particle/bloom limits, and explicit postprocessing cleanup.

## Skill stack
- Orchestration autopilot/subagent review
- frontend-design / design-taste / high-end visual design direction
- accessibility-review and webapp-testing gates
- Playwright/Control Tower browser evidence
- github:yeet publish flow

## Routes changed
- `/journey/chapter/ch9`

## Visual thesis
Ambivalence should read as a navigable paradox mirror: one fish-symbol holding blessing and counter-pole, returning through an ouroboric loop, with sparse text and a dominant symbolic teaching surface.

## Browser evidence
- `npm run test:visual:control-tower`
- Report: `test-results/control-tower/route-scores.md`
- Chapter 9 screenshots inspected: desktop, 390x844 mobile, 320x568 narrow
- Control Tower result: 20 routes inspected, 0 technical blockers, no mobile overflow for Chapter 9

## Checks
- `rg -n "^(<<<<<<<|=======|>>>>>>>)" .`
- `git diff --check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm run build`
- `AION_SMOKE_PORT=4221 node scripts/testing/app-shell-smoke.mjs --shard=scene-controls`
- `AION_SMOKE_PORT=4222 node scripts/testing/app-shell-smoke.mjs --shard=mobile`
- `AION_SMOKE_PORT=4232 node scripts/testing/app-shell-smoke.mjs --shard=foundation`
- `AION_A11Y_PORT=4233 node scripts/testing/app-accessibility-smoke.mjs`
- `npm run build:pages && npm run test:pages:artifact`
- `npm run test:visual:control-tower`

## Residual debt
- Existing Vite large chunk warning remains for shared Three/react bundles.
- Chapter 10 is the next natural batch for transformation grammar polish.
