### PR TITLE
[codex] Refine chapter eleven alchemical tree

### DIFF
--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -6862,7 +6862,7 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .chapter-stage__intro h1 {
   max-width: 13.2ch;
-  font-size: clamp(3.25rem, 5.55vw, 5.35rem);
+  font-size: clamp(3.35rem, 5.75vw, 5.58rem);
   line-height: 0.93;
 }
 
@@ -6894,11 +6894,11 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .chapter-stage__scrim {
   background:
-    linear-gradient(180deg, rgba(3, 3, 7, 0.86), rgba(3, 3, 7, 0.46) 48%, rgba(3, 3, 7, 0.84)),
-    linear-gradient(90deg, rgba(3, 3, 7, 0.98), rgba(3, 3, 7, 0.72) 56%, rgba(3, 3, 7, 0.32)),
-    radial-gradient(circle at 31% 51%, rgba(212, 175, 55, 0.17), transparent 31%),
-    radial-gradient(circle at 58% 48%, rgba(83, 216, 232, 0.11), transparent 34%),
-    radial-gradient(circle at 74% 66%, rgba(181, 130, 255, 0.08), transparent 32%);
+    linear-gradient(180deg, rgba(3, 3, 7, 0.82), rgba(3, 3, 7, 0.34) 48%, rgba(3, 3, 7, 0.8)),
+    linear-gradient(90deg, rgba(3, 3, 7, 0.98), rgba(3, 3, 7, 0.66) 54%, rgba(3, 3, 7, 0.18)),
+    radial-gradient(circle at 31% 51%, rgba(212, 175, 55, 0.19), transparent 31%),
+    radial-gradient(circle at 58% 48%, rgba(83, 216, 232, 0.14), transparent 34%),
+    radial-gradient(circle at 75% 65%, rgba(194, 55, 43, 0.07), transparent 32%);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .chapter-stage__reference-node[data-panel-id="mercurius"] .chapter-stage__reference-mark::before {
@@ -6974,23 +6974,26 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument {
+  isolation: isolate;
   position: relative;
   width: min(35.5rem, 100%);
-  min-height: clamp(9.45rem, 15vh, 10.85rem);
+  min-height: clamp(10.15rem, 16vh, 11.4rem);
   overflow: hidden;
   margin-top: 0.7rem;
-  border: 1px solid rgba(244, 240, 232, 0.16);
+  border: 1px solid rgba(255, 227, 156, 0.24);
   border-radius: var(--radius);
   background:
-    radial-gradient(circle at 22% 68%, rgba(83, 216, 232, 0.22), transparent 6.2rem),
-    radial-gradient(circle at 50% 46%, rgba(212, 175, 55, 0.25), transparent 6.3rem),
-    radial-gradient(circle at 78% 50%, rgba(255, 111, 82, 0.16), transparent 5.9rem),
-    radial-gradient(circle at 72% 68%, rgba(181, 130, 255, 0.11), transparent 5.2rem),
-    linear-gradient(90deg, rgba(6, 8, 13, 0.94), rgba(11, 9, 12, 0.83) 46%, rgba(18, 8, 16, 0.76));
+    repeating-linear-gradient(0deg, rgba(255, 227, 156, 0.035) 0 1px, transparent 1px 0.72rem),
+    repeating-linear-gradient(90deg, rgba(83, 216, 232, 0.025) 0 1px, transparent 1px 2.1rem),
+    radial-gradient(circle at 22% 68%, rgba(83, 216, 232, 0.3), transparent 6.35rem),
+    radial-gradient(circle at 50% 46%, rgba(212, 175, 55, 0.32), transparent 6.55rem),
+    radial-gradient(circle at 78% 50%, rgba(255, 111, 82, 0.2), transparent 5.95rem),
+    linear-gradient(90deg, rgba(6, 8, 13, 0.96), rgba(11, 9, 12, 0.86) 46%, rgba(21, 10, 11, 0.8));
   box-shadow:
     var(--shadow-inset),
     0 1.6rem 4.9rem rgba(0, 0, 0, 0.34),
-    0 0 3.2rem rgba(212, 175, 55, 0.09);
+    0 0 3.2rem rgba(212, 175, 55, 0.12),
+    0 0 4.2rem rgba(83, 216, 232, 0.06);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::before,
@@ -7002,7 +7005,8 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::before {
   inset: 0.58rem;
-  border: 1px solid rgba(255, 227, 156, 0.08);
+  z-index: 0;
+  border: 1px solid rgba(255, 227, 156, 0.12);
   border-radius: calc(var(--radius) - 2px);
   background:
     linear-gradient(90deg, transparent 30%, rgba(255, 227, 156, 0.1) 30.2%, transparent 30.8%),
@@ -7011,6 +7015,7 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument::after {
+  z-index: 0;
   left: 50%;
   top: 50%;
   width: 74%;
@@ -7035,6 +7040,7 @@ h3 {
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__reflection,
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
   position: absolute;
+  z-index: 1;
   pointer-events: none;
 }
 
@@ -7067,7 +7073,7 @@ h3 {
   height: 8.25rem;
   border: 1px solid rgba(255, 227, 156, 0.2);
   border-radius: 50%;
-  opacity: 0.62;
+  opacity: 0.7;
   box-shadow:
     inset 0 0 2rem rgba(255, 227, 156, 0.06),
     0 0 2.4rem rgba(83, 216, 232, 0.08);
@@ -7081,7 +7087,7 @@ h3 {
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__trunk {
   left: 50%;
   top: 11%;
-  width: 0.24rem;
+  width: 0.28rem;
   height: 76%;
   border-radius: 999px;
   background:
@@ -7090,7 +7096,7 @@ h3 {
   box-shadow:
     0 0 1.35rem rgba(83, 216, 232, 0.24),
     0 0 1.05rem rgba(212, 175, 55, 0.18);
-  opacity: 0.82;
+  opacity: 0.9;
   transform: translateX(-50%);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -7104,7 +7110,7 @@ h3 {
   height: 2.95rem;
   border-top: 1px solid rgba(83, 216, 232, 0.4);
   border-radius: 50%;
-  opacity: 0.64;
+  opacity: 0.76;
   filter: drop-shadow(0 0 0.82rem rgba(83, 216, 232, 0.18));
   transition:
     opacity 0.55s var(--motion-spring),
@@ -7133,7 +7139,7 @@ h3 {
   height: 3.32rem;
   border-bottom: 1px solid rgba(255, 227, 156, 0.4);
   border-radius: 50%;
-  opacity: 0.64;
+  opacity: 0.76;
   filter: drop-shadow(0 0 0.82rem rgba(212, 175, 55, 0.18));
   transition:
     opacity 0.55s var(--motion-spring),
@@ -7154,7 +7160,7 @@ h3 {
   width: 16rem;
   height: 5.8rem;
   border-radius: 50%;
-  opacity: 0.58;
+  opacity: 0.68;
   transition:
     opacity 0.55s var(--motion-spring),
     transform 0.55s var(--motion-spring),
@@ -7223,7 +7229,7 @@ h3 {
   top: 50%;
   width: 6.5rem;
   aspect-ratio: 1;
-  border: 1px solid rgba(255, 227, 156, 0.36);
+  border: 1px solid rgba(255, 227, 156, 0.48);
   border-radius: 50%;
   background:
     radial-gradient(circle at 50% 50%, rgba(3, 3, 7, 0.96) 0 34%, transparent 36%),
@@ -7231,7 +7237,7 @@ h3 {
   box-shadow:
     inset 0 0 1rem rgba(3, 3, 7, 0.7),
     0 0 1.85rem rgba(212, 175, 55, 0.2);
-  opacity: 0.82;
+  opacity: 0.9;
   transform: translateY(-50%);
   animation: alchemical-tree-wheel 18s linear infinite;
   transition:
@@ -7307,7 +7313,7 @@ h3 {
   box-shadow:
     0 0 0 0.5rem rgba(212, 175, 55, 0.05),
     0 0 1.35rem rgba(212, 175, 55, 0.2);
-  opacity: 0.78;
+  opacity: 0.88;
   transform: translate(-50%, -50%) rotate(45deg) scale(0.9);
   transition:
     opacity 0.55s var(--motion-spring),
@@ -7354,11 +7360,16 @@ h3 {
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
-  color: rgba(244, 240, 232, 0.82);
+  color: rgba(244, 240, 232, 0.88);
   font-family: var(--font-ui);
   font-size: 0.62rem;
   font-weight: 700;
   letter-spacing: 0;
+  padding: 0.12rem 0.28rem;
+  border: 1px solid rgba(244, 240, 232, 0.08);
+  border-radius: 999px;
+  background: rgba(3, 3, 7, 0.42);
+  box-shadow: var(--shadow-inset);
 }
 
 .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--mercurius {
@@ -9674,6 +9685,32 @@ h3 {
 
 .chapter-experience[data-chapter-id="ch10"] .scene-host__status span {
   color: rgba(255, 227, 156, 0.82);
+  font-family: var(--font-ui);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chapter-experience[data-chapter-id="ch11"] .scene-host__status {
+  left: clamp(1rem, 3vw, 2rem);
+  top: auto;
+  bottom: clamp(1rem, 3vh, 2rem);
+  width: min(18rem, calc(100% - 2rem));
+  transform: none;
+  padding: 0.72rem 0.82rem;
+  border-color: rgba(255, 227, 156, 0.2);
+  background:
+    linear-gradient(135deg, rgba(8, 7, 10, 0.76), rgba(4, 18, 24, 0.58)),
+    radial-gradient(circle at 18% 30%, rgba(255, 227, 156, 0.13), transparent 3rem),
+    radial-gradient(circle at 82% 70%, rgba(83, 216, 232, 0.12), transparent 3rem);
+  text-align: left;
+  box-shadow:
+    var(--shadow-inset),
+    0 1.2rem 3rem rgba(0, 0, 0, 0.28);
+}
+
+.chapter-experience[data-chapter-id="ch11"] .scene-host__status span {
+  color: rgba(143, 231, 237, 0.82);
   font-family: var(--font-ui);
   font-size: 0.66rem;
   letter-spacing: 0.08em;
@@ -14040,7 +14077,14 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .chapter-sigil {
-		    display: none;
+		    display: block;
+		    position: absolute;
+		    right: 0;
+		    top: 10.78rem;
+		    width: 2.82rem;
+		    height: 2.82rem;
+		    opacity: 0.72;
+		    filter: drop-shadow(0 0 1rem rgba(83, 216, 232, 0.14));
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .chapter-stage__intro h1 {
@@ -14058,10 +14102,10 @@ h3 {
 
 		  .chapter-experience[data-chapter-id="ch11"] .chapter-stage__scrim {
 		    background:
-		      linear-gradient(180deg, rgba(3, 3, 7, 0.92), rgba(3, 3, 7, 0.64) 48%, rgba(3, 3, 7, 0.88)),
-		      linear-gradient(90deg, rgba(3, 3, 7, 0.98), rgba(3, 3, 7, 0.82) 62%, rgba(3, 3, 7, 0.46)),
-		      radial-gradient(circle at 30% 48%, rgba(212, 175, 55, 0.13), transparent 28%),
-		      radial-gradient(circle at 66% 50%, rgba(83, 216, 232, 0.08), transparent 34%);
+		      linear-gradient(180deg, rgba(3, 3, 7, 0.9), rgba(3, 3, 7, 0.58) 48%, rgba(3, 3, 7, 0.86)),
+		      linear-gradient(90deg, rgba(3, 3, 7, 0.98), rgba(3, 3, 7, 0.74) 62%, rgba(3, 3, 7, 0.34)),
+		      radial-gradient(circle at 30% 48%, rgba(212, 175, 55, 0.15), transparent 28%),
+		      radial-gradient(circle at 66% 50%, rgba(83, 216, 232, 0.11), transparent 34%);
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .scene-host__pause {
@@ -14081,7 +14125,7 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument {
-		    min-height: 7.65rem;
+		    min-height: 7.95rem;
 		    margin-top: 0.58rem;
 		  }
 
@@ -14183,7 +14227,8 @@ h3 {
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label {
-		    font-size: 0.51rem;
+		    font-size: 0.5rem;
+		    padding: 0.08rem 0.2rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"] .alchemical-tree-instrument__label--mercurius {
@@ -14201,6 +14246,26 @@ h3 {
 		    right: auto;
 		    left: 5%;
 		    top: 12%;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .scene-host__status {
+		    left: 0.78rem;
+		    bottom: 0.78rem;
+		    width: min(12.5rem, calc(100% - 1.56rem));
+		    padding: 0.54rem 0.62rem;
+		    opacity: 0.88;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .scene-host__status strong {
+		    display: block;
+		    overflow: hidden;
+		    max-width: 100%;
+		    text-overflow: ellipsis;
+		    white-space: nowrap;
+		  }
+
+		  .chapter-experience[data-chapter-id="ch11"] .scene-host__status span {
+		    font-size: 0.58rem;
 		  }
 
 		  .chapter-experience[data-chapter-id="ch11"][data-reduced-motion="true"] .scene-host__fallback {

--- a/src/visualizations/chapters/ch11/ThreeTreeViz.js
+++ b/src/visualizations/chapters/ch11/ThreeTreeViz.js
@@ -19,26 +19,30 @@ import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
 import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import BaseViz from '../../../features/viz-platform/BaseViz.js';
+import {
+    createTreeSceneRandom,
+    getTreeBloomStrength,
+    getTreeCosmicParticleCount,
+    getTreePixelRatioCap,
+    getTreeWaterParticleCount,
+    isTreeMobile,
+    OPUS_STAGES,
+    THOUSAND_NAMES,
+    TREE_COLORS,
+    VOID,
+} from './treeSceneConfig.js';
 
-const ROOT_DARK = new THREE.Color('#4b1a74');
-const TRUNK_BROWN = new THREE.Color('#9b6a3c');
-const BRANCH_GOLD = new THREE.Color('#f0c85e');
-const WATER_BLUE = new THREE.Color('#235d9a');
-const WATER_GLOW = new THREE.Color('#66e5ff');
-const LAPIS_GOLD = new THREE.Color('#ffd76a');
-const FIGURE_WHITE = new THREE.Color('#f2eee3');
-const MIRROR_CYAN = new THREE.Color('#53d8e8');
-const COSMOS_PURPLE = new THREE.Color('#5f3fa8');
-const VOID = 0x030308;
-
-const WATER_PARTICLES = 320;
-const THOUSAND_NAMES = 72;
-const OPUS_STAGES = [
-    { color: '#050506', y: 1.35, x: 0, scale: 1.08 },
-    { color: '#e8e8f0', y: 0, x: 1.35, scale: 0.86 },
-    { color: '#ffd76a', y: -1.35, x: 0, scale: 0.96 },
-    { color: '#c0392b', y: 0, x: -1.35, scale: 1.02 },
-];
+const {
+    ROOT_DARK,
+    TRUNK_BROWN,
+    BRANCH_GOLD,
+    WATER_GLOW,
+    LAPIS_GOLD,
+    FIGURE_WHITE,
+    MIRROR_CYAN,
+    RUBEDO,
+    COSMOS_BLUE,
+} = TREE_COLORS;
 
 export default class ThreeTreeViz extends BaseViz {
     constructor(container, opts = {}) {
@@ -59,14 +63,15 @@ export default class ThreeTreeViz extends BaseViz {
     }
 
     async init() {
+        this.random = createTreeSceneRandom();
         this.renderer = new THREE.WebGLRenderer({
             canvas: this.canvas, antialias: true, alpha: false, powerPreference: 'high-performance',
         });
-        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, getTreePixelRatioCap(this.width)));
         this.renderer.setSize(this.width, this.height);
         this.renderer.setClearColor(VOID);
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 1.12;
+        this.renderer.toneMappingExposure = 1.24;
 
         this.scene = new THREE.Scene();
         this.scene.fog = new THREE.FogExp2(VOID, 0.012);
@@ -76,8 +81,10 @@ export default class ThreeTreeViz extends BaseViz {
 
         this.mouse = new THREE.Vector2(0, 0);
         this.mouseSmooth = new THREE.Vector2(0, 0);
+        this.particleBucket = isTreeMobile(this.width) ? 'mobile' : 'desktop';
         this._onMouseMove = this._onMouseMove.bind(this);
-        window.addEventListener('mousemove', this._onMouseMove);
+        this.pointerTarget = this.container || window;
+        this.pointerTarget.addEventListener('mousemove', this._onMouseMove);
 
         this._createPhilosophicalTree();
         this._createMercuriusMediator();
@@ -93,7 +100,7 @@ export default class ThreeTreeViz extends BaseViz {
         this.composer = new EffectComposer(this.renderer);
         this.composer.addPass(new RenderPass(this.scene, this.camera));
         this.bloomPass = new UnrealBloomPass(
-            new THREE.Vector2(this.width, this.height), 1.18, 0.72, 0.36
+            new THREE.Vector2(this.width, this.height), getTreeBloomStrength(this.width), 0.72, 0.32
         );
         this.composer.addPass(this.bloomPass);
     }
@@ -116,11 +123,11 @@ export default class ThreeTreeViz extends BaseViz {
         // Roots (above — unconscious, reaching into sky)
         for (let i = 0; i < 6; i++) {
             const angle = (i / 6) * Math.PI * 2;
-            const len = 1 + Math.random() * 1.5;
+            const len = 1.05 + this.random() * 1.45;
             const rootGeo = new THREE.CylinderGeometry(0.02, 0.04, len, 4);
             const root = new THREE.Mesh(rootGeo, new THREE.MeshStandardMaterial({
                 color: ROOT_DARK, emissive: ROOT_DARK, emissiveIntensity: 0.3,
-                transparent: true, opacity: 0.6,
+                transparent: true, opacity: 0.68,
             }));
             root.position.set(Math.cos(angle) * 0.3, 3 + len * 0.4, Math.sin(angle) * 0.3);
             root.rotation.z = angle * 0.4 - Math.PI * 0.1;
@@ -133,18 +140,18 @@ export default class ThreeTreeViz extends BaseViz {
         this.nameParticles = [];
         for (let i = 0; i < THOUSAND_NAMES; i++) {
             const angle = (i / THOUSAND_NAMES) * Math.PI * 2;
-            const branchLen = 1.5 + Math.random() * 2;
+            const branchLen = 1.55 + this.random() * 2.05;
             const branchGeo = new THREE.CylinderGeometry(0.01, 0.02, branchLen, 3);
             const branch = new THREE.Mesh(branchGeo, new THREE.MeshStandardMaterial({
                 color: BRANCH_GOLD, emissive: BRANCH_GOLD, emissiveIntensity: 0.3,
-                transparent: true, opacity: 0.4,
+                transparent: true, opacity: 0.48,
             }));
             branch.position.set(
-                Math.cos(angle) * (0.5 + Math.random() * 0.5),
+                Math.cos(angle) * (0.5 + this.random() * 0.5),
                 -3 - branchLen * 0.3,
-                Math.sin(angle) * (0.5 + Math.random() * 0.5)
+                Math.sin(angle) * (0.5 + this.random() * 0.5)
             );
-            branch.rotation.z = (Math.random() - 0.5) * 0.5;
+            branch.rotation.z = (this.random() - 0.5) * 0.5;
             this.treeGroup.add(branch);
             this.branchMeshes.push(branch);
             this.treeMaterials.push(branch.material);
@@ -206,13 +213,13 @@ export default class ThreeTreeViz extends BaseViz {
         }
 
         this.mercuriusCore = new THREE.Mesh(
-            new THREE.OctahedronGeometry(0.32, 0),
+            new THREE.OctahedronGeometry(0.36, 0),
             new THREE.MeshStandardMaterial({
                 color: MIRROR_CYAN,
                 emissive: MIRROR_CYAN,
-                emissiveIntensity: 0.72,
+                emissiveIntensity: 0.82,
                 transparent: true,
-                opacity: 0.68,
+                opacity: 0.76,
                 metalness: 0.4,
                 roughness: 0.28,
             })
@@ -273,19 +280,19 @@ export default class ThreeTreeViz extends BaseViz {
     }
 
     _createAquaDoctrinae() {
-        const count = WATER_PARTICLES;
+        const count = getTreeWaterParticleCount(this.width);
         const positions = new Float32Array(count * 3);
         this.waterPhases = new Float32Array(count);
         for (let i = 0; i < count; i++) {
-            positions[i * 3] = (Math.random() - 0.5) * 3;
-            positions[i * 3 + 1] = -6 + Math.random() * 2;
-            positions[i * 3 + 2] = (Math.random() - 0.5) * 3;
-            this.waterPhases[i] = Math.random() * Math.PI * 2;
+            positions[i * 3] = (this.random() - 0.5) * 3;
+            positions[i * 3 + 1] = -6 + this.random() * 2;
+            positions[i * 3 + 2] = (this.random() - 0.5) * 3;
+            this.waterPhases[i] = this.random() * Math.PI * 2;
         }
         const geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
         this.waterPts = new THREE.Points(geo, new THREE.PointsMaterial({
-            color: WATER_GLOW, size: 0.072, transparent: true, opacity: 0.42,
+            color: WATER_GLOW, size: 0.078, transparent: true, opacity: 0.5,
             blending: THREE.AdditiveBlending, depthWrite: false,
         }));
         this.scene.add(this.waterPts);
@@ -546,38 +553,38 @@ export default class ThreeTreeViz extends BaseViz {
 
     _createCosmicSubstance() {
         // Arcane substance particles — both near figure AND in distant cosmos
-        const count = 400;
+        const count = getTreeCosmicParticleCount(this.width);
         const positions = new Float32Array(count * 3);
         const colors = new Float32Array(count * 3);
         for (let i = 0; i < count; i++) {
             if (i < count / 2) {
                 // Near figure
-                const r = 0.5 + Math.random() * 1.5;
-                const theta = Math.random() * Math.PI * 2;
+                const r = 0.5 + this.random() * 1.5;
+                const theta = this.random() * Math.PI * 2;
                 positions[i * 3] = 4 + Math.cos(theta) * r;
-                positions[i * 3 + 1] = -4 + (Math.random() - 0.5) * 2;
+                positions[i * 3 + 1] = -4 + (this.random() - 0.5) * 2;
                 positions[i * 3 + 2] = Math.sin(theta) * r;
                 colors[i * 3] = LAPIS_GOLD.r * 0.5;
                 colors[i * 3 + 1] = LAPIS_GOLD.g * 0.5;
                 colors[i * 3 + 2] = LAPIS_GOLD.b * 0.5;
             } else {
                 // In distant cosmos
-                const r = 8 + Math.random() * 15;
-                const theta = Math.random() * Math.PI * 2;
-                const phi = Math.acos(2 * Math.random() - 1);
+                const r = 8 + this.random() * 15;
+                const theta = this.random() * Math.PI * 2;
+                const phi = Math.acos(2 * this.random() - 1);
                 positions[i * 3] = r * Math.sin(phi) * Math.cos(theta);
                 positions[i * 3 + 1] = r * Math.sin(phi) * Math.sin(theta);
                 positions[i * 3 + 2] = r * Math.cos(phi);
-                colors[i * 3] = COSMOS_PURPLE.r;
-                colors[i * 3 + 1] = COSMOS_PURPLE.g;
-                colors[i * 3 + 2] = COSMOS_PURPLE.b;
+                colors[i * 3] = COSMOS_BLUE.r;
+                colors[i * 3 + 1] = COSMOS_BLUE.g;
+                colors[i * 3 + 2] = COSMOS_BLUE.b;
             }
         }
         const geo = new THREE.BufferGeometry();
         geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
         geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
         this.cosmicPts = new THREE.Points(geo, new THREE.PointsMaterial({
-            vertexColors: true, size: 0.045, transparent: true, opacity: 0.24,
+            vertexColors: true, size: 0.052, transparent: true, opacity: 0.28,
             blending: THREE.AdditiveBlending, depthWrite: false,
         }));
         this.scene.add(this.cosmicPts);
@@ -585,17 +592,21 @@ export default class ThreeTreeViz extends BaseViz {
 
     _createLights() {
         this.scene.add(new THREE.AmbientLight(0x0a0a15, 0.3));
-        const rootLight = new THREE.PointLight(0x2a0845, 0.5, 15);
+        const rootLight = new THREE.PointLight(0x1f5262, 0.54, 15);
         rootLight.position.set(0, 5, 3);
         this.scene.add(rootLight);
 
-        const branchLight = new THREE.PointLight(0xc8a820, 0.5, 15);
+        const branchLight = new THREE.PointLight(0xc8a820, 0.62, 15);
         branchLight.position.set(0, -4, 3);
         this.scene.add(branchLight);
 
-        const waterLight = new THREE.PointLight(0x4a8aca, 0.3, 10);
+        const waterLight = new THREE.PointLight(0x4a8aca, 0.42, 10);
         waterLight.position.set(4, -5, 2);
         this.scene.add(waterLight);
+
+        const rubedoLight = new THREE.PointLight(RUBEDO, 0.32, 9);
+        rubedoLight.position.set(3.6, 0.2, 2.2);
+        this.scene.add(rubedoLight);
     }
 
     update(dt) {
@@ -604,30 +615,30 @@ export default class ThreeTreeViz extends BaseViz {
         const panelId = this.panelState?.activePanelId || 'mercurius';
         const dampRate = this.reducedMotion ? 9 : 3.2;
         const motionScale = this.reducedMotion ? 0.12 : 1;
-        const isMobile = this.width < 680;
+        const isMobile = isTreeMobile(this.width);
         this.mercuriusFocus = THREE.MathUtils.damp(this.mercuriusFocus, panelId === 'mercurius' ? 1 : 0.18, dampRate, dt);
         this.opusFocus = THREE.MathUtils.damp(this.opusFocus, panelId === 'opus-wheel' ? 1 : 0.16, dampRate, dt);
         this.lapisFocus = THREE.MathUtils.damp(this.lapisFocus, panelId === 'lapis' ? 1 : 0.16, dampRate, dt);
         this.mouseSmooth.lerp(this.mouse, 0.03);
 
         // Tree gentle sway
-        this.treeGroup.position.x = THREE.MathUtils.damp(this.treeGroup.position.x, isMobile ? 3.75 : 1.95, 4, dt);
-        this.treeGroup.position.y = THREE.MathUtils.damp(this.treeGroup.position.y, isMobile ? -0.32 : -0.08, 4, dt);
+        this.treeGroup.position.x = THREE.MathUtils.damp(this.treeGroup.position.x, isMobile ? 3.25 : 1.72, 4, dt);
+        this.treeGroup.position.y = THREE.MathUtils.damp(this.treeGroup.position.y, isMobile ? -0.18 : -0.02, 4, dt);
         this.treeGroup.rotation.z = Math.sin(t * 0.05 * motionScale) * 0.03;
         this.treeGroup.rotation.y = t * 0.005 * motionScale;
-        this.treeGroup.scale.setScalar((isMobile ? 0.72 : 0.78) + this.mercuriusFocus * 0.07 + this.opusFocus * 0.05 + this.lapisFocus * 0.03);
-        this.trunkMesh.material.emissiveIntensity = 0.12 + this.mercuriusFocus * 0.18 + this.opusFocus * 0.2;
+        this.treeGroup.scale.setScalar((isMobile ? 0.76 : 0.84) + this.mercuriusFocus * 0.08 + this.opusFocus * 0.06 + this.lapisFocus * 0.04);
+        this.trunkMesh.material.emissiveIntensity = 0.18 + this.mercuriusFocus * 0.26 + this.opusFocus * 0.24;
         this.rootMeshes?.forEach((root, index) => {
-            root.material.opacity = 0.16 + this.mercuriusFocus * 0.3 + Math.sin(t * 0.16 * motionScale + index) * 0.03;
-            root.material.emissiveIntensity = 0.14 + this.mercuriusFocus * 0.26;
+            root.material.opacity = 0.22 + this.mercuriusFocus * 0.34 + Math.sin(t * 0.16 * motionScale + index) * 0.03;
+            root.material.emissiveIntensity = 0.2 + this.mercuriusFocus * 0.34;
         });
         this.branchMeshes?.forEach((branch, index) => {
-            branch.material.opacity = 0.12 + this.opusFocus * 0.34 + this.lapisFocus * 0.18 + Math.sin(t * 0.2 * motionScale + index) * 0.025;
-            branch.material.emissiveIntensity = 0.14 + this.opusFocus * 0.34 + this.lapisFocus * 0.18;
+            branch.material.opacity = 0.18 + this.opusFocus * 0.38 + this.lapisFocus * 0.22 + Math.sin(t * 0.2 * motionScale + index) * 0.025;
+            branch.material.emissiveIntensity = 0.2 + this.opusFocus * 0.4 + this.lapisFocus * 0.22;
         });
 
-        this.mercuriusGroup.position.x = THREE.MathUtils.damp(this.mercuriusGroup.position.x, isMobile ? 3.85 : 1.95, 4, dt);
-        this.mercuriusGroup.position.y = THREE.MathUtils.damp(this.mercuriusGroup.position.y, isMobile ? 0.42 : 0.08, 4, dt);
+        this.mercuriusGroup.position.x = THREE.MathUtils.damp(this.mercuriusGroup.position.x, isMobile ? 3.2 : 1.72, 4, dt);
+        this.mercuriusGroup.position.y = THREE.MathUtils.damp(this.mercuriusGroup.position.y, isMobile ? 0.56 : 0.14, 4, dt);
         this.mercuriusGroup.rotation.y = Math.sin(t * 0.12 * motionScale) * 0.35;
         this.mercuriusGroup.scale.setScalar((isMobile ? 0.62 : 0.78) + this.mercuriusFocus * (isMobile ? 0.18 : 0.26));
         this._setGroupOpacity(this.mercuriusGroup, 0.12 + this.mercuriusFocus * 0.8);
@@ -635,8 +646,8 @@ export default class ThreeTreeViz extends BaseViz {
         this.mercuriusCore.rotation.x = Math.sin(t * 0.12 * motionScale) * 0.4;
         this.mercuriusCore.material.emissiveIntensity = 0.35 + this.mercuriusFocus * 0.72;
 
-        this.opusWheel.position.x = THREE.MathUtils.damp(this.opusWheel.position.x, isMobile ? 4.2 : 3.05, 4, dt);
-        this.opusWheel.position.y = THREE.MathUtils.damp(this.opusWheel.position.y, isMobile ? 0.58 : -0.02, 4, dt);
+        this.opusWheel.position.x = THREE.MathUtils.damp(this.opusWheel.position.x, isMobile ? 3.68 : 2.88, 4, dt);
+        this.opusWheel.position.y = THREE.MathUtils.damp(this.opusWheel.position.y, isMobile ? 0.68 : 0.04, 4, dt);
         this.opusWheel.rotation.z = -t * 0.045 * motionScale;
         this.opusWheel.scale.setScalar((isMobile ? 0.66 : 0.9) + this.opusFocus * (isMobile ? 0.22 : 0.34));
         this._setGroupOpacity(this.opusWheel, 0.12 + this.opusFocus * 0.9);
@@ -648,9 +659,9 @@ export default class ThreeTreeViz extends BaseViz {
 
         if (this.opusTreeField) {
             const fieldFocus = Math.max(this.mercuriusFocus * 0.86, this.opusFocus, this.lapisFocus * 0.94);
-            this.opusTreeField.position.x = THREE.MathUtils.damp(this.opusTreeField.position.x, isMobile ? 3.9 : 1.95, 4, dt);
-            this.opusTreeField.position.y = THREE.MathUtils.damp(this.opusTreeField.position.y, isMobile ? 0.02 : 0, 4, dt);
-            this.opusTreeField.scale.setScalar((isMobile ? 0.56 : 0.78) + fieldFocus * (isMobile ? 0.1 : 0.14));
+            this.opusTreeField.position.x = THREE.MathUtils.damp(this.opusTreeField.position.x, isMobile ? 3.28 : 1.72, 4, dt);
+            this.opusTreeField.position.y = THREE.MathUtils.damp(this.opusTreeField.position.y, isMobile ? 0.12 : 0.05, 4, dt);
+            this.opusTreeField.scale.setScalar((isMobile ? 0.62 : 0.86) + fieldFocus * (isMobile ? 0.12 : 0.16));
             this.opusTreeField.rotation.z = Math.sin(t * 0.06 * motionScale) * 0.035;
             this._setGroupOpacity(this.opusTreeField, (0.32 + fieldFocus * 0.54) * (isMobile ? 0.82 : 1));
         }
@@ -690,12 +701,12 @@ export default class ThreeTreeViz extends BaseViz {
         // Water rising
         const waterPos = this.waterPts.geometry.attributes.position.array;
         const waterSpeed = (0.08 + this.mercuriusFocus * 0.14 + this.lapisFocus * 0.18) * motionScale;
-        for (let i = 0; i < WATER_PARTICLES; i++) {
+        for (let i = 0; i < this.waterPhases.length; i++) {
             waterPos[i * 3 + 1] += dt * waterSpeed;
             waterPos[i * 3] += Math.sin(t * 0.2 * motionScale + this.waterPhases[i]) * dt * 0.05;
             if (waterPos[i * 3 + 1] > 0) {
                 waterPos[i * 3 + 1] = -6;
-                waterPos[i * 3] = (Math.random() - 0.5) * 3;
+                waterPos[i * 3] = (this.random() - 0.5) * 3;
             }
         }
         this.waterPts.geometry.attributes.position.needsUpdate = true;
@@ -712,8 +723,8 @@ export default class ThreeTreeViz extends BaseViz {
         this.reflectionGroup.scale.setScalar(0.95 + this.lapisFocus * 0.16);
         this.figureGroup.scale.setScalar(0.9 + this.lapisFocus * 0.12);
 
-        this.lapisMandala.position.x = THREE.MathUtils.damp(this.lapisMandala.position.x, isMobile ? 4.45 : 3.75, 4, dt);
-        this.lapisMandala.position.y = THREE.MathUtils.damp(this.lapisMandala.position.y, isMobile ? -1.1 : -1.92, 4, dt);
+        this.lapisMandala.position.x = THREE.MathUtils.damp(this.lapisMandala.position.x, isMobile ? 3.9 : 3.56, 4, dt);
+        this.lapisMandala.position.y = THREE.MathUtils.damp(this.lapisMandala.position.y, isMobile ? -0.98 : -1.8, 4, dt);
         this.lapisMandala.scale.setScalar((isMobile ? 0.5 : 0.78) + this.lapisFocus * (isMobile ? 0.3 : 0.5));
         this.lapisMandala.rotation.y = t * 0.04 * motionScale;
         this.lapisStone.rotation.y = t * 0.16 * motionScale;
@@ -734,29 +745,48 @@ export default class ThreeTreeViz extends BaseViz {
 
         // Camera
         const camAngle = t * 0.012 * motionScale + this.mouseSmooth.x * 0.22;
-        const baseRadius = (isMobile ? 13.8 : 12.6) - this.opusFocus * 0.72 - this.lapisFocus * 1.05;
+        const baseRadius = (isMobile ? 12.9 : 12.0) - this.opusFocus * 0.72 - this.lapisFocus * 1.05;
         const targetCam = new THREE.Vector3(
-            Math.sin(camAngle) * baseRadius + this.opusFocus * 0.8 + this.lapisFocus * 1.35 + (isMobile ? 2.55 : 0.9),
-            1.55 + this.mouseSmooth.y * 2 - this.opusFocus * 0.46 - this.lapisFocus * 1.45,
+            Math.sin(camAngle) * baseRadius + this.opusFocus * 0.7 + this.lapisFocus * 1.22 + (isMobile ? 1.85 : 0.62),
+            1.7 + this.mouseSmooth.y * 1.7 - this.opusFocus * 0.42 - this.lapisFocus * 1.32,
             Math.cos(camAngle) * baseRadius
         );
         this.camera.position.lerp(targetCam, this.reducedMotion ? 1 : Math.min(1, dt * 1.8));
         this.camera.lookAt(
-            this.opusFocus * 1.5 + this.lapisFocus * 1.55 + (isMobile ? 0.98 : 0.48),
+            this.opusFocus * 1.42 + this.lapisFocus * 1.48 + (isMobile ? 0.72 : 0.36),
             -0.82 - this.opusFocus * 0.3 - this.lapisFocus * 0.96,
             0.5
         );
 
-        if (this.bloomPass) this.bloomPass.strength = 0.76 + Math.sin(t * 0.1 * motionScale) * 0.12 + this.mercuriusFocus * 0.18 + this.lapisFocus * 0.2;
+        if (this.bloomPass) this.bloomPass.strength = getTreeBloomStrength(this.width) + Math.sin(t * 0.1 * motionScale) * 0.1 + this.mercuriusFocus * 0.12 + this.lapisFocus * 0.15;
     }
 
     render() { this.composer?.render(); }
     onResize(w, h) {
         if (!this.renderer || !this.camera) return;
         this.camera.aspect = w / h; this.camera.updateProjectionMatrix();
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, getTreePixelRatioCap(w)));
         this.renderer.setSize(w, h); this.composer?.setSize(w, h); this.bloomPass?.setSize(w, h);
+        if (this.bloomPass) this.bloomPass.strength = getTreeBloomStrength(w);
+
+        const nextBucket = isTreeMobile(w) ? 'mobile' : 'desktop';
+        if (nextBucket !== this.particleBucket && this.scene) {
+            this.particleBucket = nextBucket;
+            this._rebuildResponsiveParticles();
+        }
     }
-    _onMouseMove(e) { this.mouse.x = (e.clientX / window.innerWidth) * 2 - 1; this.mouse.y = -(e.clientY / window.innerHeight) * 2 + 1; }
+    _onMouseMove(e) {
+        const bounds = this.container?.getBoundingClientRect?.();
+        if (!bounds || bounds.width <= 0 || bounds.height <= 0) {
+            this.mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
+            this.mouse.y = -(e.clientY / window.innerHeight) * 2 + 1;
+            return;
+        }
+        const x = (e.clientX - bounds.left) / bounds.width;
+        const y = (e.clientY - bounds.top) / bounds.height;
+        this.mouse.x = THREE.MathUtils.clamp(x * 2 - 1, -1, 1);
+        this.mouse.y = THREE.MathUtils.clamp(-(y * 2 - 1), -1, 1);
+    }
     _setGroupOpacity(group, opacity) {
         group?.traverse((obj) => {
             const materials = obj.material ? (Array.isArray(obj.material) ? obj.material : [obj.material]) : [];
@@ -768,8 +798,23 @@ export default class ThreeTreeViz extends BaseViz {
             });
         });
     }
+    _rebuildResponsiveParticles() {
+        this._disposeSceneObject(this.waterPts);
+        this._disposeSceneObject(this.cosmicPts);
+        this.waterPts = null;
+        this.cosmicPts = null;
+        this._createAquaDoctrinae();
+        this._createCosmicSubstance();
+    }
+    _disposeSceneObject(object) {
+        if (!object) return;
+        object.parent?.remove(object);
+        object.geometry?.dispose?.();
+        const materials = object.material ? (Array.isArray(object.material) ? object.material : [object.material]) : [];
+        materials.forEach((material) => material.dispose?.());
+    }
     dispose() {
-        window.removeEventListener('mousemove', this._onMouseMove);
+        this.pointerTarget?.removeEventListener?.('mousemove', this._onMouseMove);
         this.stop();
         this.resizeObserver?.disconnect();
         this.bloomPass?.dispose?.();

--- a/src/visualizations/chapters/ch11/treeSceneConfig.js
+++ b/src/visualizations/chapters/ch11/treeSceneConfig.js
@@ -1,0 +1,51 @@
+import * as THREE from 'three';
+
+export const TREE_MOBILE_BREAKPOINT = 720;
+export const TREE_COLORS = {
+  ROOT_DARK: new THREE.Color('#27424c'),
+  TRUNK_BROWN: new THREE.Color('#9b6a3c'),
+  BRANCH_GOLD: new THREE.Color('#f0c85e'),
+  WATER_GLOW: new THREE.Color('#66e5ff'),
+  LAPIS_GOLD: new THREE.Color('#ffd76a'),
+  FIGURE_WHITE: new THREE.Color('#f2eee3'),
+  MIRROR_CYAN: new THREE.Color('#53d8e8'),
+  RUBEDO: new THREE.Color('#c0392b'),
+  COSMOS_BLUE: new THREE.Color('#21415b'),
+};
+
+export const VOID = 0x030308;
+export const THOUSAND_NAMES = 72;
+export const OPUS_STAGES = [
+  { color: '#050506', y: 1.35, x: 0, scale: 1.08 },
+  { color: '#e8e8f0', y: 0, x: 1.35, scale: 0.86 },
+  { color: '#ffd76a', y: -1.35, x: 0, scale: 0.96 },
+  { color: '#c0392b', y: 0, x: -1.35, scale: 1.02 },
+];
+
+export function isTreeMobile(width) {
+  return width < TREE_MOBILE_BREAKPOINT;
+}
+
+export function getTreePixelRatioCap(width) {
+  return isTreeMobile(width) ? 1.35 : 1.8;
+}
+
+export function getTreeWaterParticleCount(width) {
+  return isTreeMobile(width) ? 220 : 320;
+}
+
+export function getTreeCosmicParticleCount(width) {
+  return isTreeMobile(width) ? 280 : 420;
+}
+
+export function getTreeBloomStrength(width) {
+  return isTreeMobile(width) ? 0.92 : 1.08;
+}
+
+export function createTreeSceneRandom(seed = 11031) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+}

--- a/tests/app/aion-app-contract.test.ts
+++ b/tests/app/aion-app-contract.test.ts
@@ -313,6 +313,25 @@ describe('Aion framework data contract', () => {
     ]);
   });
 
+  test('keeps Chapter 11 tree scene helpers mobile-aware', async () => {
+    const {
+      getTreeBloomStrength,
+      getTreeCosmicParticleCount,
+      getTreePixelRatioCap,
+      getTreeWaterParticleCount,
+      isTreeMobile,
+      TREE_MOBILE_BREAKPOINT,
+    } = await import('../../src/visualizations/chapters/ch11/treeSceneConfig.js');
+
+    expect(TREE_MOBILE_BREAKPOINT).toBe(720);
+    expect(isTreeMobile(390)).toBe(true);
+    expect(isTreeMobile(1440)).toBe(false);
+    expect(getTreePixelRatioCap(390)).toBeLessThan(getTreePixelRatioCap(1440));
+    expect(getTreeWaterParticleCount(390)).toBeLessThan(getTreeWaterParticleCount(1440));
+    expect(getTreeCosmicParticleCount(390)).toBeLessThan(getTreeCosmicParticleCount(1440));
+    expect(getTreeBloomStrength(390)).toBeLessThan(getTreeBloomStrength(1440));
+  });
+
   test('keeps Chapter 12 amplification lens panels tied to symbolic interpretation', () => {
     expect(CHAPTER_SCENES.ch12.panels.map((panel) => panel.id)).toEqual([
       'background',


### PR DESCRIPTION
## Summary
- refines Chapter 11 as a brighter alchemical interpretation field with clearer Mercurius, opus wheel, lapis, and aqua doctrinae visual hierarchy
- adds a focused tree scene config for deterministic color/motion/performance values and mobile-aware particle counts
- tightens Chapter 11 mobile layout, scene status styling, and the inline alchemical bridge instrument while preserving the global shell
- adds a contract test for the new mobile-aware scene helpers

## Visual thesis
Chapter 11 now reads as an alchemical tree of interpretation: Mercurius mediates the middle, the opus wheel marks cyclic transformation, and the lapis/mirror resolves as a formed paradox rather than a simple endpoint. The polish keeps the black/gold scholarly atlas direction while reducing the previous purple cast.

## Browser evidence
- Manual screenshots captured for `/journey/chapter/ch11` at 1440x1000, 390x844, and 320x568 in `test-results/manual-ch11-polish/`
- Manual browser pass: HTTP 200, no console errors, no unexpected 404s, no request failures, 0px horizontal overflow, visible canvas/instrument/sigil, reduced-motion fallback visible
- Visual Control Tower: 20 routes inspected, 3 viewports each, 0 technical blockers; `/journey/chapter/ch11` scored 100% desktop and 0px overflow on mobile/narrow

## Verification
- `git diff --check`
- `npm run lint`
- `npx tsc --noEmit`
- `npm run validate:consistency`
- `npm run ci:chapter-shell`
- `npm run test:app`
- `npm test`
- `npm run build`
- `AION_SMOKE_PORT=4266 node scripts/testing/app-shell-smoke.mjs --shard=scene-controls`
- `AION_SMOKE_PORT=4267 node scripts/testing/app-shell-smoke.mjs --shard=mobile`
- `npm run test:a11y:app`
- `npm run test:e2e:app`
- `npm run build:pages && npm run test:pages:artifact`
- `AION_VISUAL_QA_PORT=4268 npm run test:visual:control-tower`

## Notes
- Vite still reports the existing large `three` chunk warning; this batch does not change the chunking strategy.
- `ThreeTreeViz.js` remains large and should be split in a future performance/maintainability pass.
